### PR TITLE
Add start and end time logic in boost_library_tracker (#25).

### DIFF
--- a/boost_library_tracker/management/commands/run_boost_library_tracker.py
+++ b/boost_library_tracker/management/commands/run_boost_library_tracker.py
@@ -59,7 +59,7 @@ def task_fetch_github_activity(
     from_library: str | None = None,
 ) -> None:
     """Fetch GitHub activity for boostorg/boost and all its submodules.
-    
+
     Args:
         dry_run: If True, only show what would be done.
         start_date: Start date for sync (default: auto from DB).
@@ -76,7 +76,7 @@ def task_fetch_github_activity(
         self.stdout.write("  To: now")
     if from_library:
         self.stdout.write(f"  From library: {from_library} (and all after)")
-    
+
     client = get_github_client(use="scraping")
 
     # Resolve owner account for main repo (boostorg)
@@ -126,7 +126,9 @@ def task_fetch_github_activity(
                 "Check the name (e.g. 'build', 'algorithm')."
             )
         repos_to_sync = repos_to_sync[idx:]
-        self.stdout.write(f"  Starting from {repos_to_sync[0][0]}/{repos_to_sync[0][1]} ({len(repos_to_sync)} repo(s))")
+        self.stdout.write(
+            f"  Starting from {repos_to_sync[0][0]}/{repos_to_sync[0][1]} ({len(repos_to_sync)} repo(s))"
+        )
 
     if dry_run:
         self.stdout.write(
@@ -209,7 +211,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         task_filter = (options["task"] or "").strip().lower()
-        
+
         # Parse date arguments
         start_date = None
         end_date = None
@@ -225,7 +227,7 @@ class Command(BaseCommand):
             except ValueError as e:
                 self.stderr.write(self.style.ERROR(f"Invalid --to-date format: {e}"))
                 return
-        
+
         from_library = (options.get("from_library") or "").strip() or None
         logger.debug(
             "run_boost_library_tracker: starting (dry_run=%s, task=%s, from=%s, to=%s, from_library=%s)",

--- a/boost_library_tracker/management/commands/run_boost_library_tracker.py
+++ b/boost_library_tracker/management/commands/run_boost_library_tracker.py
@@ -10,6 +10,7 @@ For now only task 1 (fetch GitHub activity) is implemented.
 """
 
 import logging
+from datetime import datetime
 
 import requests
 from django.core.management.base import BaseCommand
@@ -50,9 +51,27 @@ def _parse_gitmodules_owner_repo(gitmodules_content: str) -> list[tuple[str, str
     return result
 
 
-def task_fetch_github_activity(self, dry_run: bool = False) -> None:
-    """Fetch GitHub activity for boostorg/boost and all its submodules."""
+def task_fetch_github_activity(
+    self,
+    dry_run: bool = False,
+    start_date: datetime = None,
+    end_date: datetime = None,
+) -> None:
+    """Fetch GitHub activity for boostorg/boost and all its submodules.
+    
+    Args:
+        dry_run: If True, only show what would be done.
+        start_date: Start date for sync (default: auto from DB).
+        end_date: End date for sync (default: now).
+    """
     self.stdout.write("Task 1: Fetch GitHub activity (main repo + submodules)...")
+    if start_date:
+        self.stdout.write(f"  From: {start_date.isoformat()}")
+    if end_date:
+        self.stdout.write(f"  To: {end_date.isoformat()}")
+    else:
+        self.stdout.write("  To: now")
+    
     client = get_github_client(use="scraping")
 
     # Resolve owner account for main repo (boostorg)
@@ -105,7 +124,7 @@ def task_fetch_github_activity(self, dry_run: bool = False) -> None:
             repo, _ = get_or_create_repository(acc, repo_name)
             ensure_repository_owner(repo, acc)
             boost_repo, _ = get_or_create_boost_library_repo(repo)
-            sync_github(boost_repo)
+            sync_github(boost_repo, start_date=start_date, end_date=end_date)
             synced += 1
             self.stdout.write(self.style.SUCCESS(f"  Synced {owner}/{repo_name}"))
         except (ConnectionException, RateLimitException) as e:
@@ -145,19 +164,52 @@ class Command(BaseCommand):
             default=None,
             help="Run only this task: 'github_activity' or 'library_tracker'. Default: run all.",
         )
+        parser.add_argument(
+            "--from-date",
+            type=str,
+            default=None,
+            help="Start date for sync (ISO format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS). Default: auto from DB.",
+        )
+        parser.add_argument(
+            "--to-date",
+            type=str,
+            default=None,
+            help="End date for sync (ISO format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS). Default: now.",
+        )
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         task_filter = (options["task"] or "").strip().lower()
+        
+        # Parse date arguments
+        start_date = None
+        end_date = None
+        if options.get("from_date"):
+            try:
+                start_date = datetime.fromisoformat(options["from_date"])
+            except ValueError as e:
+                self.stderr.write(self.style.ERROR(f"Invalid --from-date format: {e}"))
+                return
+        if options.get("to_date"):
+            try:
+                end_date = datetime.fromisoformat(options["to_date"])
+            except ValueError as e:
+                self.stderr.write(self.style.ERROR(f"Invalid --to-date format: {e}"))
+                return
+        
         logger.debug(
-            "run_boost_library_tracker: starting (dry_run=%s, task=%s)",
+            "run_boost_library_tracker: starting (dry_run=%s, task=%s, from=%s, to=%s)",
             dry_run,
             task_filter or "all",
+            start_date.isoformat() if start_date else "auto",
+            end_date.isoformat() if end_date else "now",
         )
 
         try:
             if not task_filter or task_filter == "github_activity":
-                task_fetch_github_activity(self, dry_run=dry_run)
+                task_fetch_github_activity(
+                    self, dry_run=dry_run, start_date=start_date, end_date=end_date
+                )
             if not task_filter or task_filter == "library_tracker":
                 task_library_tracker(self, dry_run=dry_run)
 

--- a/boost_library_tracker/management/commands/run_boost_library_tracker.py
+++ b/boost_library_tracker/management/commands/run_boost_library_tracker.py
@@ -13,7 +13,7 @@ import logging
 from datetime import datetime
 
 import requests
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from cppa_user_tracker.services import get_or_create_owner_account
 from github_activity_tracker.services import (
@@ -56,6 +56,7 @@ def task_fetch_github_activity(
     dry_run: bool = False,
     start_date: datetime = None,
     end_date: datetime = None,
+    from_library: str | None = None,
 ) -> None:
     """Fetch GitHub activity for boostorg/boost and all its submodules.
     
@@ -63,6 +64,8 @@ def task_fetch_github_activity(
         dry_run: If True, only show what would be done.
         start_date: Start date for sync (default: auto from DB).
         end_date: End date for sync (default: now).
+        from_library: If set, sync only from this submodule onward (skip main repo and
+            submodules before it). Library name = repo name (e.g. 'build', 'algorithm').
     """
     self.stdout.write("Task 1: Fetch GitHub activity (main repo + submodules)...")
     if start_date:
@@ -71,6 +74,8 @@ def task_fetch_github_activity(
         self.stdout.write(f"  To: {end_date.isoformat()}")
     else:
         self.stdout.write("  To: now")
+    if from_library:
+        self.stdout.write(f"  From library: {from_library} (and all after)")
     
     client = get_github_client(use="scraping")
 
@@ -106,6 +111,22 @@ def task_fetch_github_activity(
             raise
     except Exception as e:
         logger.warning("Could not fetch .gitmodules: %s; syncing main repo only", e)
+
+    # If --from-library is set, start only from that submodule onward
+    if from_library:
+        from_name = from_library.strip()
+        idx = None
+        for i, (_owner, repo_name) in enumerate(repos_to_sync):
+            if repo_name == from_name:
+                idx = i
+                break
+        if idx is None:
+            raise CommandError(
+                f"Library '{from_name}' not found in repo list (main + submodules). "
+                "Check the name (e.g. 'build', 'algorithm')."
+            )
+        repos_to_sync = repos_to_sync[idx:]
+        self.stdout.write(f"  Starting from {repos_to_sync[0][0]}/{repos_to_sync[0][1]} ({len(repos_to_sync)} repo(s))")
 
     if dry_run:
         self.stdout.write(
@@ -176,6 +197,14 @@ class Command(BaseCommand):
             default=None,
             help="End date for sync (ISO format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS). Default: now.",
         )
+        parser.add_argument(
+            "--from-library",
+            type=str,
+            default=None,
+            metavar="NAME",
+            help="Start from this submodule onward (repo name, e.g. 'build', 'algorithm'). "
+            "Skips main repo and submodules before this one. Default: sync all from scratch.",
+        )
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
@@ -197,18 +226,24 @@ class Command(BaseCommand):
                 self.stderr.write(self.style.ERROR(f"Invalid --to-date format: {e}"))
                 return
         
+        from_library = (options.get("from_library") or "").strip() or None
         logger.debug(
-            "run_boost_library_tracker: starting (dry_run=%s, task=%s, from=%s, to=%s)",
+            "run_boost_library_tracker: starting (dry_run=%s, task=%s, from=%s, to=%s, from_library=%s)",
             dry_run,
             task_filter or "all",
             start_date.isoformat() if start_date else "auto",
             end_date.isoformat() if end_date else "now",
+            from_library or "all",
         )
 
         try:
             if not task_filter or task_filter == "github_activity":
                 task_fetch_github_activity(
-                    self, dry_run=dry_run, start_date=start_date, end_date=end_date
+                    self,
+                    dry_run=dry_run,
+                    start_date=start_date,
+                    end_date=end_date,
+                    from_library=from_library,
                 )
             if not task_filter or task_filter == "library_tracker":
                 task_library_tracker(self, dry_run=dry_run)

--- a/boost_library_tracker/tests/test_commands.py
+++ b/boost_library_tracker/tests/test_commands.py
@@ -16,7 +16,13 @@ def test_run_boost_library_tracker_invalid_from_date_writes_error_and_returns():
     """With invalid --from-date, command writes error to stderr and returns without raising."""
     out = StringIO()
     err = StringIO()
-    call_command(CMD_NAME, "--from-date=not-a-date", "--task=github_activity", stdout=out, stderr=err)
+    call_command(
+        CMD_NAME,
+        "--from-date=not-a-date",
+        "--task=github_activity",
+        stdout=out,
+        stderr=err,
+    )
     assert "Invalid" in err.getvalue() or "from-date" in err.getvalue().lower()
 
 
@@ -25,7 +31,9 @@ def test_run_boost_library_tracker_invalid_to_date_writes_error_and_returns():
     """With invalid --to-date, command writes error to stderr and returns without raising."""
     out = StringIO()
     err = StringIO()
-    call_command(CMD_NAME, "--to-date=invalid", "--task=github_activity", stdout=out, stderr=err)
+    call_command(
+        CMD_NAME, "--to-date=invalid", "--task=github_activity", stdout=out, stderr=err
+    )
     assert "Invalid" in err.getvalue() or "to-date" in err.getvalue().lower()
 
 

--- a/boost_library_tracker/tests/test_commands.py
+++ b/boost_library_tracker/tests/test_commands.py
@@ -1,0 +1,127 @@
+"""Tests for boost_library_tracker management commands (run_boost_library_tracker)."""
+
+import pytest
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+CMD_NAME = "run_boost_library_tracker"
+
+
+@pytest.mark.django_db
+def test_run_boost_library_tracker_invalid_from_date_writes_error_and_returns():
+    """With invalid --from-date, command writes error to stderr and returns without raising."""
+    out = StringIO()
+    err = StringIO()
+    call_command(CMD_NAME, "--from-date=not-a-date", "--task=github_activity", stdout=out, stderr=err)
+    assert "Invalid" in err.getvalue() or "from-date" in err.getvalue().lower()
+
+
+@pytest.mark.django_db
+def test_run_boost_library_tracker_invalid_to_date_writes_error_and_returns():
+    """With invalid --to-date, command writes error to stderr and returns without raising."""
+    out = StringIO()
+    err = StringIO()
+    call_command(CMD_NAME, "--to-date=invalid", "--task=github_activity", stdout=out, stderr=err)
+    assert "Invalid" in err.getvalue() or "to-date" in err.getvalue().lower()
+
+
+@pytest.mark.django_db
+def test_run_boost_library_tracker_from_library_not_found_raises_command_error():
+    """With --from-library that is not in repo list, command raises CommandError."""
+    mock_client = MagicMock()
+    mock_client.get_file_content.return_value = (
+        b'[submodule "libs/build"]\npath = libs/build\nurl = ../build.git\n',
+        "utf-8",
+    )
+    mock_account = MagicMock()
+    mock_account.username = "boostorg"
+    with patch(
+        "boost_library_tracker.management.commands.run_boost_library_tracker.get_github_client",
+        return_value=mock_client,
+    ), patch(
+        "boost_library_tracker.management.commands.run_boost_library_tracker.get_or_create_owner_account",
+        return_value=mock_account,
+    ):
+        with pytest.raises(CommandError, match="not found in repo list"):
+            call_command(
+                CMD_NAME,
+                "--from-library=NonExistentLib",
+                "--task=github_activity",
+                "--dry-run",
+                stdout=StringIO(),
+                stderr=StringIO(),
+            )
+
+
+@pytest.mark.django_db
+def test_run_boost_library_tracker_from_library_valid_calls_sync_with_filter():
+    """With valid --from-library and --dry-run, task runs and stdout mentions the library."""
+    mock_client = MagicMock()
+    mock_client.get_file_content.return_value = (
+        b'[submodule "libs/build"]\npath = libs/build\nurl = ../build.git\n'
+        b'[submodule "libs/algorithm"]\npath = libs/algorithm\nurl = ../algorithm.git\n',
+        "utf-8",
+    )
+    mock_account = MagicMock()
+    mock_account.username = "boostorg"
+    with patch(
+        "boost_library_tracker.management.commands.run_boost_library_tracker.get_github_client",
+        return_value=mock_client,
+    ), patch(
+        "boost_library_tracker.management.commands.run_boost_library_tracker.get_or_create_owner_account",
+        return_value=mock_account,
+    ), patch(
+        "boost_library_tracker.management.commands.run_boost_library_tracker.sync_github",
+    ):
+        out = StringIO()
+        err = StringIO()
+        call_command(
+            CMD_NAME,
+            "--from-library=algorithm",
+            "--task=github_activity",
+            "--dry-run",
+            stdout=out,
+            stderr=err,
+        )
+    content = out.getvalue()
+    assert "algorithm" in content.lower() or "Starting from" in content
+
+
+@pytest.mark.django_db
+def test_run_boost_library_tracker_passes_from_date_to_date_to_task():
+    """With --from-date and --to-date, task_fetch_github_activity is called with those dates."""
+    mock_client = MagicMock()
+    mock_client.get_file_content.return_value = (b"", "utf-8")
+    mock_account = MagicMock()
+    mock_account.username = "boostorg"
+    with patch(
+        "boost_library_tracker.management.commands.run_boost_library_tracker.get_github_client",
+        return_value=mock_client,
+    ), patch(
+        "boost_library_tracker.management.commands.run_boost_library_tracker.get_or_create_owner_account",
+        return_value=mock_account,
+    ), patch(
+        "boost_library_tracker.management.commands.run_boost_library_tracker.sync_github",
+    ), patch(
+        "boost_library_tracker.management.commands.run_boost_library_tracker.task_fetch_github_activity",
+    ) as task_mock:
+        out = StringIO()
+        call_command(
+            CMD_NAME,
+            "--from-date=2024-01-01",
+            "--to-date=2024-06-30",
+            "--task=github_activity",
+            "--dry-run",
+            stdout=out,
+            stderr=StringIO(),
+        )
+        task_mock.assert_called_once()
+        call_kw = task_mock.call_args[1]
+        assert call_kw.get("start_date") is not None
+        assert call_kw.get("end_date") is not None
+        assert call_kw["start_date"].isoformat().startswith("2024-01-01")
+        assert call_kw["end_date"].isoformat().startswith("2024-06-30")

--- a/github_activity_tracker/fetcher.py
+++ b/github_activity_tracker/fetcher.py
@@ -10,6 +10,8 @@ import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Iterator, Optional
 
+import requests
+
 if TYPE_CHECKING:
     from github_ops.client import GitHubAPIClient
 
@@ -99,10 +101,23 @@ def fetch_commits_from_github(
                         f"Failed to parse commit date '{commit_date_str}': {e}"
                     )
 
-            # Fetch full commit with stats
-            commit_with_stats = client.rest_request(
-                f"/repos/{owner}/{repo}/commits/{commit['sha']}"
-            )
+            # Fetch full commit with stats (skip on persistent server errors so sync continues)
+            try:
+                commit_with_stats = client.rest_request(
+                    f"/repos/{owner}/{repo}/commits/{commit['sha']}"
+                )
+            except requests.exceptions.HTTPError as e:
+                if e.response is not None and e.response.status_code in (502, 503, 504):
+                    logger.warning(
+                        "Skipping commit %s for %s/%s after HTTP %s: %s",
+                        commit["sha"][:7],
+                        owner,
+                        repo,
+                        e.response.status_code,
+                        e,
+                    )
+                    continue
+                raise
             yield commit_with_stats
 
         if len(commits) < per_page:

--- a/github_activity_tracker/sync/__init__.py
+++ b/github_activity_tracker/sync/__init__.py
@@ -8,7 +8,8 @@ Accepts GitHubRepository or any subclass (e.g. BoostLibraryRepository); base fie
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
 
 from .commits import sync_commits
 from .issues import sync_issues
@@ -19,14 +20,22 @@ if TYPE_CHECKING:
     from ..models import GitHubRepository
 
 
-def sync_github(repo: GitHubRepository) -> None:
+def sync_github(
+    repo: GitHubRepository,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> None:
     """Run full sync for one repo: repos (metadata), then commits, issues, pull requests.
 
     Accepts GitHubRepository or a subclass (e.g. BoostLibraryRepository); the same
     base row is used, so extended models can be passed and sync will work.
 
+    Args:
+        repo: Repository to sync.
+        start_date: Override start date for commits/issues/PRs (default: auto from DB).
+        end_date: Override end date for commits/issues/PRs (default: now).
     """
     sync_repos(repo)
-    sync_commits(repo)
-    sync_issues(repo)
-    sync_pull_requests(repo)
+    sync_commits(repo, start_date=start_date, end_date=end_date)
+    sync_issues(repo, start_date=start_date, end_date=end_date)
+    sync_pull_requests(repo, start_date=start_date, end_date=end_date)

--- a/github_activity_tracker/sync/commits.py
+++ b/github_activity_tracker/sync/commits.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from cppa_user_tracker.services import (
     get_or_create_github_account,
@@ -25,6 +25,7 @@ from github_activity_tracker.workspace import (
 )
 from github_ops import get_github_client
 from github_ops.client import ConnectionException, RateLimitException
+from .raw_source import save_commit_raw_source
 from github_activity_tracker.sync.utils import (
     parse_datetime,
     parse_github_user,
@@ -44,7 +45,9 @@ def _process_commit_files(
 ) -> None:
     """Create/update GitHubFile and GitCommitFileChange for each file in the commit."""
     for file_info in commit_data.get("files") or []:
-        filename = file_info.get("filename") or file_info.get("previous_filename")
+        filename = file_info.get("filename") or file_info.get(
+            "previous_filename"
+        )
         if not (filename and filename.strip()):
             continue
         filename = filename.strip()
@@ -94,7 +97,9 @@ def _process_commit_data(repo: GitHubRepository, commit_data: dict) -> None:
         )
     else:
         name, email = _commit_author_name_and_email(commit_data)
-        account, _ = get_or_create_unknown_github_account(name=name, email=email)
+        account, _ = get_or_create_unknown_github_account(
+            name=name, email=email
+        )
 
     commit_hash = commit_data.get("sha")
     comment = commit_data.get("commit", {}).get("message", "")
@@ -123,6 +128,7 @@ def _process_existing_commit_jsons(repo: GitHubRepository) -> int:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             _process_commit_data(repo, data)
+            save_commit_raw_source(owner, repo_name, data)
             path.unlink()
             count += 1
         except Exception as e:
@@ -130,9 +136,21 @@ def _process_existing_commit_jsons(repo: GitHubRepository) -> int:
     return count
 
 
-def sync_commits(repo: GitHubRepository) -> None:
-    """1) Process existing workspace JSONs; 2) Fetch from GitHub, save as JSON, persist to DB, remove file."""
-    logger.info("sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name)
+def sync_commits(
+    repo: GitHubRepository,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> None:
+    """1) Process existing workspace JSONs; 2) Fetch from GitHub, save as JSON, persist to DB, remove file.
+
+    Args:
+        repo: Repository to sync.
+        start_date: Override start date (default: last commit date + 1s, or None if no commits).
+        end_date: Override end date (default: now).
+    """
+    logger.info(
+        "sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name
+    )
 
     owner = repo.owner_account.username
     repo_name = repo.repo_name
@@ -142,17 +160,18 @@ def sync_commits(repo: GitHubRepository) -> None:
         n_existing = _process_existing_commit_jsons(repo)
         if n_existing:
             logger.info(
-                "sync_commits: processed %s existing commit JSON(s)", n_existing
+                "sync_commits: processed %s existing commit JSON(s)",
+                n_existing,
             )
 
         # Phase 2: fetch from GitHub, write JSON, persist to DB, remove file
         client = get_github_client()
-        last_commit = repo.commits.order_by("-commit_at").first()
-        if last_commit:
-            start_date = last_commit.commit_at + timedelta(seconds=1)
-        else:
-            start_date = None
-        end_date = datetime.now()
+        if start_date is None:
+            last_commit = repo.commits.order_by("-commit_at").first()
+            if last_commit:
+                start_date = last_commit.commit_at + timedelta(seconds=1)
+        if end_date is None:
+            end_date = datetime.now()
 
         count = 0
         for commit_data in fetcher.fetch_commits_from_github(
@@ -164,9 +183,11 @@ def sync_commits(repo: GitHubRepository) -> None:
             json_path = get_commit_json_path(owner, repo_name, sha)
             json_path.parent.mkdir(parents=True, exist_ok=True)
             json_path.write_text(
-                json.dumps(commit_data, indent=2, default=str), encoding="utf-8"
+                json.dumps(commit_data, indent=2, default=str),
+                encoding="utf-8",
             )
             _process_commit_data(repo, commit_data)
+            save_commit_raw_source(owner, repo_name, commit_data)
             json_path.unlink()
             count += 1
 

--- a/github_activity_tracker/sync/commits.py
+++ b/github_activity_tracker/sync/commits.py
@@ -45,9 +45,7 @@ def _process_commit_files(
 ) -> None:
     """Create/update GitHubFile and GitCommitFileChange for each file in the commit."""
     for file_info in commit_data.get("files") or []:
-        filename = file_info.get("filename") or file_info.get(
-            "previous_filename"
-        )
+        filename = file_info.get("filename") or file_info.get("previous_filename")
         if not (filename and filename.strip()):
             continue
         filename = filename.strip()
@@ -97,9 +95,7 @@ def _process_commit_data(repo: GitHubRepository, commit_data: dict) -> None:
         )
     else:
         name, email = _commit_author_name_and_email(commit_data)
-        account, _ = get_or_create_unknown_github_account(
-            name=name, email=email
-        )
+        account, _ = get_or_create_unknown_github_account(name=name, email=email)
 
     commit_hash = commit_data.get("sha")
     comment = commit_data.get("commit", {}).get("message", "")
@@ -148,9 +144,7 @@ def sync_commits(
         start_date: Override start date (default: last commit date + 1s, or None if no commits).
         end_date: Override end date (default: now).
     """
-    logger.info(
-        "sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name
-    )
+    logger.info("sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name)
 
     owner = repo.owner_account.username
     repo_name = repo.repo_name

--- a/github_activity_tracker/sync/issues.py
+++ b/github_activity_tracker/sync/issues.py
@@ -77,12 +77,8 @@ def _process_issue_data(repo: GitHubRepository, issue_data: dict) -> None:
                 account=comment_account,
                 issue_comment_id=comment_data.get("id"),
                 body=comment_data.get("body", ""),
-                issue_comment_created_at=parse_datetime(
-                    comment_data.get("created_at")
-                ),
-                issue_comment_updated_at=parse_datetime(
-                    comment_data.get("updated_at")
-                ),
+                issue_comment_created_at=parse_datetime(comment_data.get("created_at")),
+                issue_comment_updated_at=parse_datetime(comment_data.get("updated_at")),
             )
 
     assignee_infos = [parse_github_user(a) for a in issue_data.get("assignees", [])]
@@ -131,15 +127,13 @@ def sync_issues(
     end_date: Optional[datetime] = None,
 ) -> None:
     """1) Process existing workspace JSONs; 2) Fetch from GitHub, save as JSON, persist to DB, remove file.
-    
+
     Args:
         repo: Repository to sync.
         start_date: Override start date (default: last issue updated_at + 1s, or None if no issues).
         end_date: Override end date (default: now).
     """
-    logger.info(
-        "sync_issues: starting for repo id=%s (%s)", repo.pk, repo.repo_name
-    )
+    logger.info("sync_issues: starting for repo id=%s (%s)", repo.pk, repo.repo_name)
 
     owner = repo.owner_account.username
     repo_name = repo.repo_name
@@ -148,9 +142,7 @@ def sync_issues(
         # Phase 1: process existing JSON files
         n_existing = _process_existing_issue_jsons(repo)
         if n_existing:
-            logger.info(
-                "sync_issues: processed %s existing issue JSON(s)", n_existing
-            )
+            logger.info("sync_issues: processed %s existing issue JSON(s)", n_existing)
 
         # Phase 2: fetch from GitHub, write JSON, persist to DB, remove file
         client = get_github_client()
@@ -189,7 +181,5 @@ def sync_issues(
         logger.error("sync_issues: failed for repo id=%s: %s", repo.pk, e)
         raise
     except Exception as e:
-        logger.exception(
-            "sync_issues: unexpected error for repo id=%s: %s", repo.pk, e
-        )
+        logger.exception("sync_issues: unexpected error for repo id=%s: %s", repo.pk, e)
         raise

--- a/github_activity_tracker/sync/issues.py
+++ b/github_activity_tracker/sync/issues.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from cppa_user_tracker.services import get_or_create_github_account
 from github_activity_tracker import fetcher, services
+from .raw_source import save_issue_raw_source
 from github_activity_tracker.workspace import (
     get_issue_json_path,
     iter_existing_issue_jsons,
@@ -76,8 +77,12 @@ def _process_issue_data(repo: GitHubRepository, issue_data: dict) -> None:
                 account=comment_account,
                 issue_comment_id=comment_data.get("id"),
                 body=comment_data.get("body", ""),
-                issue_comment_created_at=parse_datetime(comment_data.get("created_at")),
-                issue_comment_updated_at=parse_datetime(comment_data.get("updated_at")),
+                issue_comment_created_at=parse_datetime(
+                    comment_data.get("created_at")
+                ),
+                issue_comment_updated_at=parse_datetime(
+                    comment_data.get("updated_at")
+                ),
             )
 
     assignee_infos = [parse_github_user(a) for a in issue_data.get("assignees", [])]
@@ -112,6 +117,7 @@ def _process_existing_issue_jsons(repo: GitHubRepository) -> int:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             _process_issue_data(repo, data)
+            save_issue_raw_source(owner, repo_name, data)
             path.unlink()
             count += 1
         except Exception as e:
@@ -119,9 +125,21 @@ def _process_existing_issue_jsons(repo: GitHubRepository) -> int:
     return count
 
 
-def sync_issues(repo: GitHubRepository) -> None:
-    """1) Process existing workspace JSONs; 2) Fetch from GitHub, save as JSON, persist to DB, remove file."""
-    logger.info("sync_issues: starting for repo id=%s (%s)", repo.pk, repo.repo_name)
+def sync_issues(
+    repo: GitHubRepository,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> None:
+    """1) Process existing workspace JSONs; 2) Fetch from GitHub, save as JSON, persist to DB, remove file.
+    
+    Args:
+        repo: Repository to sync.
+        start_date: Override start date (default: last issue updated_at + 1s, or None if no issues).
+        end_date: Override end date (default: now).
+    """
+    logger.info(
+        "sync_issues: starting for repo id=%s (%s)", repo.pk, repo.repo_name
+    )
 
     owner = repo.owner_account.username
     repo_name = repo.repo_name
@@ -130,16 +148,18 @@ def sync_issues(repo: GitHubRepository) -> None:
         # Phase 1: process existing JSON files
         n_existing = _process_existing_issue_jsons(repo)
         if n_existing:
-            logger.info("sync_issues: processed %s existing issue JSON(s)", n_existing)
+            logger.info(
+                "sync_issues: processed %s existing issue JSON(s)", n_existing
+            )
 
         # Phase 2: fetch from GitHub, write JSON, persist to DB, remove file
         client = get_github_client()
-        last_issue = repo.issues.order_by("-issue_updated_at").first()
-        if last_issue:
-            start_date = last_issue.issue_updated_at + timedelta(seconds=1)
-        else:
-            start_date = None
-        end_date = datetime.now()
+        if start_date is None:
+            last_issue = repo.issues.order_by("-issue_updated_at").first()
+            if last_issue:
+                start_date = last_issue.issue_updated_at + timedelta(seconds=1)
+        if end_date is None:
+            end_date = datetime.now()
 
         count = 0
         for issue_data in fetcher.fetch_issues_from_github(
@@ -154,6 +174,7 @@ def sync_issues(repo: GitHubRepository) -> None:
                 json.dumps(issue_data, indent=2, default=str), encoding="utf-8"
             )
             _process_issue_data(repo, issue_data)
+            save_issue_raw_source(owner, repo_name, issue_data)
             json_path.unlink()
             count += 1
 
@@ -168,5 +189,7 @@ def sync_issues(repo: GitHubRepository) -> None:
         logger.error("sync_issues: failed for repo id=%s: %s", repo.pk, e)
         raise
     except Exception as e:
-        logger.exception("sync_issues: unexpected error for repo id=%s: %s", repo.pk, e)
+        logger.exception(
+            "sync_issues: unexpected error for repo id=%s: %s", repo.pk, e
+        )
         raise

--- a/github_activity_tracker/sync/pull_requests.py
+++ b/github_activity_tracker/sync/pull_requests.py
@@ -79,12 +79,8 @@ def _process_pr_data(repo: GitHubRepository, pr_data: dict) -> None:
                 account=comment_account,
                 pr_comment_id=comment_data.get("id"),
                 body=comment_data.get("body", ""),
-                pr_comment_created_at=parse_datetime(
-                    comment_data.get("created_at")
-                ),
-                pr_comment_updated_at=parse_datetime(
-                    comment_data.get("updated_at")
-                ),
+                pr_comment_created_at=parse_datetime(comment_data.get("created_at")),
+                pr_comment_updated_at=parse_datetime(comment_data.get("updated_at")),
             )
 
     for review_data in pr_data.get("reviews", []):
@@ -102,12 +98,8 @@ def _process_pr_data(repo: GitHubRepository, pr_data: dict) -> None:
                 pr_review_id=review_data.get("id"),
                 body=review_data.get("body", ""),
                 in_reply_to_id=review_data.get("in_reply_to_id"),
-                pr_review_created_at=parse_datetime(
-                    review_data.get("created_at")
-                ),
-                pr_review_updated_at=parse_datetime(
-                    review_data.get("updated_at")
-                ),
+                pr_review_created_at=parse_datetime(review_data.get("created_at")),
+                pr_review_updated_at=parse_datetime(review_data.get("updated_at")),
             )
 
     for assignee_data in pr_data.get("assignees", []):
@@ -152,7 +144,7 @@ def sync_pull_requests(
     end_date: Optional[datetime] = None,
 ) -> None:
     """1) Process existing workspace JSONs; 2) Fetch from GitHub, save as JSON, persist to DB, remove file.
-    
+
     Args:
         repo: Repository to sync.
         start_date: Override start date (default: last PR updated_at + 1s, or None if no PRs).
@@ -210,9 +202,7 @@ def sync_pull_requests(
         )
 
     except (RateLimitException, ConnectionException) as e:
-        logger.error(
-            "sync_pull_requests: failed for repo id=%s: %s", repo.pk, e
-        )
+        logger.error("sync_pull_requests: failed for repo id=%s: %s", repo.pk, e)
         raise
     except Exception as e:
         logger.exception(

--- a/github_activity_tracker/sync/pull_requests.py
+++ b/github_activity_tracker/sync/pull_requests.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from cppa_user_tracker.services import get_or_create_github_account
 from github_activity_tracker import fetcher, services
+from .raw_source import save_pr_raw_source
 from github_activity_tracker.workspace import (
     get_pr_json_path,
     iter_existing_pr_jsons,
@@ -78,8 +79,12 @@ def _process_pr_data(repo: GitHubRepository, pr_data: dict) -> None:
                 account=comment_account,
                 pr_comment_id=comment_data.get("id"),
                 body=comment_data.get("body", ""),
-                pr_comment_created_at=parse_datetime(comment_data.get("created_at")),
-                pr_comment_updated_at=parse_datetime(comment_data.get("updated_at")),
+                pr_comment_created_at=parse_datetime(
+                    comment_data.get("created_at")
+                ),
+                pr_comment_updated_at=parse_datetime(
+                    comment_data.get("updated_at")
+                ),
             )
 
     for review_data in pr_data.get("reviews", []):
@@ -97,8 +102,12 @@ def _process_pr_data(repo: GitHubRepository, pr_data: dict) -> None:
                 pr_review_id=review_data.get("id"),
                 body=review_data.get("body", ""),
                 in_reply_to_id=review_data.get("in_reply_to_id"),
-                pr_review_created_at=parse_datetime(review_data.get("created_at")),
-                pr_review_updated_at=parse_datetime(review_data.get("updated_at")),
+                pr_review_created_at=parse_datetime(
+                    review_data.get("created_at")
+                ),
+                pr_review_updated_at=parse_datetime(
+                    review_data.get("updated_at")
+                ),
             )
 
     for assignee_data in pr_data.get("assignees", []):
@@ -129,6 +138,7 @@ def _process_existing_pr_jsons(repo: GitHubRepository) -> int:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             _process_pr_data(repo, data)
+            save_pr_raw_source(owner, repo_name, data)
             path.unlink()
             count += 1
         except Exception as e:
@@ -136,10 +146,22 @@ def _process_existing_pr_jsons(repo: GitHubRepository) -> int:
     return count
 
 
-def sync_pull_requests(repo: GitHubRepository) -> None:
-    """1) Process existing workspace JSONs; 2) Fetch from GitHub, save as JSON, persist to DB, remove file."""
+def sync_pull_requests(
+    repo: GitHubRepository,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> None:
+    """1) Process existing workspace JSONs; 2) Fetch from GitHub, save as JSON, persist to DB, remove file.
+    
+    Args:
+        repo: Repository to sync.
+        start_date: Override start date (default: last PR updated_at + 1s, or None if no PRs).
+        end_date: Override end date (default: now).
+    """
     logger.info(
-        "sync_pull_requests: starting for repo id=%s (%s)", repo.pk, repo.repo_name
+        "sync_pull_requests: starting for repo id=%s (%s)",
+        repo.pk,
+        repo.repo_name,
     )
 
     owner = repo.owner_account.username
@@ -150,17 +172,18 @@ def sync_pull_requests(repo: GitHubRepository) -> None:
         n_existing = _process_existing_pr_jsons(repo)
         if n_existing:
             logger.info(
-                "sync_pull_requests: processed %s existing PR JSON(s)", n_existing
+                "sync_pull_requests: processed %s existing PR JSON(s)",
+                n_existing,
             )
 
         # Phase 2: fetch from GitHub, write JSON, persist to DB, remove file
         client = get_github_client()
-        last_pr = repo.pull_requests.order_by("-pr_updated_at").first()
-        if last_pr:
-            start_date = last_pr.pr_updated_at + timedelta(seconds=1)
-        else:
-            start_date = None
-        end_date = datetime.now()
+        if start_date is None:
+            last_pr = repo.pull_requests.order_by("-pr_updated_at").first()
+            if last_pr:
+                start_date = last_pr.pr_updated_at + timedelta(seconds=1)
+        if end_date is None:
+            end_date = datetime.now()
 
         count = 0
         for pr_data in fetcher.fetch_pull_requests_from_github(
@@ -175,6 +198,7 @@ def sync_pull_requests(repo: GitHubRepository) -> None:
                 json.dumps(pr_data, indent=2, default=str), encoding="utf-8"
             )
             _process_pr_data(repo, pr_data)
+            save_pr_raw_source(owner, repo_name, pr_data)
             json_path.unlink()
             count += 1
 
@@ -186,10 +210,14 @@ def sync_pull_requests(repo: GitHubRepository) -> None:
         )
 
     except (RateLimitException, ConnectionException) as e:
-        logger.error("sync_pull_requests: failed for repo id=%s: %s", repo.pk, e)
+        logger.error(
+            "sync_pull_requests: failed for repo id=%s: %s", repo.pk, e
+        )
         raise
     except Exception as e:
         logger.exception(
-            "sync_pull_requests: unexpected error for repo id=%s: %s", repo.pk, e
+            "sync_pull_requests: unexpected error for repo id=%s: %s",
+            repo.pk,
+            e,
         )
         raise

--- a/github_activity_tracker/sync/raw_source.py
+++ b/github_activity_tracker/sync/raw_source.py
@@ -18,9 +18,7 @@ from github_activity_tracker.workspace import (
 )
 
 
-def _merge_list_by_id(
-    existing_list: list, new_list: list, id_key: str = "id"
-) -> list:
+def _merge_list_by_id(existing_list: list, new_list: list, id_key: str = "id") -> list:
     """Merge two lists of dicts by id; new wins for same id. Preserve order: existing then new (by id)."""
     by_id: dict = {}
     for item in existing_list or []:
@@ -34,11 +32,7 @@ def _merge_list_by_id(
     # Order: existing order for pre-existing ids, then new ids in new order
     order_ids = list(
         dict.fromkeys(
-            [
-                x.get(id_key)
-                for x in (existing_list or [])
-                if x.get(id_key) is not None
-            ]
+            [x.get(id_key) for x in (existing_list or []) if x.get(id_key) is not None]
         )
     )
     for x in new_list or []:

--- a/github_activity_tracker/sync/raw_source.py
+++ b/github_activity_tracker/sync/raw_source.py
@@ -1,5 +1,5 @@
 """
-Tmp: save/update JSON in workspace/raw/github_activity_source. Will be removed in product.
+Tmp: save/update JSON in workspace/raw/github_activity_tracker. Will be removed in product.
 
 - Commits: write once (no merge).
 - Issues/PRs: load existing file if any, merge by id for comments/reviews so updated
@@ -75,7 +75,7 @@ def _write_json(path: Path, data: dict) -> None:
 
 
 def save_commit_raw_source(owner: str, repo: str, commit_data: dict) -> None:
-    """Save commit JSON to raw/github_activity_source (no merge; overwrite)."""
+    """Save commit JSON to raw/github_activity_tracker (no merge; overwrite)."""
     path = get_raw_source_commit_path(owner, repo, commit_data.get("sha", ""))
     if not path.name or path.name == ".json":
         return

--- a/github_activity_tracker/sync/raw_source.py
+++ b/github_activity_tracker/sync/raw_source.py
@@ -1,0 +1,118 @@
+"""
+Tmp: save/update JSON in workspace/raw/github_activity_source. Will be removed in product.
+
+- Commits: write once (no merge).
+- Issues/PRs: load existing file if any, merge by id for comments/reviews so updated
+  comments or reviews are not lost, then write.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from github_activity_tracker.workspace import (
+    get_raw_source_commit_path,
+    get_raw_source_issue_path,
+    get_raw_source_pr_path,
+)
+
+
+def _merge_list_by_id(
+    existing_list: list, new_list: list, id_key: str = "id"
+) -> list:
+    """Merge two lists of dicts by id; new wins for same id. Preserve order: existing then new (by id)."""
+    by_id: dict = {}
+    for item in existing_list or []:
+        kid = item.get(id_key)
+        if kid is not None:
+            by_id[kid] = item
+    for item in new_list or []:
+        kid = item.get(id_key)
+        if kid is not None:
+            by_id[kid] = item
+    # Order: existing order for pre-existing ids, then new ids in new order
+    order_ids = list(
+        dict.fromkeys(
+            [
+                x.get(id_key)
+                for x in (existing_list or [])
+                if x.get(id_key) is not None
+            ]
+        )
+    )
+    for x in new_list or []:
+        kid = x.get(id_key)
+        if kid is not None and kid not in order_ids:
+            order_ids.append(kid)
+    return [by_id[kid] for kid in order_ids if kid in by_id]
+
+
+def _merge_issue_json(existing: dict, new: dict) -> dict:
+    """Merge issue JSON: top-level from new; comments merged by id so we keep all/updated comments."""
+    merged = {**new}
+    merged["comments"] = _merge_list_by_id(
+        existing.get("comments") or [],
+        new.get("comments") or [],
+        "id",
+    )
+    return merged
+
+
+def _merge_pr_json(existing: dict, new: dict) -> dict:
+    """Merge PR JSON: top-level from new; comments and reviews merged by id."""
+    merged = {**new}
+    merged["comments"] = _merge_list_by_id(
+        existing.get("comments") or [],
+        new.get("comments") or [],
+        "id",
+    )
+    merged["reviews"] = _merge_list_by_id(
+        existing.get("reviews") or [],
+        new.get("reviews") or [],
+        "id",
+    )
+    return merged
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+
+
+def save_commit_raw_source(owner: str, repo: str, commit_data: dict) -> None:
+    """Save commit JSON to raw/github_activity_source (no merge; overwrite)."""
+    path = get_raw_source_commit_path(owner, repo, commit_data.get("sha", ""))
+    if not path.name or path.name == ".json":
+        return
+    _write_json(path, commit_data)
+
+
+def save_issue_raw_source(owner: str, repo: str, issue_data: dict) -> None:
+    """Load existing issue JSON if present, merge comments by id, then write."""
+    path = get_raw_source_issue_path(owner, repo, issue_data.get("number", 0))
+    if not path.name or path.name == ".json":
+        return
+    existing: dict = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    merged = _merge_issue_json(existing, issue_data)
+    _write_json(path, merged)
+
+
+def save_pr_raw_source(owner: str, repo: str, pr_data: dict) -> None:
+    """Load existing PR JSON if present, merge comments and reviews by id, then write."""
+    path = get_raw_source_pr_path(owner, repo, pr_data.get("number", 0))
+    if not path.name or path.name == ".json":
+        return
+    existing: dict = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    merged = _merge_pr_json(existing, pr_data)
+    _write_json(path, merged)

--- a/github_activity_tracker/sync/repos.py
+++ b/github_activity_tracker/sync/repos.py
@@ -35,7 +35,7 @@ def sync_repos(repo: GitHubRepository) -> None:
         # Update repo fields (stars, forks, description, dates)
         repo.stars = repo_data.get("stargazers_count", 0)
         repo.forks = repo_data.get("forks_count", 0)
-        repo.description = repo_data.get("description", "")
+        repo.description = repo_data.get("description") or ""
         repo.repo_pushed_at = parse_datetime(repo_data.get("pushed_at"))
         repo.repo_created_at = parse_datetime(repo_data.get("created_at"))
         repo.repo_updated_at = parse_datetime(repo_data.get("updated_at"))

--- a/github_activity_tracker/tests/test_fetcher.py
+++ b/github_activity_tracker/tests/test_fetcher.py
@@ -1,5 +1,6 @@
 """Tests for github_activity_tracker.fetcher."""
 
+import pytest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
@@ -109,6 +110,43 @@ def test_fetch_commits_from_github_includes_since_until_params():
     params = call_args[0][1] or {}
     assert "since" in params
     assert "until" in params
+
+
+def test_fetch_commits_from_github_skips_commit_on_502_503_504():
+    """fetch_commits_from_github skips commit and continues when full-commit fetch returns 502/503/504."""
+    import requests as req
+
+    client = MagicMock()
+    client.rest_request.side_effect = [
+        [
+            {
+                "sha": "abc123",
+                "commit": {"author": {"date": "2024-01-01T00:00:00Z"}},
+            },
+            {
+                "sha": "def456",
+                "commit": {"author": {"date": "2024-01-02T00:00:00Z"}},
+            },
+        ],
+        req.exceptions.HTTPError("Bad Gateway", response=MagicMock(status_code=502)),
+        {"sha": "def456", "commit": {"message": "msg2"}, "stats": {"additions": 2}},
+    ]
+    items = list(fetch_commits_from_github(client, "o", "r"))
+    assert len(items) == 1
+    assert items[0]["sha"] == "def456"
+
+
+def test_fetch_commits_from_github_reraises_non_server_error_http():
+    """fetch_commits_from_github re-raises HTTPError when status is not 502/503/504."""
+    import requests as req
+
+    client = MagicMock()
+    client.rest_request.side_effect = [
+        [{"sha": "abc", "commit": {"author": {"date": "2024-01-01T00:00:00Z"}}}],
+        req.exceptions.HTTPError("Forbidden", response=MagicMock(status_code=403)),
+    ]
+    with pytest.raises(req.exceptions.HTTPError):
+        list(fetch_commits_from_github(client, "o", "r"))
 
 
 # --- fetch_comments_from_github ---

--- a/github_activity_tracker/tests/test_sync.py
+++ b/github_activity_tracker/tests/test_sync.py
@@ -1,0 +1,39 @@
+"""Tests for github_activity_tracker.sync (sync_github and date forwarding)."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from github_activity_tracker.sync import sync_github
+
+
+def test_sync_github_passes_start_date_end_date_to_sync_modules():
+    """sync_github forwards start_date and end_date to sync_commits, sync_issues, sync_pull_requests."""
+    mock_repo = MagicMock()
+    start = datetime(2024, 1, 1)
+    end = datetime(2024, 12, 31)
+    with patch("github_activity_tracker.sync.sync_repos") as m_repos, patch(
+        "github_activity_tracker.sync.sync_commits"
+    ) as m_commits, patch(
+        "github_activity_tracker.sync.sync_issues"
+    ) as m_issues, patch(
+        "github_activity_tracker.sync.sync_pull_requests"
+    ) as m_prs:
+        sync_github(mock_repo, start_date=start, end_date=end)
+    m_repos.assert_called_once_with(mock_repo)
+    m_commits.assert_called_once_with(mock_repo, start_date=start, end_date=end)
+    m_issues.assert_called_once_with(mock_repo, start_date=start, end_date=end)
+    m_prs.assert_called_once_with(mock_repo, start_date=start, end_date=end)
+
+
+def test_sync_github_calls_sync_without_dates_when_none():
+    """sync_github calls sync_commits/issues/pull_requests with start_date and end_date None when not provided."""
+    mock_repo = MagicMock()
+    with patch("github_activity_tracker.sync.sync_repos"), patch(
+        "github_activity_tracker.sync.sync_commits"
+    ) as m_commits, patch("github_activity_tracker.sync.sync_issues") as m_issues, patch(
+        "github_activity_tracker.sync.sync_pull_requests"
+    ) as m_prs:
+        sync_github(mock_repo)
+    m_commits.assert_called_once_with(mock_repo, start_date=None, end_date=None)
+    m_issues.assert_called_once_with(mock_repo, start_date=None, end_date=None)
+    m_prs.assert_called_once_with(mock_repo, start_date=None, end_date=None)

--- a/github_activity_tracker/tests/test_sync.py
+++ b/github_activity_tracker/tests/test_sync.py
@@ -30,7 +30,9 @@ def test_sync_github_calls_sync_without_dates_when_none():
     mock_repo = MagicMock()
     with patch("github_activity_tracker.sync.sync_repos"), patch(
         "github_activity_tracker.sync.sync_commits"
-    ) as m_commits, patch("github_activity_tracker.sync.sync_issues") as m_issues, patch(
+    ) as m_commits, patch(
+        "github_activity_tracker.sync.sync_issues"
+    ) as m_issues, patch(
         "github_activity_tracker.sync.sync_pull_requests"
     ) as m_prs:
         sync_github(mock_repo)

--- a/github_activity_tracker/tests/test_sync_raw_source.py
+++ b/github_activity_tracker/tests/test_sync_raw_source.py
@@ -2,7 +2,6 @@
 
 import json
 import pytest
-from pathlib import Path
 from unittest.mock import patch
 
 from github_activity_tracker.sync.raw_source import (
@@ -15,7 +14,7 @@ from github_activity_tracker.sync.raw_source import (
 @pytest.fixture
 def raw_source_tmp(tmp_path):
     """Patch workspace path helpers so raw source writes go to tmp_path."""
-    root = tmp_path / "raw" / "github_activity_source"
+    root = tmp_path / "raw" / "github_activity_tracker"
     with patch(
         "github_activity_tracker.sync.raw_source.get_raw_source_commit_path",
         side_effect=lambda o, r, sha: root / o / r / "commits" / f"{sha}.json",
@@ -54,7 +53,11 @@ def test_save_issue_raw_source_merges_comments_by_id(raw_source_tmp):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(
-            {"number": 1, "title": "Old", "comments": [{"id": 10, "body": "old comment"}]},
+            {
+                "number": 1,
+                "title": "Old",
+                "comments": [{"id": 10, "body": "old comment"}],
+            },
             indent=2,
         ),
         encoding="utf-8",
@@ -62,7 +65,11 @@ def test_save_issue_raw_source_merges_comments_by_id(raw_source_tmp):
     save_issue_raw_source(
         "owner",
         "repo",
-        {"number": 1, "title": "New", "comments": [{"id": 10, "body": "updated"}, {"id": 11, "body": "new"}]},
+        {
+            "number": 1,
+            "title": "New",
+            "comments": [{"id": 10, "body": "updated"}, {"id": 11, "body": "new"}],
+        },
     )
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["title"] == "New"

--- a/github_activity_tracker/tests/test_sync_raw_source.py
+++ b/github_activity_tracker/tests/test_sync_raw_source.py
@@ -1,0 +1,135 @@
+"""Tests for github_activity_tracker.sync.raw_source."""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from github_activity_tracker.sync.raw_source import (
+    save_commit_raw_source,
+    save_issue_raw_source,
+    save_pr_raw_source,
+)
+
+
+@pytest.fixture
+def raw_source_tmp(tmp_path):
+    """Patch workspace path helpers so raw source writes go to tmp_path."""
+    root = tmp_path / "raw" / "github_activity_source"
+    with patch(
+        "github_activity_tracker.sync.raw_source.get_raw_source_commit_path",
+        side_effect=lambda o, r, sha: root / o / r / "commits" / f"{sha}.json",
+    ), patch(
+        "github_activity_tracker.sync.raw_source.get_raw_source_issue_path",
+        side_effect=lambda o, r, num: root / o / r / "issues" / f"{num}.json",
+    ), patch(
+        "github_activity_tracker.sync.raw_source.get_raw_source_pr_path",
+        side_effect=lambda o, r, num: root / o / r / "prs" / f"{num}.json",
+    ):
+        yield root
+
+
+def test_save_commit_raw_source_writes_file(raw_source_tmp):
+    """save_commit_raw_source writes commit JSON to commits/<sha>.json."""
+    save_commit_raw_source(
+        "owner", "repo", {"sha": "abc123", "commit": {"message": "fix"}}
+    )
+    path = raw_source_tmp / "owner" / "repo" / "commits" / "abc123.json"
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["sha"] == "abc123"
+    assert data["commit"]["message"] == "fix"
+
+
+def test_save_commit_raw_source_skips_empty_sha(raw_source_tmp):
+    """save_commit_raw_source does not write when sha is missing or empty."""
+    save_commit_raw_source("owner", "repo", {})
+    commits_dir = raw_source_tmp / "owner" / "repo" / "commits"
+    assert not commits_dir.exists() or list(commits_dir.iterdir()) == []
+
+
+def test_save_issue_raw_source_merges_comments_by_id(raw_source_tmp):
+    """save_issue_raw_source merges existing and new comments by id (new wins)."""
+    path = raw_source_tmp / "owner" / "repo" / "issues" / "1.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"number": 1, "title": "Old", "comments": [{"id": 10, "body": "old comment"}]},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    save_issue_raw_source(
+        "owner",
+        "repo",
+        {"number": 1, "title": "New", "comments": [{"id": 10, "body": "updated"}, {"id": 11, "body": "new"}]},
+    )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["title"] == "New"
+    assert len(data["comments"]) == 2
+    by_id = {c["id"]: c["body"] for c in data["comments"]}
+    assert by_id[10] == "updated"
+    assert by_id[11] == "new"
+
+
+def test_save_issue_raw_source_writes_new_file(raw_source_tmp):
+    """save_issue_raw_source writes new issue JSON when file does not exist."""
+    save_issue_raw_source(
+        "owner", "repo", {"number": 2, "title": "Issue 2", "comments": []}
+    )
+    path = raw_source_tmp / "owner" / "repo" / "issues" / "2.json"
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["number"] == 2
+    assert data["comments"] == []
+
+
+def test_save_pr_raw_source_merges_comments_and_reviews_by_id(raw_source_tmp):
+    """save_pr_raw_source merges comments and reviews by id (new wins)."""
+    path = raw_source_tmp / "owner" / "repo" / "prs" / "1.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "number": 1,
+                "title": "Old",
+                "comments": [{"id": 20, "body": "old"}],
+                "reviews": [{"id": 30, "state": "CHANGES_REQUESTED"}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    save_pr_raw_source(
+        "owner",
+        "repo",
+        {
+            "number": 1,
+            "title": "New",
+            "comments": [{"id": 20, "body": "updated"}],
+            "reviews": [{"id": 30, "state": "APPROVED"}, {"id": 31, "body": "LGTM"}],
+        },
+    )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["title"] == "New"
+    assert len(data["comments"]) == 1
+    assert data["comments"][0]["body"] == "updated"
+    assert len(data["reviews"]) == 2
+    by_id = {r["id"]: r.get("state") or r.get("body") for r in data["reviews"]}
+    assert by_id[30] == "APPROVED"
+    assert by_id[31] == "LGTM"
+
+
+def test_save_pr_raw_source_writes_new_file(raw_source_tmp):
+    """save_pr_raw_source writes new PR JSON when file does not exist."""
+    save_pr_raw_source(
+        "owner",
+        "repo",
+        {"number": 3, "title": "PR 3", "comments": [], "reviews": []},
+    )
+    path = raw_source_tmp / "owner" / "repo" / "prs" / "3.json"
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["number"] == 3
+    assert data["comments"] == []
+    assert data["reviews"] == []

--- a/github_activity_tracker/tests/test_sync_repos.py
+++ b/github_activity_tracker/tests/test_sync_repos.py
@@ -85,3 +85,24 @@ def test_sync_repos_raises_on_rate_limit_exception(github_repository):
     ):
         with pytest.raises(RateLimitException, match="rate limited"):
             sync_repos(github_repository)
+
+
+@pytest.mark.django_db
+def test_sync_repos_sets_description_empty_when_api_returns_none(github_repository):
+    """sync_repos sets description to '' when repo_data description is None."""
+    mock_client = MagicMock()
+    mock_client.get_repository_info.return_value = {
+        "stargazers_count": 0,
+        "forks_count": 0,
+        "description": None,
+        "pushed_at": None,
+        "created_at": None,
+        "updated_at": None,
+    }
+    with patch(
+        "github_activity_tracker.sync.repos.get_github_client",
+        return_value=mock_client,
+    ):
+        sync_repos(github_repository)
+    github_repository.refresh_from_db()
+    assert github_repository.description == ""

--- a/github_activity_tracker/tests/test_workspace.py
+++ b/github_activity_tracker/tests/test_workspace.py
@@ -320,30 +320,30 @@ def test_iter_existing_pr_jsons_ignores_non_json(mock_workspace_path):
     assert paths[0].name == "4.json"
 
 
-# --- Raw source (workspace/raw/github_activity_source) ---
+# --- Raw source (workspace/raw/github_activity_tracker) ---
 
 
 @pytest.fixture
 def mock_raw_workspace_path(tmp_path):
-    """Patch get_workspace_path so raw source root is tmp_path/raw/github_activity_source."""
+    """Patch get_workspace_path so raw source root is tmp_path/raw/github_activity_tracker."""
     with patch("github_activity_tracker.workspace.get_workspace_path") as m:
         m.side_effect = lambda slug: tmp_path / slug
         yield tmp_path / "raw"
 
 
 def test_get_raw_source_root_returns_path_and_creates_dir(mock_raw_workspace_path):
-    """get_raw_source_root returns .../raw/github_activity_source/ and creates dirs."""
+    """get_raw_source_root returns .../raw/github_activity_tracker/ and creates dirs."""
     root = get_raw_source_root()
-    assert root == mock_raw_workspace_path / "github_activity_source"
+    assert root == mock_raw_workspace_path / "github_activity_tracker"
     assert root.is_dir()
 
 
 def test_get_raw_source_repo_dir_returns_owner_repo_subdir(mock_raw_workspace_path):
-    """get_raw_source_repo_dir returns .../github_activity_source/<owner>/<repo>/."""
+    """get_raw_source_repo_dir returns .../github_activity_tracker/<owner>/<repo>/."""
     path = get_raw_source_repo_dir("boostorg", "boost")
     assert (
         path
-        == mock_raw_workspace_path / "github_activity_source" / "boostorg" / "boost"
+        == mock_raw_workspace_path / "github_activity_tracker" / "boostorg" / "boost"
     )
     assert path.is_dir()
 
@@ -353,7 +353,7 @@ def test_get_raw_source_commits_dir_returns_commits_subdir(mock_raw_workspace_pa
     path = get_raw_source_commits_dir("o", "r")
     assert (
         path
-        == mock_raw_workspace_path / "github_activity_source" / "o" / "r" / "commits"
+        == mock_raw_workspace_path / "github_activity_tracker" / "o" / "r" / "commits"
     )
     assert path.is_dir()
 
@@ -363,7 +363,7 @@ def test_get_raw_source_issues_dir_returns_issues_subdir(mock_raw_workspace_path
     path = get_raw_source_issues_dir("o", "r")
     assert (
         path
-        == mock_raw_workspace_path / "github_activity_source" / "o" / "r" / "issues"
+        == mock_raw_workspace_path / "github_activity_tracker" / "o" / "r" / "issues"
     )
     assert path.is_dir()
 
@@ -372,7 +372,7 @@ def test_get_raw_source_prs_dir_returns_prs_subdir(mock_raw_workspace_path):
     """get_raw_source_prs_dir returns .../<owner>/<repo>/prs/."""
     path = get_raw_source_prs_dir("o", "r")
     assert (
-        path == mock_raw_workspace_path / "github_activity_source" / "o" / "r" / "prs"
+        path == mock_raw_workspace_path / "github_activity_tracker" / "o" / "r" / "prs"
     )
     assert path.is_dir()
 
@@ -383,7 +383,7 @@ def test_get_raw_source_commit_path_returns_sha_json(mock_raw_workspace_path):
     assert (
         path
         == mock_raw_workspace_path
-        / "github_activity_source"
+        / "github_activity_tracker"
         / "owner"
         / "repo"
         / "commits"
@@ -397,7 +397,7 @@ def test_get_raw_source_issue_path_returns_number_json(mock_raw_workspace_path):
     assert (
         path
         == mock_raw_workspace_path
-        / "github_activity_source"
+        / "github_activity_tracker"
         / "owner"
         / "repo"
         / "issues"
@@ -411,7 +411,7 @@ def test_get_raw_source_pr_path_returns_number_json(mock_raw_workspace_path):
     assert (
         path
         == mock_raw_workspace_path
-        / "github_activity_source"
+        / "github_activity_tracker"
         / "owner"
         / "repo"
         / "prs"

--- a/github_activity_tracker/tests/test_workspace.py
+++ b/github_activity_tracker/tests/test_workspace.py
@@ -11,6 +11,14 @@ from github_activity_tracker.workspace import (
     get_issue_json_path,
     get_prs_dir,
     get_pr_json_path,
+    get_raw_source_commits_dir,
+    get_raw_source_commit_path,
+    get_raw_source_issue_path,
+    get_raw_source_issues_dir,
+    get_raw_source_pr_path,
+    get_raw_source_prs_dir,
+    get_raw_source_repo_dir,
+    get_raw_source_root,
     get_repo_dir,
     get_workspace_root,
     iter_existing_commit_jsons,
@@ -310,3 +318,102 @@ def test_iter_existing_pr_jsons_ignores_non_json(mock_workspace_path):
     paths = list(iter_existing_pr_jsons("o", "r"))
     assert len(paths) == 1
     assert paths[0].name == "4.json"
+
+
+# --- Raw source (workspace/raw/github_activity_source) ---
+
+
+@pytest.fixture
+def mock_raw_workspace_path(tmp_path):
+    """Patch get_workspace_path so raw source root is tmp_path/raw/github_activity_source."""
+    with patch("github_activity_tracker.workspace.get_workspace_path") as m:
+        m.side_effect = lambda slug: tmp_path / slug
+        yield tmp_path / "raw"
+
+
+def test_get_raw_source_root_returns_path_and_creates_dir(mock_raw_workspace_path):
+    """get_raw_source_root returns .../raw/github_activity_source/ and creates dirs."""
+    root = get_raw_source_root()
+    assert root == mock_raw_workspace_path / "github_activity_source"
+    assert root.is_dir()
+
+
+def test_get_raw_source_repo_dir_returns_owner_repo_subdir(mock_raw_workspace_path):
+    """get_raw_source_repo_dir returns .../github_activity_source/<owner>/<repo>/."""
+    path = get_raw_source_repo_dir("boostorg", "boost")
+    assert (
+        path
+        == mock_raw_workspace_path / "github_activity_source" / "boostorg" / "boost"
+    )
+    assert path.is_dir()
+
+
+def test_get_raw_source_commits_dir_returns_commits_subdir(mock_raw_workspace_path):
+    """get_raw_source_commits_dir returns .../<owner>/<repo>/commits/."""
+    path = get_raw_source_commits_dir("o", "r")
+    assert (
+        path
+        == mock_raw_workspace_path / "github_activity_source" / "o" / "r" / "commits"
+    )
+    assert path.is_dir()
+
+
+def test_get_raw_source_issues_dir_returns_issues_subdir(mock_raw_workspace_path):
+    """get_raw_source_issues_dir returns .../<owner>/<repo>/issues/."""
+    path = get_raw_source_issues_dir("o", "r")
+    assert (
+        path
+        == mock_raw_workspace_path / "github_activity_source" / "o" / "r" / "issues"
+    )
+    assert path.is_dir()
+
+
+def test_get_raw_source_prs_dir_returns_prs_subdir(mock_raw_workspace_path):
+    """get_raw_source_prs_dir returns .../<owner>/<repo>/prs/."""
+    path = get_raw_source_prs_dir("o", "r")
+    assert (
+        path == mock_raw_workspace_path / "github_activity_source" / "o" / "r" / "prs"
+    )
+    assert path.is_dir()
+
+
+def test_get_raw_source_commit_path_returns_sha_json(mock_raw_workspace_path):
+    """get_raw_source_commit_path returns .../commits/<sha>.json."""
+    path = get_raw_source_commit_path("owner", "repo", "abc123def")
+    assert (
+        path
+        == mock_raw_workspace_path
+        / "github_activity_source"
+        / "owner"
+        / "repo"
+        / "commits"
+        / "abc123def.json"
+    )
+
+
+def test_get_raw_source_issue_path_returns_number_json(mock_raw_workspace_path):
+    """get_raw_source_issue_path returns .../issues/<number>.json."""
+    path = get_raw_source_issue_path("owner", "repo", 42)
+    assert (
+        path
+        == mock_raw_workspace_path
+        / "github_activity_source"
+        / "owner"
+        / "repo"
+        / "issues"
+        / "42.json"
+    )
+
+
+def test_get_raw_source_pr_path_returns_number_json(mock_raw_workspace_path):
+    """get_raw_source_pr_path returns .../prs/<number>.json."""
+    path = get_raw_source_pr_path("owner", "repo", 7)
+    assert (
+        path
+        == mock_raw_workspace_path
+        / "github_activity_source"
+        / "owner"
+        / "repo"
+        / "prs"
+        / "7.json"
+    )

--- a/github_activity_tracker/workspace.py
+++ b/github_activity_tracker/workspace.py
@@ -89,18 +89,18 @@ def iter_existing_pr_jsons(owner: str, repo: str):
         yield path
 
 
-# --- Raw source (tmp: workspace/raw/github_activity_source); will be removed in product ---
+# --- Raw source (tmp: workspace/raw/github_activity_tracker); will be removed in product ---
 
 
 def get_raw_source_root() -> Path:
-    """Return workspace/raw/github_activity_source/; creates dirs if missing."""
-    path = get_workspace_path("raw") / "github_activity_source"
+    """Return workspace/raw/github_activity_tracker/; creates dirs if missing."""
+    path = get_workspace_path("raw") / "github_activity_tracker"
     path.mkdir(parents=True, exist_ok=True)
     return path
 
 
 def get_raw_source_repo_dir(owner: str, repo: str) -> Path:
-    """Return .../raw/github_activity_source/<owner>/<repo>/; creates if missing."""
+    """Return .../raw/github_activity_tracker/<owner>/<repo>/; creates if missing."""
     path = get_raw_source_root() / owner / repo
     path.mkdir(parents=True, exist_ok=True)
     return path

--- a/github_activity_tracker/workspace.py
+++ b/github_activity_tracker/workspace.py
@@ -132,9 +132,7 @@ def get_raw_source_commit_path(owner: str, repo: str, commit_sha: str) -> Path:
     return get_raw_source_commits_dir(owner, repo) / f"{commit_sha}.json"
 
 
-def get_raw_source_issue_path(
-    owner: str, repo: str, issue_number: int
-) -> Path:
+def get_raw_source_issue_path(owner: str, repo: str, issue_number: int) -> Path:
     """Path for raw source issues/<number>.json."""
     return get_raw_source_issues_dir(owner, repo) / f"{issue_number}.json"
 

--- a/github_activity_tracker/workspace.py
+++ b/github_activity_tracker/workspace.py
@@ -87,3 +87,58 @@ def iter_existing_pr_jsons(owner: str, repo: str):
         return
     for path in prs_dir.glob("*.json"):
         yield path
+
+
+# --- Raw source (tmp: workspace/raw/github_activity_source); will be removed in product ---
+
+
+def get_raw_source_root() -> Path:
+    """Return workspace/raw/github_activity_source/; creates dirs if missing."""
+    path = get_workspace_path("raw") / "github_activity_source"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_raw_source_repo_dir(owner: str, repo: str) -> Path:
+    """Return .../raw/github_activity_source/<owner>/<repo>/; creates if missing."""
+    path = get_raw_source_root() / owner / repo
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_raw_source_commits_dir(owner: str, repo: str) -> Path:
+    """Return .../<owner>/<repo>/commits/; creates if missing."""
+    path = get_raw_source_repo_dir(owner, repo) / "commits"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_raw_source_issues_dir(owner: str, repo: str) -> Path:
+    """Return .../<owner>/<repo>/issues/; creates if missing."""
+    path = get_raw_source_repo_dir(owner, repo) / "issues"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_raw_source_prs_dir(owner: str, repo: str) -> Path:
+    """Return .../<owner>/<repo>/prs/; creates if missing."""
+    path = get_raw_source_repo_dir(owner, repo) / "prs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_raw_source_commit_path(owner: str, repo: str, commit_sha: str) -> Path:
+    """Path for raw source commits/<sha>.json."""
+    return get_raw_source_commits_dir(owner, repo) / f"{commit_sha}.json"
+
+
+def get_raw_source_issue_path(
+    owner: str, repo: str, issue_number: int
+) -> Path:
+    """Path for raw source issues/<number>.json."""
+    return get_raw_source_issues_dir(owner, repo) / f"{issue_number}.json"
+
+
+def get_raw_source_pr_path(owner: str, repo: str, pr_number: int) -> Path:
+    """Path for raw source prs/<number>.json."""
+    return get_raw_source_prs_dir(owner, repo) / f"{pr_number}.json"

--- a/github_ops/client.py
+++ b/github_ops/client.py
@@ -118,6 +118,22 @@ class GitHubAPIClient:
                             self._handle_rate_limit(wait_time)
                             return self.rest_request(endpoint, params)
 
+                # Retry on server errors (502 Bad Gateway, 503 Unavailable, 504 Gateway Timeout)
+                if response.status_code in (502, 503, 504):
+                    if attempt < self.max_retries - 1:
+                        wait_time = self.retry_delay * (2**attempt)
+                        logger.warning(
+                            "HTTP %s on %s (attempt %s/%s), retrying in %ss...",
+                            response.status_code,
+                            endpoint,
+                            attempt + 1,
+                            self.max_retries,
+                            wait_time,
+                        )
+                        time.sleep(wait_time)
+                        continue
+                    response.raise_for_status()
+
                 response.raise_for_status()
 
                 if "X-RateLimit-Remaining" in response.headers:

--- a/github_ops/tests/test_client.py
+++ b/github_ops/tests/test_client.py
@@ -176,6 +176,37 @@ def test_rest_request_connection_error_after_retries_raises():
         client.rest_request("/repos/foo/bar")
 
 
+def test_rest_request_retries_on_502_then_succeeds():
+    """rest_request retries on 502/503/504 and returns JSON when a later attempt succeeds."""
+    client = GitHubAPIClient("token")
+    client._check_rate_limit = MagicMock()
+    resp_502 = MagicMock(status_code=502, headers={})
+    resp_502.raise_for_status = MagicMock()
+    resp_200 = MagicMock(status_code=200, headers={}, json=lambda: {"id": 1})
+    resp_200.raise_for_status = MagicMock()
+    client.session.get = MagicMock(side_effect=[resp_502, resp_200])
+    out = client.rest_request("/repos/foo/bar")
+    assert out == {"id": 1}
+    assert client.session.get.call_count == 2
+
+
+def test_rest_request_502_after_max_retries_raises():
+    """rest_request raises after max retries when all attempts return 502."""
+    import requests as req
+
+    client = GitHubAPIClient("token")
+    client.max_retries = 2
+    client._check_rate_limit = MagicMock()
+    resp_502 = MagicMock(status_code=502, headers={})
+    resp_502.raise_for_status = MagicMock(
+        side_effect=req.exceptions.HTTPError("Bad Gateway", response=resp_502)
+    )
+    client.session.get = MagicMock(return_value=resp_502)
+    with pytest.raises(req.exceptions.HTTPError):
+        client.rest_request("/repos/foo/bar")
+    assert client.session.get.call_count == 2
+
+
 # --- rest_post ---
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 DJANGO_SETTINGS_MODULE = config.test_settings
 python_files = test_*.py
 addopts = --reuse-db --no-migrations -v
-norecursedirs = .git .venv venv env node_modules staticfiles __pycache__ .test_artifacts docs
+norecursedirs = .git .venv venv env node_modules staticfiles __pycache__ .test_artifacts docs workspace
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning


### PR DESCRIPTION
- Date range and library filter: `run_boost_library_tracker` has `--from-date`, `--to-date`, and `--from-library`.
- Server error handling: The GitHub client retries on 502/503/504 with backoff.
- Raw source JSON (temporary): A new `raw_source` module and paths under `workspace/raw/github_activity_tracker` save commit/issue/PR JSON.
- Tests and pytest: New or updated tests for fetcher, client, workspace, `raw_source`, `sync`, `sync_repos`, and `run_boost_library_tracker`. workspace is in `pytest.ini`’s `norecursedirs` so Boost scripts under `workspace/` are not collected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added --from-date and --to-date options to sync GitHub activity within specific time periods.
  * Added --from-library option to selectively start syncing from a specified repository.
  * Raw GitHub activity data (commits, issues, pull requests) now automatically persists for backup.

* **Improvements**
  * Automatic retry mechanism for transient GitHub API server errors (502, 503, 504).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->