### PR TITLE
#53 - Add error notification for maintenance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,18 @@ DATABASE_URL=postgres://user:password@localhost:5432/boost_dashboard
 # LOG_BACKUP_COUNT=5
 
 # =============================================================================
+# Error Notifications (Discord/Slack)
+# =============================================================================
+# Enable automatic error notifications to Discord/Slack when errors occur
+# ENABLE_ERROR_NOTIFICATIONS=False
+
+# Discord webhook URL (get from Discord: Server Settings > Integrations > Webhooks)
+# DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN
+
+# Slack webhook URL (get from Slack: https://api.slack.com/messaging/webhooks)
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+
+# =============================================================================
 # GitHub tokens (multiple use cases)
 # =============================================================================
 # Fallback when a specific token is not set (used for read if no scraping list):

--- a/config/logging_handlers.py
+++ b/config/logging_handlers.py
@@ -5,8 +5,9 @@ Automatically sends error logs to configured channels.
 
 import json
 import logging
+import sys
 import traceback
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib import request
 from urllib.error import URLError
 
@@ -36,7 +37,7 @@ class DiscordHandler(logging.Handler):
                 "title": f"🚨 {record.levelname}: {record.name}",
                 "description": f"```\n{record.getMessage()}\n```",
                 "color": self._get_color(record.levelname),
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "fields": [
                     {
                         "name": "Module",
@@ -76,14 +77,16 @@ class DiscordHandler(logging.Handler):
 
             with request.urlopen(req, timeout=10) as response:
                 if response.status != 204:
-                    print(f"Discord webhook returned status {response.status}")
+                    sys.stderr.write(
+                        f"Discord webhook returned status {response.status}\n"
+                    )
 
         except URLError as e:
             # Don't fail the application if notification fails
-            print(f"Failed to send Discord notification: {e}")
+            sys.stderr.write(f"Failed to send Discord notification: {e}\n")
         except Exception as e:
             # Prevent handler from breaking the logging system
-            print(f"Error in DiscordHandler: {e}")
+            sys.stderr.write(f"Error in DiscordHandler: {e}\n")
 
     def _get_color(self, levelname):
         """Get embed color based on log level."""
@@ -147,7 +150,7 @@ class SlackHandler(logging.Handler):
                         },
                         {
                             "type": "mrkdwn",
-                            "text": f"*Time:*\n{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+                            "text": f"*Time:*\n{datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}",
                         },
                         {
                             "type": "mrkdwn",
@@ -199,11 +202,13 @@ class SlackHandler(logging.Handler):
 
             with request.urlopen(req, timeout=10) as response:
                 if response.status != 200:
-                    print(f"Slack webhook returned status {response.status}")
+                    sys.stderr.write(
+                        f"Slack webhook returned status {response.status}\n"
+                    )
 
         except URLError as e:
             # Don't fail the application if notification fails
-            print(f"Failed to send Slack notification: {e}")
+            sys.stderr.write(f"Failed to send Slack notification: {e}\n")
         except Exception as e:
             # Prevent handler from breaking the logging system
-            print(f"Error in SlackHandler: {e}")
+            sys.stderr.write(f"Error in SlackHandler: {e}\n")

--- a/config/logging_handlers.py
+++ b/config/logging_handlers.py
@@ -6,10 +6,14 @@ Automatically sends error logs to configured channels.
 import json
 import logging
 import sys
+import time
 import traceback
 from datetime import datetime, timezone
 from urllib import request
 from urllib.error import URLError
+
+
+COOLDOWN_TIME = 60  # 1 minute
 
 
 class DiscordHandler(logging.Handler):
@@ -28,10 +32,17 @@ class DiscordHandler(logging.Handler):
         super().__init__(level)
         self.webhook_url = webhook_url
         self.username = username
+        self.last_notification = 0
 
     def emit(self, record):
         """Send log record to Discord."""
         try:
+            # Check cooldown
+            now = time.time()
+            if now - self.last_notification < COOLDOWN_TIME:
+                return
+            self.last_notification = now
+
             # Build embed for better formatting
             embed = {
                 "title": f"🚨 {record.levelname}: {record.name}",
@@ -123,10 +134,17 @@ class SlackHandler(logging.Handler):
         self.webhook_url = webhook_url
         self.username = username
         self.channel = channel
+        self.last_notification = 0
 
     def emit(self, record):
         """Send log record to Slack."""
         try:
+            # Check cooldown
+            now = time.time()
+            if now - self.last_notification < COOLDOWN_TIME:
+                return
+            self.last_notification = now
+
             # Build blocks for better formatting (Slack Block Kit)
             blocks = [
                 {

--- a/config/logging_handlers.py
+++ b/config/logging_handlers.py
@@ -1,0 +1,206 @@
+"""
+Custom logging handlers for Discord and Slack notifications.
+Automatically sends error logs to configured channels.
+"""
+
+import json
+import logging
+import traceback
+from datetime import datetime
+from urllib import request
+from urllib.error import URLError
+
+
+class DiscordHandler(logging.Handler):
+    """
+    Logging handler that sends error messages to Discord via webhook.
+    
+    Usage in LOGGING config:
+        'discord': {
+            'class': 'config.logging_handlers.DiscordHandler',
+            'webhook_url': 'https://discord.com/api/webhooks/...',
+            'level': 'ERROR',
+        }
+    """
+
+    def __init__(self, webhook_url, level=logging.ERROR, username="Django Logger"):
+        super().__init__(level)
+        self.webhook_url = webhook_url
+        self.username = username
+
+    def emit(self, record):
+        """Send log record to Discord."""
+        try:
+            log_entry = self.format(record)
+            
+            # Build embed for better formatting
+            embed = {
+                "title": f"🚨 {record.levelname}: {record.name}",
+                "description": f"```\n{record.getMessage()}\n```",
+                "color": self._get_color(record.levelname),
+                "timestamp": datetime.utcnow().isoformat(),
+                "fields": [
+                    {
+                        "name": "Module",
+                        "value": f"`{record.module}.{record.funcName}`",
+                        "inline": True
+                    },
+                    {
+                        "name": "Line",
+                        "value": f"`{record.lineno}`",
+                        "inline": True
+                    },
+                ]
+            }
+
+            # Add exception info if present
+            if record.exc_info:
+                exc_text = ''.join(traceback.format_exception(*record.exc_info))
+                # Discord has a 4096 char limit for description
+                if len(exc_text) > 1900:
+                    exc_text = exc_text[:1900] + "\n... (truncated)"
+                embed["fields"].append({
+                    "name": "Exception",
+                    "value": f"```python\n{exc_text}\n```",
+                    "inline": False
+                })
+
+            payload = {
+                "username": self.username,
+                "embeds": [embed]
+            }
+
+            data = json.dumps(payload).encode('utf-8')
+            req = request.Request(
+                self.webhook_url,
+                data=data,
+                headers={'Content-Type': 'application/json'}
+            )
+            
+            with request.urlopen(req, timeout=10) as response:
+                if response.status != 204:
+                    print(f"Discord webhook returned status {response.status}")
+
+        except URLError as e:
+            # Don't fail the application if notification fails
+            print(f"Failed to send Discord notification: {e}")
+        except Exception as e:
+            # Prevent handler from breaking the logging system
+            print(f"Error in DiscordHandler: {e}")
+
+    def _get_color(self, levelname):
+        """Get embed color based on log level."""
+        colors = {
+            'DEBUG': 0x7289DA,      # Blue
+            'INFO': 0x3498DB,       # Light Blue
+            'WARNING': 0xF39C12,    # Orange
+            'ERROR': 0xE74C3C,      # Red
+            'CRITICAL': 0x992D22,   # Dark Red
+        }
+        return colors.get(levelname, 0x95A5A6)  # Gray default
+
+
+class SlackHandler(logging.Handler):
+    """
+    Logging handler that sends error messages to Slack via webhook.
+    
+    Usage in LOGGING config:
+        'slack': {
+            'class': 'config.logging_handlers.SlackHandler',
+            'webhook_url': 'https://hooks.slack.com/services/...',
+            'level': 'ERROR',
+        }
+    """
+
+    def __init__(self, webhook_url, level=logging.ERROR, username="Django Logger", channel=None):
+        super().__init__(level)
+        self.webhook_url = webhook_url
+        self.username = username
+        self.channel = channel
+
+    def emit(self, record):
+        """Send log record to Slack."""
+        try:
+            log_entry = self.format(record)
+            
+            # Build blocks for better formatting (Slack Block Kit)
+            blocks = [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": f"🚨 {record.levelname}: {record.name}",
+                        "emoji": True
+                    }
+                },
+                {
+                    "type": "section",
+                    "fields": [
+                        {
+                            "type": "mrkdwn",
+                            "text": f"*Module:*\n`{record.module}.{record.funcName}`"
+                        },
+                        {
+                            "type": "mrkdwn",
+                            "text": f"*Line:*\n`{record.lineno}`"
+                        },
+                        {
+                            "type": "mrkdwn",
+                            "text": f"*Time:*\n{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+                        },
+                        {
+                            "type": "mrkdwn",
+                            "text": f"*Level:*\n`{record.levelname}`"
+                        }
+                    ]
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"*Message:*\n```{record.getMessage()}```"
+                    }
+                }
+            ]
+
+            # Add exception info if present
+            if record.exc_info:
+                exc_text = ''.join(traceback.format_exception(*record.exc_info))
+                # Slack has a 3000 char limit per block
+                if len(exc_text) > 2900:
+                    exc_text = exc_text[:2900] + "\n... (truncated)"
+                
+                blocks.append({
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"*Exception:*\n```{exc_text}```"
+                    }
+                })
+
+            payload = {
+                "username": self.username,
+                "blocks": blocks,
+                "icon_emoji": ":warning:"
+            }
+
+            if self.channel:
+                payload["channel"] = self.channel
+
+            data = json.dumps(payload).encode('utf-8')
+            req = request.Request(
+                self.webhook_url,
+                data=data,
+                headers={'Content-Type': 'application/json'}
+            )
+            
+            with request.urlopen(req, timeout=10) as response:
+                if response.status != 200:
+                    print(f"Slack webhook returned status {response.status}")
+
+        except URLError as e:
+            # Don't fail the application if notification fails
+            print(f"Failed to send Slack notification: {e}")
+        except Exception as e:
+            # Prevent handler from breaking the logging system
+            print(f"Error in SlackHandler: {e}")

--- a/config/logging_handlers.py
+++ b/config/logging_handlers.py
@@ -14,7 +14,7 @@ from urllib.error import URLError
 class DiscordHandler(logging.Handler):
     """
     Logging handler that sends error messages to Discord via webhook.
-    
+
     Usage in LOGGING config:
         'discord': {
             'class': 'config.logging_handlers.DiscordHandler',
@@ -31,8 +31,6 @@ class DiscordHandler(logging.Handler):
     def emit(self, record):
         """Send log record to Discord."""
         try:
-            log_entry = self.format(record)
-            
             # Build embed for better formatting
             embed = {
                 "title": f"🚨 {record.levelname}: {record.name}",
@@ -43,40 +41,39 @@ class DiscordHandler(logging.Handler):
                     {
                         "name": "Module",
                         "value": f"`{record.module}.{record.funcName}`",
-                        "inline": True
+                        "inline": True,
                     },
                     {
                         "name": "Line",
                         "value": f"`{record.lineno}`",
-                        "inline": True
+                        "inline": True,
                     },
-                ]
+                ],
             }
 
             # Add exception info if present
             if record.exc_info:
-                exc_text = ''.join(traceback.format_exception(*record.exc_info))
+                exc_text = "".join(traceback.format_exception(*record.exc_info))
                 # Discord has a 4096 char limit for description
                 if len(exc_text) > 1900:
                     exc_text = exc_text[:1900] + "\n... (truncated)"
-                embed["fields"].append({
-                    "name": "Exception",
-                    "value": f"```python\n{exc_text}\n```",
-                    "inline": False
-                })
+                embed["fields"].append(
+                    {
+                        "name": "Exception",
+                        "value": f"```python\n{exc_text}\n```",
+                        "inline": False,
+                    }
+                )
 
-            payload = {
-                "username": self.username,
-                "embeds": [embed]
-            }
+            payload = {"username": self.username, "embeds": [embed]}
 
-            data = json.dumps(payload).encode('utf-8')
+            data = json.dumps(payload).encode("utf-8")
             req = request.Request(
                 self.webhook_url,
                 data=data,
-                headers={'Content-Type': 'application/json'}
+                headers={"Content-Type": "application/json"},
             )
-            
+
             with request.urlopen(req, timeout=10) as response:
                 if response.status != 204:
                     print(f"Discord webhook returned status {response.status}")
@@ -91,11 +88,11 @@ class DiscordHandler(logging.Handler):
     def _get_color(self, levelname):
         """Get embed color based on log level."""
         colors = {
-            'DEBUG': 0x7289DA,      # Blue
-            'INFO': 0x3498DB,       # Light Blue
-            'WARNING': 0xF39C12,    # Orange
-            'ERROR': 0xE74C3C,      # Red
-            'CRITICAL': 0x992D22,   # Dark Red
+            "DEBUG": 0x7289DA,  # Blue
+            "INFO": 0x3498DB,  # Light Blue
+            "WARNING": 0xF39C12,  # Orange
+            "ERROR": 0xE74C3C,  # Red
+            "CRITICAL": 0x992D22,  # Dark Red
         }
         return colors.get(levelname, 0x95A5A6)  # Gray default
 
@@ -103,7 +100,7 @@ class DiscordHandler(logging.Handler):
 class SlackHandler(logging.Handler):
     """
     Logging handler that sends error messages to Slack via webhook.
-    
+
     Usage in LOGGING config:
         'slack': {
             'class': 'config.logging_handlers.SlackHandler',
@@ -112,7 +109,13 @@ class SlackHandler(logging.Handler):
         }
     """
 
-    def __init__(self, webhook_url, level=logging.ERROR, username="Django Logger", channel=None):
+    def __init__(
+        self,
+        webhook_url,
+        level=logging.ERROR,
+        username="Django Logger",
+        channel=None,
+    ):
         super().__init__(level)
         self.webhook_url = webhook_url
         self.username = username
@@ -121,8 +124,6 @@ class SlackHandler(logging.Handler):
     def emit(self, record):
         """Send log record to Slack."""
         try:
-            log_entry = self.format(record)
-            
             # Build blocks for better formatting (Slack Block Kit)
             blocks = [
                 {
@@ -130,70 +131,72 @@ class SlackHandler(logging.Handler):
                     "text": {
                         "type": "plain_text",
                         "text": f"🚨 {record.levelname}: {record.name}",
-                        "emoji": True
-                    }
+                        "emoji": True,
+                    },
                 },
                 {
                     "type": "section",
                     "fields": [
                         {
                             "type": "mrkdwn",
-                            "text": f"*Module:*\n`{record.module}.{record.funcName}`"
+                            "text": f"*Module:*\n`{record.module}.{record.funcName}`",
                         },
                         {
                             "type": "mrkdwn",
-                            "text": f"*Line:*\n`{record.lineno}`"
+                            "text": f"*Line:*\n`{record.lineno}`",
                         },
                         {
                             "type": "mrkdwn",
-                            "text": f"*Time:*\n{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+                            "text": f"*Time:*\n{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
                         },
                         {
                             "type": "mrkdwn",
-                            "text": f"*Level:*\n`{record.levelname}`"
-                        }
-                    ]
+                            "text": f"*Level:*\n`{record.levelname}`",
+                        },
+                    ],
                 },
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"*Message:*\n```{record.getMessage()}```"
-                    }
-                }
+                        "text": f"*Message:*\n```{record.getMessage()}```",
+                    },
+                },
             ]
 
             # Add exception info if present
             if record.exc_info:
-                exc_text = ''.join(traceback.format_exception(*record.exc_info))
+                exc_text = "".join(traceback.format_exception(*record.exc_info))
                 # Slack has a 3000 char limit per block
                 if len(exc_text) > 2900:
                     exc_text = exc_text[:2900] + "\n... (truncated)"
-                
-                blocks.append({
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f"*Exception:*\n```{exc_text}```"
+
+                blocks.append(
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": f"*Exception:*\n```{exc_text}```",
+                        },
                     }
-                })
+                )
 
             payload = {
                 "username": self.username,
                 "blocks": blocks,
-                "icon_emoji": ":warning:"
+                "icon_emoji": ":warning:",
             }
 
             if self.channel:
                 payload["channel"] = self.channel
 
-            data = json.dumps(payload).encode('utf-8')
+            data = json.dumps(payload).encode("utf-8")
             req = request.Request(
                 self.webhook_url,
                 data=data,
-                headers={'Content-Type': 'application/json'}
+                headers={"Content-Type": "application/json"},
             )
-            
+
             with request.urlopen(req, timeout=10) as response:
                 if response.status != 200:
                     print(f"Slack webhook returned status {response.status}")

--- a/config/settings.py
+++ b/config/settings.py
@@ -227,7 +227,6 @@ if ENABLE_ERROR_NOTIFICATIONS:
             "class": "config.logging_handlers.DiscordHandler",
             "webhook_url": DISCORD_WEBHOOK_URL,
             "level": "ERROR",
-            "formatter": "verbose",
         }
         LOGGING["root"]["handlers"].append("discord")
 
@@ -236,6 +235,5 @@ if ENABLE_ERROR_NOTIFICATIONS:
             "class": "config.logging_handlers.SlackHandler",
             "webhook_url": SLACK_WEBHOOK_URL,
             "level": "ERROR",
-            "formatter": "verbose",
         }
         LOGGING["root"]["handlers"].append("slack")

--- a/config/settings.py
+++ b/config/settings.py
@@ -22,7 +22,9 @@ if env_file.exists():
     environ.Env.read_env(str(env_file))
 
 # Security
-SECRET_KEY = env("SECRET_KEY") or "django-insecure-dev-only-change-in-production"
+SECRET_KEY = (
+    env("SECRET_KEY") or "django-insecure-dev-only-change-in-production"
+)
 DEBUG = env("DEBUG")
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
@@ -102,8 +104,12 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
     },
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
-    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
-    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"
+    },
 ]
 
 # Internationalization
@@ -134,7 +140,9 @@ for _slug in _WORKSPACE_APP_SLUGS:
 # - GITHUB_TOKENS_SCRAPING: comma-separated list for API read/scraping (round-robin for rate limits)
 # - GITHUB_TOKEN_WRITE: for create PR, issue, comment, and git push
 GITHUB_TOKEN = (env("GITHUB_TOKEN", default="") or "").strip()
-_github_tokens_scraping_str = (env("GITHUB_TOKENS_SCRAPING", default="") or "").strip()
+_github_tokens_scraping_str = (
+    env("GITHUB_TOKENS_SCRAPING", default="") or ""
+).strip()
 GITHUB_TOKENS_SCRAPING = [
     t.strip() for t in _github_tokens_scraping_str.split(",") if t.strip()
 ]
@@ -159,6 +167,13 @@ else:
     LOG_LEVEL = "INFO"
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 _LOG_FILE_PATH = LOG_DIR / LOG_FILE
+
+# Error notification settings (Discord/Slack)
+ENABLE_ERROR_NOTIFICATIONS = env.bool(
+    "ENABLE_ERROR_NOTIFICATIONS", default=False
+)
+DISCORD_WEBHOOK_URL = env("DISCORD_WEBHOOK_URL", default="")
+SLACK_WEBHOOK_URL = env("SLACK_WEBHOOK_URL", default="")
 
 LOGGING = {
     "version": 1,
@@ -214,3 +229,23 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(hour=1, minute=0),
     },
 }
+
+# Conditionally add Discord/Slack handlers for error notifications
+if ENABLE_ERROR_NOTIFICATIONS:
+    if DISCORD_WEBHOOK_URL:
+        LOGGING["handlers"]["discord"] = {
+            "class": "config.logging_handlers.DiscordHandler",
+            "webhook_url": DISCORD_WEBHOOK_URL,
+            "level": "ERROR",
+            "formatter": "verbose",
+        }
+        LOGGING["root"]["handlers"].append("discord")
+
+    if SLACK_WEBHOOK_URL:
+        LOGGING["handlers"]["slack"] = {
+            "class": "config.logging_handlers.SlackHandler",
+            "webhook_url": SLACK_WEBHOOK_URL,
+            "level": "ERROR",
+            "formatter": "verbose",
+        }
+        LOGGING["root"]["handlers"].append("slack")

--- a/config/settings.py
+++ b/config/settings.py
@@ -22,9 +22,7 @@ if env_file.exists():
     environ.Env.read_env(str(env_file))
 
 # Security
-SECRET_KEY = (
-    env("SECRET_KEY") or "django-insecure-dev-only-change-in-production"
-)
+SECRET_KEY = env("SECRET_KEY") or "django-insecure-dev-only-change-in-production"
 DEBUG = env("DEBUG")
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
@@ -104,12 +102,8 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
     },
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
-    {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"
-    },
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
 # Internationalization
@@ -140,9 +134,7 @@ for _slug in _WORKSPACE_APP_SLUGS:
 # - GITHUB_TOKENS_SCRAPING: comma-separated list for API read/scraping (round-robin for rate limits)
 # - GITHUB_TOKEN_WRITE: for create PR, issue, comment, and git push
 GITHUB_TOKEN = (env("GITHUB_TOKEN", default="") or "").strip()
-_github_tokens_scraping_str = (
-    env("GITHUB_TOKENS_SCRAPING", default="") or ""
-).strip()
+_github_tokens_scraping_str = (env("GITHUB_TOKENS_SCRAPING", default="") or "").strip()
 GITHUB_TOKENS_SCRAPING = [
     t.strip() for t in _github_tokens_scraping_str.split(",") if t.strip()
 ]
@@ -169,9 +161,7 @@ LOG_DIR.mkdir(parents=True, exist_ok=True)
 _LOG_FILE_PATH = LOG_DIR / LOG_FILE
 
 # Error notification settings (Discord/Slack)
-ENABLE_ERROR_NOTIFICATIONS = env.bool(
-    "ENABLE_ERROR_NOTIFICATIONS", default=False
-)
+ENABLE_ERROR_NOTIFICATIONS = env.bool("ENABLE_ERROR_NOTIFICATIONS", default=False)
 DISCORD_WEBHOOK_URL = env("DISCORD_WEBHOOK_URL", default="")
 SLACK_WEBHOOK_URL = env("SLACK_WEBHOOK_URL", default="")
 


### PR DESCRIPTION
- When an error occurs, the error message is sent to maintainers via Discord and Slack.

- Developers should report errors with `logger.error(<message>)` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Discord and Slack webhook integration for application error notifications
  * Error notifications can be selectively enabled through environment configuration
  * Structured error messages with detailed context and optional exception traces
  * Automatic cooldown protection to prevent excessive notifications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->