### PR TITLE
Bug fix: Record all file changes for commits with 300+ files - #59

### DIFF
--- a/github_activity_tracker/big_commit.py
+++ b/github_activity_tracker/big_commit.py
@@ -1,0 +1,236 @@
+"""
+Handle commits with 300+ file changes (GitHub API limit).
+
+Flow:
+1. Detect when commit has 300 files (possibly truncated).
+2. Optionally check real count via GitHub Trees API.
+3. If > 300, clone repo and use git to get full file list.
+4. Build commit payload with full files array for sync.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from github_ops import clone_repo, get_commit_file_changes
+from github_activity_tracker.workspace import get_clone_dir, register_clone
+
+if TYPE_CHECKING:
+    from github_ops.client import GitHubAPIClient
+
+logger = logging.getLogger(__name__)
+
+# Per-repo locks to prevent concurrent clone/fetch for same repo
+_repo_locks: dict[tuple[str, str], threading.Lock] = {}
+_repo_locks_lock = threading.Lock()
+
+
+def _get_repo_lock(owner: str, repo: str) -> threading.Lock:
+    """Get or create a lock for a specific repo."""
+    key = (owner, repo)
+    with _repo_locks_lock:
+        if key not in _repo_locks:
+            _repo_locks[key] = threading.Lock()
+        return _repo_locks[key]
+
+
+def is_commit_truncated(commit_data: dict) -> bool:
+    """
+    Check if commit files array is possibly truncated (exactly 300 files).
+    
+    Returns True if commit has exactly 300 files (GitHub API limit).
+    """
+    files = commit_data.get("files") or []
+    return len(files) == 300
+
+
+def get_changed_file_count_via_trees(
+    client: GitHubAPIClient,
+    owner: str,
+    repo: str,
+    commit_data: dict,
+) -> Optional[int]:
+    """
+    Get real changed file count via GitHub Trees API (compare commit tree vs parent tree).
+    
+    Returns count, or None if trees are truncated or error occurs.
+    
+    Note: This is optional; can skip and just use clone path for all 300-file commits.
+    """
+    try:
+        # Get commit tree SHA and parent SHA
+        commit_tree_sha = commit_data.get("commit", {}).get("tree", {}).get("sha")
+        parents = commit_data.get("parents") or []
+        if not parents:
+            logger.debug("Commit has no parent (initial commit), skipping tree check")
+            return None
+        parent_sha = parents[0].get("sha")
+        
+        if not commit_tree_sha or not parent_sha:
+            logger.warning("Missing tree or parent SHA, cannot check via trees API")
+            return None
+        
+        # Get parent commit to get its tree SHA
+        parent_commit = client.rest_request(f"/repos/{owner}/{repo}/commits/{parent_sha}")
+        if not parent_commit:
+            logger.warning("Could not fetch parent commit %s", parent_sha)
+            return None
+        parent_tree_sha = parent_commit.get("commit", {}).get("tree", {}).get("sha")
+        
+        if not parent_tree_sha:
+            logger.warning("Could not get parent tree SHA")
+            return None
+        
+        # Fetch both trees (recursive)
+        commit_tree = client.rest_request(
+            f"/repos/{owner}/{repo}/git/trees/{commit_tree_sha}?recursive=1"
+        )
+        parent_tree = client.rest_request(
+            f"/repos/{owner}/{repo}/git/trees/{parent_tree_sha}?recursive=1"
+        )
+        
+        if not commit_tree or not parent_tree:
+            logger.warning("Could not fetch trees")
+            return None
+        
+        # Check if truncated
+        if commit_tree.get("truncated") or parent_tree.get("truncated"):
+            logger.info("Trees are truncated, cannot get accurate count via API")
+            return None
+        
+        # Get blob paths (type == "blob" means file)
+        commit_blobs = {
+            item["path"]: item["sha"]
+            for item in commit_tree.get("tree", [])
+            if item.get("type") == "blob"
+        }
+        parent_blobs = {
+            item["path"]: item["sha"]
+            for item in parent_tree.get("tree", [])
+            if item.get("type") == "blob"
+        }
+        
+        # Count changed files (added, removed, or modified)
+        added = set(commit_blobs.keys()) - set(parent_blobs.keys())
+        removed = set(parent_blobs.keys()) - set(commit_blobs.keys())
+        modified = {
+            path
+            for path in commit_blobs
+            if path in parent_blobs and commit_blobs[path] != parent_blobs[path]
+        }
+        
+        total_changed = len(added) + len(removed) + len(modified)
+        logger.info(
+            "Trees API: %d added, %d removed, %d modified = %d total changed",
+            len(added),
+            len(removed),
+            len(modified),
+            total_changed,
+        )
+        return total_changed
+    
+    except Exception as e:
+        logger.warning("Failed to get changed file count via trees: %s", e)
+        return None
+
+
+def ensure_repo_cloned(owner: str, repo: str) -> Path:
+    """
+    Ensure repo is cloned in workspace; clone or fetch as needed.
+    
+    Returns path to cloned repo.
+    Registers clone path for cleanup when run finishes.
+    Thread-safe (uses per-repo lock).
+    """
+    clone_path = get_clone_dir(owner, repo)
+    lock = _get_repo_lock(owner, repo)
+    
+    with lock:
+        if clone_path.exists() and (clone_path / ".git").is_dir():
+            # Already cloned; fetch updates
+            logger.info("Repo %s/%s already cloned at %s, fetching updates", owner, repo, clone_path)
+            try:
+                subprocess.run(
+                    ["git", "-C", str(clone_path), "fetch", "--all"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=300,
+                )
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                logger.warning("Failed to fetch updates for %s/%s: %s", owner, repo, e)
+                # Continue with existing clone
+        else:
+            # Clone repo (remove existing dir if present, so git clone does not fail with exit 128)
+            if clone_path.exists():
+                logger.warning(
+                    "Removing existing non-git directory %s before clone", clone_path
+                )
+                shutil.rmtree(clone_path)
+            logger.info("Cloning %s/%s to %s", owner, repo, clone_path)
+            clone_repo(f"{owner}/{repo}", clone_path)
+        
+        # Register for cleanup
+        register_clone(clone_path)
+    
+    return clone_path
+
+
+# Git's empty tree SHA (same in every repo). Used to diff initial commits.
+# https://github.com/git/git/blob/master/cache.h
+_GIT_EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+
+def get_full_commit_files(
+    owner: str,
+    repo: str,
+    commit_data: dict,
+) -> list[dict]:
+    """
+    Get full list of changed files for a commit via git (for commits with 300+ files).
+    
+    1. Ensures repo is cloned.
+    2. Calls github_ops.get_commit_file_changes to get full file list.
+    3. For initial commits (no parent), diffs against git's empty tree so we still get full file list + patches.
+    
+    Returns list of file dicts matching GitHub API shape.
+    Raises exception if clone or git operations fail.
+    """
+    commit_sha = commit_data.get("sha")
+    parents = commit_data.get("parents") or []
+    
+    # For initial commit, diff against empty tree to get all files as "added" with full patches
+    is_initial_commit = not parents
+    parent_sha = parents[0].get("sha") if parents else _GIT_EMPTY_TREE_SHA
+    if is_initial_commit:
+        logger.info(
+            "Commit %s is initial commit, diffing against empty tree",
+            commit_sha[:7],
+        )
+
+    # Ensure clone
+    clone_path = ensure_repo_cloned(owner, repo)
+
+    # Get full file list via github_ops
+    logger.info("Getting full file list for commit %s via git", commit_sha[:7])
+    try:
+        files = get_commit_file_changes(clone_path, parent_sha, commit_sha)
+    except Exception as e:
+        if is_initial_commit:
+            # Fallback: e.g. empty tree not in shallow clone
+            logger.warning(
+                "Initial commit %s: git diff failed (%s), using API files",
+                commit_sha[:7],
+                e,
+            )
+            files = commit_data.get("files") or []
+        else:
+            raise
+    return files

--- a/github_activity_tracker/big_commit.py
+++ b/github_activity_tracker/big_commit.py
@@ -209,7 +209,8 @@ _GIT_EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 def get_full_commit_files(
     owner: str,
     repo: str,
-    commit_data: dict,
+    commit_sha: str,
+    parent_shas: list[str] | None = None,
 ) -> list[dict]:
     """
     Get full list of changed files for a commit via git (for commits with 300+ files).
@@ -221,12 +222,21 @@ def get_full_commit_files(
     Returns list of file dicts matching GitHub API shape.
     Raises exception if clone or git operations fail.
     """
-    commit_sha = commit_data.get("sha")
-    parents = commit_data.get("parents") or []
+    if parent_shas is None:
+        # Resolve parents using git log if not provided
+        clone_path = ensure_repo_cloned(owner, repo)
+        import subprocess
+        result = subprocess.run(
+            ["git", "-C", str(clone_path), "log", "--pretty=%P", "-n", "1", commit_sha],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        parent_shas = result.stdout.strip().split()
 
     # For initial commit, diff against empty tree to get all files as "added" with full patches
-    is_initial_commit = not parents
-    parent_sha = parents[0].get("sha") if parents else _GIT_EMPTY_TREE_SHA
+    is_initial_commit = len(parent_shas) == 0
+    parent_sha = parent_shas[0] if parent_shas else _GIT_EMPTY_TREE_SHA
     if is_initial_commit:
         logger.debug(
             "Commit %s is initial commit, diffing against empty tree",
@@ -241,34 +251,13 @@ def get_full_commit_files(
     try:
         files = get_commit_file_changes(clone_path, parent_sha, commit_sha)
     except Exception as e:
-        if is_initial_commit:
-            api_files = commit_data.get("files") or []
-            if len(api_files) == 300:
-                # API result may be truncated; do not silently violate full-file-list contract
-                logger.error(
-                    "Initial commit %s: git diff failed (%s); API files count is 300 (truncated?), re-raising",
-                    commit_sha[:7],
-                    e,
-                )
-                raise RuntimeError(
-                    "Initial commit %s: could not get full file list (git diff failed: %s); "
-                    "API returned 300 files (possibly truncated)" % (commit_sha[:7], e)
-                ) from e
-            files = api_files
-            logger.error(
-                "Initial commit %s: git diff failed (%s), using API files (%d)",
-                commit_sha[:7],
-                e,
-                len(files),
-            )
-        else:
-            logger.error(
-                "Commit %s: git diff failed (%s), re-raising",
-                commit_sha[:7],
-                e,
-            )
-            raise RuntimeError(
-                "Commit %s: could not get full file list via git (git diff failed: %s)"
-                % (commit_sha[:7], e)
-            ) from e
+        logger.error(
+            "Commit %s: git diff failed (%s), re-raising",
+            commit_sha[:7],
+            e,
+        )
+        raise RuntimeError(
+            "Commit %s: could not get full file list via git (git diff failed: %s)"
+            % (commit_sha[:7], e)
+        ) from e
     return files

--- a/github_activity_tracker/big_commit.py
+++ b/github_activity_tracker/big_commit.py
@@ -3,9 +3,8 @@ Handle commits with 300+ file changes (GitHub API limit).
 
 Flow:
 1. Detect when commit has 300 files (possibly truncated).
-2. Optionally check real count via GitHub Trees API.
-3. If > 300, clone repo and use git to get full file list.
-4. Build commit payload with full files array for sync.
+2. Clone repo and use git to get full file list.
+3. Build commit payload with full files array for sync.
 """
 
 from __future__ import annotations
@@ -14,7 +13,6 @@ import logging
 import subprocess
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
 
 from github_ops import clone_repo, get_commit_file_changes
 from github_activity_tracker.workspace import (
@@ -22,9 +20,6 @@ from github_activity_tracker.workspace import (
     register_clone,
     remove_clone_dir,
 )
-
-if TYPE_CHECKING:
-    from github_ops.client import GitHubAPIClient
 
 logger = logging.getLogger(__name__)
 
@@ -50,98 +45,6 @@ def is_commit_truncated(commit_data: dict) -> bool:
     """
     files = commit_data.get("files") or []
     return len(files) == 300
-
-
-def get_changed_file_count_via_trees(
-    client: GitHubAPIClient,
-    owner: str,
-    repo: str,
-    commit_data: dict,
-) -> Optional[int]:
-    """
-    Get real changed file count via GitHub Trees API (compare commit tree vs parent tree).
-
-    Returns count, or None if trees are truncated or error occurs.
-
-    Note: This is optional; can skip and just use clone path for all 300-file commits.
-    """
-    try:
-        # Get commit tree SHA and parent SHA
-        commit_tree_sha = commit_data.get("commit", {}).get("tree", {}).get("sha")
-        parents = commit_data.get("parents") or []
-        if not parents:
-            logger.debug("Commit has no parent (initial commit), skipping tree check")
-            return None
-        parent_sha = parents[0].get("sha")
-
-        if not commit_tree_sha or not parent_sha:
-            logger.warning("Missing tree or parent SHA, cannot check via trees API")
-            return None
-
-        # Get parent commit to get its tree SHA
-        parent_commit = client.rest_request(
-            f"/repos/{owner}/{repo}/commits/{parent_sha}"
-        )
-        if not parent_commit:
-            logger.warning("Could not fetch parent commit %s", parent_sha)
-            return None
-        parent_tree_sha = parent_commit.get("commit", {}).get("tree", {}).get("sha")
-
-        if not parent_tree_sha:
-            logger.warning("Could not get parent tree SHA")
-            return None
-
-        # Fetch both trees (recursive)
-        commit_tree = client.rest_request(
-            f"/repos/{owner}/{repo}/git/trees/{commit_tree_sha}?recursive=1"
-        )
-        parent_tree = client.rest_request(
-            f"/repos/{owner}/{repo}/git/trees/{parent_tree_sha}?recursive=1"
-        )
-
-        if not commit_tree or not parent_tree:
-            logger.warning("Could not fetch trees")
-            return None
-
-        # Check if truncated
-        if commit_tree.get("truncated") or parent_tree.get("truncated"):
-            logger.info("Trees are truncated, cannot get accurate count via API")
-            return None
-
-        # Get blob paths (type == "blob" means file)
-        commit_blobs = {
-            item["path"]: item["sha"]
-            for item in commit_tree.get("tree", [])
-            if item.get("type") == "blob"
-        }
-        parent_blobs = {
-            item["path"]: item["sha"]
-            for item in parent_tree.get("tree", [])
-            if item.get("type") == "blob"
-        }
-
-        # Count changed files (added, removed, or modified)
-        added = set(commit_blobs.keys()) - set(parent_blobs.keys())
-        removed = set(parent_blobs.keys()) - set(commit_blobs.keys())
-        modified = {
-            path
-            for path in commit_blobs
-            if path in parent_blobs and commit_blobs[path] != parent_blobs[path]
-        }
-
-        total_changed = len(added) + len(removed) + len(modified)
-        logger.info(
-            "Trees API: %d added, %d removed, %d modified = %d total changed",
-            len(added),
-            len(removed),
-            len(modified),
-            total_changed,
-        )
-        return total_changed
-
-    except Exception as e:
-        logger.warning("Failed to get changed file count via trees: %s", e)
-        return None
 
 
 def ensure_repo_cloned(owner: str, repo: str) -> Path:

--- a/github_activity_tracker/big_commit.py
+++ b/github_activity_tracker/big_commit.py
@@ -11,14 +11,17 @@ Flow:
 from __future__ import annotations
 
 import logging
-import shutil
 import subprocess
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from github_ops import clone_repo, get_commit_file_changes
-from github_activity_tracker.workspace import get_clone_dir, register_clone
+from github_activity_tracker.workspace import (
+    get_clone_dir,
+    register_clone,
+    remove_clone_dir,
+)
 
 if TYPE_CHECKING:
     from github_ops.client import GitHubAPIClient
@@ -171,16 +174,24 @@ def ensure_repo_cloned(owner: str, repo: str) -> Path:
                     errors="replace",
                     timeout=300,
                 )
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            except (
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+            ) as e:
                 logger.warning("Failed to fetch updates for %s/%s: %s", owner, repo, e)
                 # Continue with existing clone
         else:
             # Clone repo (remove existing dir if present, so git clone does not fail with exit 128)
             if clone_path.exists():
                 logger.warning(
-                    "Removing existing non-git directory %s before clone", clone_path
+                    "Removing existing non-git directory %s before clone",
+                    clone_path,
                 )
-                shutil.rmtree(clone_path)
+                if not remove_clone_dir(clone_path):
+                    raise OSError(
+                        "Could not remove existing directory %s (e.g. file in use)"
+                        % clone_path
+                    )
             logger.info("Cloning %s/%s to %s", owner, repo, clone_path)
             clone_repo(f"{owner}/{repo}", clone_path)
 
@@ -217,7 +228,7 @@ def get_full_commit_files(
     is_initial_commit = not parents
     parent_sha = parents[0].get("sha") if parents else _GIT_EMPTY_TREE_SHA
     if is_initial_commit:
-        logger.info(
+        logger.debug(
             "Commit %s is initial commit, diffing against empty tree",
             commit_sha[:7],
         )
@@ -231,13 +242,33 @@ def get_full_commit_files(
         files = get_commit_file_changes(clone_path, parent_sha, commit_sha)
     except Exception as e:
         if is_initial_commit:
-            # Fallback: e.g. empty tree not in shallow clone
-            logger.warning(
-                "Initial commit %s: git diff failed (%s), using API files",
+            api_files = commit_data.get("files") or []
+            if len(api_files) == 300:
+                # API result may be truncated; do not silently violate full-file-list contract
+                logger.error(
+                    "Initial commit %s: git diff failed (%s); API files count is 300 (truncated?), re-raising",
+                    commit_sha[:7],
+                    e,
+                )
+                raise RuntimeError(
+                    "Initial commit %s: could not get full file list (git diff failed: %s); "
+                    "API returned 300 files (possibly truncated)" % (commit_sha[:7], e)
+                ) from e
+            files = api_files
+            logger.error(
+                "Initial commit %s: git diff failed (%s), using API files (%d)",
+                commit_sha[:7],
+                e,
+                len(files),
+            )
+        else:
+            logger.error(
+                "Commit %s: git diff failed (%s), re-raising",
                 commit_sha[:7],
                 e,
             )
-            files = commit_data.get("files") or []
-        else:
-            raise
+            raise RuntimeError(
+                "Commit %s: could not get full file list via git (git diff failed: %s)"
+                % (commit_sha[:7], e)
+            ) from e
     return files

--- a/github_activity_tracker/big_commit.py
+++ b/github_activity_tracker/big_commit.py
@@ -42,7 +42,7 @@ def _get_repo_lock(owner: str, repo: str) -> threading.Lock:
 def is_commit_truncated(commit_data: dict) -> bool:
     """
     Check if commit files array is possibly truncated (exactly 300 files).
-    
+
     Returns True if commit has exactly 300 files (GitHub API limit).
     """
     files = commit_data.get("files") or []
@@ -57,9 +57,9 @@ def get_changed_file_count_via_trees(
 ) -> Optional[int]:
     """
     Get real changed file count via GitHub Trees API (compare commit tree vs parent tree).
-    
+
     Returns count, or None if trees are truncated or error occurs.
-    
+
     Note: This is optional; can skip and just use clone path for all 300-file commits.
     """
     try:
@@ -70,22 +70,24 @@ def get_changed_file_count_via_trees(
             logger.debug("Commit has no parent (initial commit), skipping tree check")
             return None
         parent_sha = parents[0].get("sha")
-        
+
         if not commit_tree_sha or not parent_sha:
             logger.warning("Missing tree or parent SHA, cannot check via trees API")
             return None
-        
+
         # Get parent commit to get its tree SHA
-        parent_commit = client.rest_request(f"/repos/{owner}/{repo}/commits/{parent_sha}")
+        parent_commit = client.rest_request(
+            f"/repos/{owner}/{repo}/commits/{parent_sha}"
+        )
         if not parent_commit:
             logger.warning("Could not fetch parent commit %s", parent_sha)
             return None
         parent_tree_sha = parent_commit.get("commit", {}).get("tree", {}).get("sha")
-        
+
         if not parent_tree_sha:
             logger.warning("Could not get parent tree SHA")
             return None
-        
+
         # Fetch both trees (recursive)
         commit_tree = client.rest_request(
             f"/repos/{owner}/{repo}/git/trees/{commit_tree_sha}?recursive=1"
@@ -93,16 +95,16 @@ def get_changed_file_count_via_trees(
         parent_tree = client.rest_request(
             f"/repos/{owner}/{repo}/git/trees/{parent_tree_sha}?recursive=1"
         )
-        
+
         if not commit_tree or not parent_tree:
             logger.warning("Could not fetch trees")
             return None
-        
+
         # Check if truncated
         if commit_tree.get("truncated") or parent_tree.get("truncated"):
             logger.info("Trees are truncated, cannot get accurate count via API")
             return None
-        
+
         # Get blob paths (type == "blob" means file)
         commit_blobs = {
             item["path"]: item["sha"]
@@ -114,7 +116,7 @@ def get_changed_file_count_via_trees(
             for item in parent_tree.get("tree", [])
             if item.get("type") == "blob"
         }
-        
+
         # Count changed files (added, removed, or modified)
         added = set(commit_blobs.keys()) - set(parent_blobs.keys())
         removed = set(parent_blobs.keys()) - set(commit_blobs.keys())
@@ -123,7 +125,7 @@ def get_changed_file_count_via_trees(
             for path in commit_blobs
             if path in parent_blobs and commit_blobs[path] != parent_blobs[path]
         }
-        
+
         total_changed = len(added) + len(removed) + len(modified)
         logger.info(
             "Trees API: %d added, %d removed, %d modified = %d total changed",
@@ -133,7 +135,7 @@ def get_changed_file_count_via_trees(
             total_changed,
         )
         return total_changed
-    
+
     except Exception as e:
         logger.warning("Failed to get changed file count via trees: %s", e)
         return None
@@ -142,18 +144,23 @@ def get_changed_file_count_via_trees(
 def ensure_repo_cloned(owner: str, repo: str) -> Path:
     """
     Ensure repo is cloned in workspace; clone or fetch as needed.
-    
+
     Returns path to cloned repo.
     Registers clone path for cleanup when run finishes.
     Thread-safe (uses per-repo lock).
     """
     clone_path = get_clone_dir(owner, repo)
     lock = _get_repo_lock(owner, repo)
-    
+
     with lock:
         if clone_path.exists() and (clone_path / ".git").is_dir():
             # Already cloned; fetch updates
-            logger.info("Repo %s/%s already cloned at %s, fetching updates", owner, repo, clone_path)
+            logger.info(
+                "Repo %s/%s already cloned at %s, fetching updates",
+                owner,
+                repo,
+                clone_path,
+            )
             try:
                 subprocess.run(
                     ["git", "-C", str(clone_path), "fetch", "--all"],
@@ -176,10 +183,10 @@ def ensure_repo_cloned(owner: str, repo: str) -> Path:
                 shutil.rmtree(clone_path)
             logger.info("Cloning %s/%s to %s", owner, repo, clone_path)
             clone_repo(f"{owner}/{repo}", clone_path)
-        
+
         # Register for cleanup
         register_clone(clone_path)
-    
+
     return clone_path
 
 
@@ -195,17 +202,17 @@ def get_full_commit_files(
 ) -> list[dict]:
     """
     Get full list of changed files for a commit via git (for commits with 300+ files).
-    
+
     1. Ensures repo is cloned.
     2. Calls github_ops.get_commit_file_changes to get full file list.
     3. For initial commits (no parent), diffs against git's empty tree so we still get full file list + patches.
-    
+
     Returns list of file dicts matching GitHub API shape.
     Raises exception if clone or git operations fail.
     """
     commit_sha = commit_data.get("sha")
     parents = commit_data.get("parents") or []
-    
+
     # For initial commit, diff against empty tree to get all files as "added" with full patches
     is_initial_commit = not parents
     parent_sha = parents[0].get("sha") if parents else _GIT_EMPTY_TREE_SHA

--- a/github_activity_tracker/big_commit.py
+++ b/github_activity_tracker/big_commit.py
@@ -222,15 +222,16 @@ def get_full_commit_files(
     Returns list of file dicts matching GitHub API shape.
     Raises exception if clone or git operations fail.
     """
+    # Ensure clone (once)
+    clone_path = ensure_repo_cloned(owner, repo)
+
     if parent_shas is None:
         # Resolve parents using git log if not provided
-        clone_path = ensure_repo_cloned(owner, repo)
-        import subprocess
         result = subprocess.run(
             ["git", "-C", str(clone_path), "log", "--pretty=%P", "-n", "1", commit_sha],
             capture_output=True,
             text=True,
-            check=True
+            check=True,
         )
         parent_shas = result.stdout.strip().split()
 
@@ -242,9 +243,6 @@ def get_full_commit_files(
             "Commit %s is initial commit, diffing against empty tree",
             commit_sha[:7],
         )
-
-    # Ensure clone
-    clone_path = ensure_repo_cloned(owner, repo)
 
     # Get full file list via github_ops
     logger.info("Getting full file list for commit %s via git", commit_sha[:7])

--- a/github_activity_tracker/management/commands/backfill_300_file_commits.py
+++ b/github_activity_tracker/management/commands/backfill_300_file_commits.py
@@ -64,7 +64,9 @@ class Command(BaseCommand):
         total = len(commits_300) if limit > 0 else commits_300.count()
         if total == 0:
             self.stdout.write(
-                self.style.SUCCESS("No commits with exactly 300 file changes found.")
+                self.style.SUCCESS(
+                    "No commits with exactly 300 file changes found."
+                )
             )
             return
 
@@ -91,7 +93,9 @@ class Command(BaseCommand):
                 repo_name = repo.repo_name
                 sha = commit_obj.commit_hash
 
-                self.stdout.write(f"Backfilling {owner}/{repo_name} {sha[:7]}...")
+                self.stdout.write(
+                    f"Backfilling {owner}/{repo_name} {sha[:7]}..."
+                )
 
                 try:
                     # Fetch commit from API to get parents (required for get_full_commit_files)
@@ -100,20 +104,26 @@ class Command(BaseCommand):
                     )
                     if not commit_data:
                         self.stdout.write(
-                            self.style.ERROR(f"  Could not fetch commit {sha} from API")
+                            self.style.ERROR(
+                                f"  Could not fetch commit {sha} from API"
+                            )
                         )
                         failed += 1
                         continue
 
                     # Get full file list via clone + git diff
+                    parents = commit_data.get("parents") or []
+                    parent_shas = [p.get("sha") for p in parents if p.get("sha")]
                     full_files = big_commit.get_full_commit_files(
-                        owner, repo_name, commit_data
+                        owner, repo_name, commit_sha=sha, parent_shas=parent_shas
                     )
 
                     # Replace file changes in DB: delete existing, re-add with full list
                     with transaction.atomic():
-                        GitCommitFileChange.objects.filter(commit=commit_obj).delete()
-                        _process_commit_files(repo, commit_obj, {"files": full_files})
+                        GitCommitFileChange.objects.filter(
+                            commit=commit_obj
+                        ).delete()
+                        _process_commit_files(repo, commit_obj, full_files)
 
                     new_count = commit_obj.file_changes.count()
                     self.stdout.write(
@@ -135,14 +145,18 @@ class Command(BaseCommand):
                     failed += 1
 
             self.stdout.write(
-                self.style.SUCCESS(f"Done. Updated {updated}, failed {failed}.")
+                self.style.SUCCESS(
+                    f"Done. Updated {updated}, failed {failed}."
+                )
             )
 
         finally:
             # Clean up cloned repos created during run
             clones = get_registered_clones()
             if clones:
-                self.stdout.write(f"Cleaning up {len(clones)} cloned repo(s)...")
+                self.stdout.write(
+                    f"Cleaning up {len(clones)} cloned repo(s)..."
+                )
                 for clone_path in clones:
                     if remove_clone_dir(clone_path):
                         logger.info("Removed clone: %s", clone_path)

--- a/github_activity_tracker/management/commands/backfill_300_file_commits.py
+++ b/github_activity_tracker/management/commands/backfill_300_file_commits.py
@@ -1,0 +1,159 @@
+"""
+Backfill commits that have exactly 300 file changes (API truncation).
+
+Finds commits in the database with 300 file_changes, fetches the full
+file list via git (using get_full_commit_files), and updates the database.
+
+Run: python manage.py backfill_300_file_commits [--dry-run] [--limit N]
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count
+
+from github_activity_tracker import big_commit
+from github_activity_tracker.models import GitCommit, GitCommitFileChange
+from github_activity_tracker.sync.commits import _process_commit_files
+from github_activity_tracker.workspace import (
+    clear_clone_registry,
+    get_registered_clones,
+    remove_clone_dir,
+)
+from github_ops import get_github_client
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Find commits with exactly 300 file changes (truncated by API), "
+        "fetch full file list via git, and update the database."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Only list commits that would be updated; do not change the database.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=0,
+            metavar="N",
+            help="Process at most N commits (0 = no limit).",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        limit = options["limit"]
+
+        # Find commits with exactly 300 file changes
+        commits_300 = (
+            GitCommit.objects.annotate(file_count=Count("file_changes"))
+            .filter(file_count=300)
+            .select_related("repo", "repo__owner_account")
+            .order_by("id")
+        )
+        if limit > 0:
+            commits_300 = commits_300[:limit]
+
+        total = commits_300.count()
+        if total == 0:
+            self.stdout.write(
+                self.style.SUCCESS("No commits with exactly 300 file changes found.")
+            )
+            return
+
+        self.stdout.write(
+            f"Found {total} commit(s) with 300 file changes (possibly truncated)."
+        )
+        if dry_run:
+            for c in commits_300:
+                owner = c.repo.owner_account.username
+                self.stdout.write(
+                    f"  Would backfill: {owner}/{c.repo.repo_name} {c.commit_hash[:7]}"
+                )
+            self.stdout.write(self.style.WARNING("Dry run: no changes made."))
+            return
+
+        client = get_github_client()
+        updated = 0
+        failed = 0
+
+        try:
+            for commit_obj in commits_300:
+                repo = commit_obj.repo
+                owner = repo.owner_account.username
+                repo_name = repo.repo_name
+                sha = commit_obj.commit_hash
+
+                self.stdout.write(f"Backfilling {owner}/{repo_name} {sha[:7]}...")
+
+                try:
+                    # Fetch commit from API to get parents (required for get_full_commit_files)
+                    commit_data = client.rest_request(
+                        f"/repos/{owner}/{repo_name}/commits/{sha}"
+                    )
+                    if not commit_data:
+                        self.stdout.write(
+                            self.style.ERROR(f"  Could not fetch commit {sha} from API")
+                        )
+                        failed += 1
+                        continue
+
+                    # Get full file list via clone + git diff
+                    full_files = big_commit.get_full_commit_files(
+                        owner, repo_name, commit_data
+                    )
+
+                    # Replace file changes in DB: delete existing, re-add with full list
+                    GitCommitFileChange.objects.filter(commit=commit_obj).delete()
+                    _process_commit_files(
+                        repo, commit_obj, {"files": full_files}
+                    )
+
+                    new_count = commit_obj.file_changes.count()
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f"  Updated: 300 -> {new_count} file changes"
+                        )
+                    )
+                    updated += 1
+
+                except Exception as e:
+                    logger.exception(
+                        "Failed to backfill %s/%s %s: %s",
+                        owner,
+                        repo_name,
+                        sha[:7],
+                        e,
+                    )
+                    self.stdout.write(
+                        self.style.ERROR(f"  Failed: {e}")
+                    )
+                    failed += 1
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Done. Updated {updated}, failed {failed}."
+                )
+            )
+
+        finally:
+            # Clean up cloned repos created during run
+            clones = get_registered_clones()
+            if clones:
+                self.stdout.write(f"Cleaning up {len(clones)} cloned repo(s)...")
+                for clone_path in clones:
+                    if remove_clone_dir(clone_path):
+                        logger.info("Removed clone: %s", clone_path)
+                    else:
+                        logger.warning(
+                            "Failed to remove clone %s (file may be in use)",
+                            clone_path,
+                        )
+                clear_clone_registry()

--- a/github_activity_tracker/management/commands/backfill_300_file_commits.py
+++ b/github_activity_tracker/management/commands/backfill_300_file_commits.py
@@ -112,9 +112,7 @@ class Command(BaseCommand):
 
                     # Replace file changes in DB: delete existing, re-add with full list
                     GitCommitFileChange.objects.filter(commit=commit_obj).delete()
-                    _process_commit_files(
-                        repo, commit_obj, {"files": full_files}
-                    )
+                    _process_commit_files(repo, commit_obj, {"files": full_files})
 
                     new_count = commit_obj.file_changes.count()
                     self.stdout.write(
@@ -132,15 +130,11 @@ class Command(BaseCommand):
                         sha[:7],
                         e,
                     )
-                    self.stdout.write(
-                        self.style.ERROR(f"  Failed: {e}")
-                    )
+                    self.stdout.write(self.style.ERROR(f"  Failed: {e}"))
                     failed += 1
 
             self.stdout.write(
-                self.style.SUCCESS(
-                    f"Done. Updated {updated}, failed {failed}."
-                )
+                self.style.SUCCESS(f"Done. Updated {updated}, failed {failed}.")
             )
 
         finally:

--- a/github_activity_tracker/management/commands/backfill_300_file_commits.py
+++ b/github_activity_tracker/management/commands/backfill_300_file_commits.py
@@ -23,7 +23,6 @@ from github_activity_tracker.workspace import (
     get_registered_clones,
     remove_clone_dir,
 )
-from github_ops import get_github_client
 
 logger = logging.getLogger(__name__)
 
@@ -64,9 +63,7 @@ class Command(BaseCommand):
         total = len(commits_300) if limit > 0 else commits_300.count()
         if total == 0:
             self.stdout.write(
-                self.style.SUCCESS(
-                    "No commits with exactly 300 file changes found."
-                )
+                self.style.SUCCESS("No commits with exactly 300 file changes found.")
             )
             return
 
@@ -82,7 +79,6 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("Dry run: no changes made."))
             return
 
-        client = get_github_client()
         updated = 0
         failed = 0
 
@@ -93,36 +89,17 @@ class Command(BaseCommand):
                 repo_name = repo.repo_name
                 sha = commit_obj.commit_hash
 
-                self.stdout.write(
-                    f"Backfilling {owner}/{repo_name} {sha[:7]}..."
-                )
+                self.stdout.write(f"Backfilling {owner}/{repo_name} {sha[:7]}...")
 
                 try:
-                    # Fetch commit from API to get parents (required for get_full_commit_files)
-                    commit_data = client.rest_request(
-                        f"/repos/{owner}/{repo_name}/commits/{sha}"
-                    )
-                    if not commit_data:
-                        self.stdout.write(
-                            self.style.ERROR(
-                                f"  Could not fetch commit {sha} from API"
-                            )
-                        )
-                        failed += 1
-                        continue
-
-                    # Get full file list via clone + git diff
-                    parents = commit_data.get("parents") or []
-                    parent_shas = [p.get("sha") for p in parents if p.get("sha")]
+                    # Get full file list via clone + git diff (parents resolved via git log if needed)
                     full_files = big_commit.get_full_commit_files(
-                        owner, repo_name, commit_sha=sha, parent_shas=parent_shas
+                        owner, repo_name, commit_sha=sha
                     )
 
                     # Replace file changes in DB: delete existing, re-add with full list
                     with transaction.atomic():
-                        GitCommitFileChange.objects.filter(
-                            commit=commit_obj
-                        ).delete()
+                        GitCommitFileChange.objects.filter(commit=commit_obj).delete()
                         _process_commit_files(repo, commit_obj, full_files)
 
                     new_count = commit_obj.file_changes.count()
@@ -145,18 +122,14 @@ class Command(BaseCommand):
                     failed += 1
 
             self.stdout.write(
-                self.style.SUCCESS(
-                    f"Done. Updated {updated}, failed {failed}."
-                )
+                self.style.SUCCESS(f"Done. Updated {updated}, failed {failed}.")
             )
 
         finally:
             # Clean up cloned repos created during run
             clones = get_registered_clones()
             if clones:
-                self.stdout.write(
-                    f"Cleaning up {len(clones)} cloned repo(s)..."
-                )
+                self.stdout.write(f"Cleaning up {len(clones)} cloned repo(s)...")
                 for clone_path in clones:
                     if remove_clone_dir(clone_path):
                         logger.info("Removed clone: %s", clone_path)

--- a/github_activity_tracker/management/commands/backfill_300_file_commits.py
+++ b/github_activity_tracker/management/commands/backfill_300_file_commits.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from django.db.models import Count
 
 from github_activity_tracker import big_commit
@@ -59,9 +60,8 @@ class Command(BaseCommand):
             .order_by("id")
         )
         if limit > 0:
-            commits_300 = commits_300[:limit]
-
-        total = commits_300.count()
+            commits_300 = list(commits_300[:limit])
+        total = len(commits_300) if limit > 0 else commits_300.count()
         if total == 0:
             self.stdout.write(
                 self.style.SUCCESS("No commits with exactly 300 file changes found.")
@@ -111,8 +111,9 @@ class Command(BaseCommand):
                     )
 
                     # Replace file changes in DB: delete existing, re-add with full list
-                    GitCommitFileChange.objects.filter(commit=commit_obj).delete()
-                    _process_commit_files(repo, commit_obj, {"files": full_files})
+                    with transaction.atomic():
+                        GitCommitFileChange.objects.filter(commit=commit_obj).delete()
+                        _process_commit_files(repo, commit_obj, {"files": full_files})
 
                     new_count = commit_obj.file_changes.count()
                     self.stdout.write(

--- a/github_activity_tracker/services.py
+++ b/github_activity_tracker/services.py
@@ -225,6 +225,8 @@ def create_or_update_github_file(
     is_deleted: bool = False,
 ) -> tuple[GitHubFile, bool]:
     """Create or update a GitHubFile by repo + filename. Returns (file, created)."""
+    # PostgreSQL TEXT cannot contain NUL (0x00)
+    filename = (filename or "").replace("\x00", "")
     github_file, created = GitHubFile.objects.get_or_create(
         repo=repo,
         filename=filename,
@@ -245,7 +247,8 @@ def add_commit_file_change(
     patch: str = "",
 ) -> tuple[GitCommitFileChange, bool]:
     """Add or update a file change for a commit. If exists, updates status, additions, deletions, patch. Returns (file_change, created)."""
-    patch_val = patch or ""
+    # PostgreSQL TEXT cannot contain NUL (0x00); strip from patch (e.g. from git diff of binary files)
+    patch_val = (patch or "").replace("\x00", "")
     obj, created = GitCommitFileChange.objects.get_or_create(
         commit=commit,
         github_file=github_file,

--- a/github_activity_tracker/sync/commits.py
+++ b/github_activity_tracker/sync/commits.py
@@ -44,11 +44,13 @@ _VALID_FILE_STATUSES = {c[0] for c in FileChangeStatus.choices}
 
 
 def _process_commit_files(
-    repo: GitHubRepository, commit_obj: GitCommit, commit_data: dict
+    repo: GitHubRepository, commit_obj: GitCommit, files: list[dict]
 ) -> None:
     """Create/update GitHubFile and GitCommitFileChange for each file in the commit."""
-    for file_info in commit_data.get("files") or []:
-        filename = file_info.get("filename") or file_info.get("previous_filename")
+    for file_info in files:
+        filename = file_info.get("filename") or file_info.get(
+            "previous_filename"
+        )
         if not (filename and filename.strip()):
             continue
         filename = filename.strip()
@@ -98,7 +100,9 @@ def _process_commit_data(repo: GitHubRepository, commit_data: dict) -> None:
         )
     else:
         name, email = _commit_author_name_and_email(commit_data)
-        account, _ = get_or_create_unknown_github_account(name=name, email=email)
+        account, _ = get_or_create_unknown_github_account(
+            name=name, email=email
+        )
 
     commit_hash = commit_data.get("sha")
     comment = commit_data.get("commit", {}).get("message", "")
@@ -114,7 +118,11 @@ def _process_commit_data(repo: GitHubRepository, commit_data: dict) -> None:
         comment=comment,
         commit_at=commit_at,
     )
-    _process_commit_files(repo, commit_obj, commit_data)
+    files = commit_data.get("files") or []
+    if files:
+        _process_commit_files(repo, commit_obj, files)
+    else:
+        logger.warning("Commit %s has no files", commit_hash)
     logger.debug("Commit %s: saved to DB", commit_hash)
 
 
@@ -135,7 +143,9 @@ def _process_existing_commit_jsons(repo: GitHubRepository) -> int:
     return count
 
 
-def _process_big_commit_worker(owner: str, repo_name: str, commit_data: dict) -> None:
+def _process_big_commit_worker(
+    owner: str, repo_name: str, commit_data: dict
+) -> None:
     """
     Background worker: get full file list for big commit (300+ files) via git clone.
 
@@ -155,7 +165,11 @@ def _process_big_commit_worker(owner: str, repo_name: str, commit_data: dict) ->
         )
 
         # Get full file list via git
-        full_files = big_commit.get_full_commit_files(owner, repo_name, commit_data)
+        parents = commit_data.get("parents") or []
+        parent_shas = [p.get("sha") for p in parents if p.get("sha")]
+        full_files = big_commit.get_full_commit_files(
+            owner, repo_name, commit_sha=sha, parent_shas=parent_shas
+        )
 
         # Build new commit_data with full files
         full_commit_data = commit_data.copy()
@@ -187,7 +201,9 @@ def _process_big_commit_worker(owner: str, repo_name: str, commit_data: dict) ->
         )
         # Write original commit data (with 300 files) so we don't lose the commit
         try:
-            json_path = get_commit_json_path(owner, repo_name, commit_data.get("sha"))
+            json_path = get_commit_json_path(
+                owner, repo_name, commit_data.get("sha")
+            )
             json_path.parent.mkdir(parents=True, exist_ok=True)
             json_path.write_text(
                 json.dumps(commit_data, indent=2, default=str),
@@ -198,7 +214,9 @@ def _process_big_commit_worker(owner: str, repo_name: str, commit_data: dict) ->
                 commit_data.get("sha")[:7],
             )
         except Exception as write_error:
-            logger.error("Failed to write fallback commit JSON: %s", write_error)
+            logger.error(
+                "Failed to write fallback commit JSON: %s", write_error
+            )
 
 
 def sync_commits(
@@ -219,7 +237,9 @@ def sync_commits(
         start_date: Override start date (default: last commit date + 1s, or None if no commits).
         end_date: Override end date (default: now).
     """
-    logger.info("sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name)
+    logger.info(
+        "sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name
+    )
 
     owner = repo.owner_account.username
     repo_name = repo.repo_name
@@ -243,7 +263,9 @@ def sync_commits(
             end_date = timezone.now()
 
         # Create thread pool for big commits (max 2-4 workers to avoid heavy disk/network load)
-        executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="big_commit")
+        executor = ThreadPoolExecutor(
+            max_workers=2, thread_name_prefix="big_commit"
+        )
         futures = []
 
         count_normal = 0
@@ -288,7 +310,9 @@ def sync_commits(
 
             # Phase 3: wait for all big commit tasks to finish
             if futures:
-                logger.info("Waiting for %d big commit task(s) to finish", len(futures))
+                logger.info(
+                    "Waiting for %d big commit task(s) to finish", len(futures)
+                )
                 executor.shutdown(wait=True)
 
                 # Check for exceptions in tasks
@@ -296,7 +320,9 @@ def sync_commits(
                     try:
                         future.result()  # Will raise if task raised
                     except Exception as e:
-                        logger.error("Big commit task %d raised exception: %s", i, e)
+                        logger.error(
+                            "Big commit task %d raised exception: %s", i, e
+                        )
 
                 # Phase 4: process big commit JSONs (written by workers)
                 logger.info("Processing big commit JSONs written by workers")

--- a/github_activity_tracker/sync/commits.py
+++ b/github_activity_tracker/sync/commits.py
@@ -4,12 +4,14 @@ Sync Git commits with the database.
 Flow:
 1. Process existing JSON files in workspace/<owner>/<repo>/commits/*.json (load → DB → remove file).
 2. Fetch from GitHub, save each as commits/<sha>.json, persist to DB, then remove the file.
+3. For commits with 300+ files (truncated), submit background task to clone repo and get full list via git.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Optional
 
@@ -17,7 +19,7 @@ from cppa_user_tracker.services import (
     get_or_create_github_account,
     get_or_create_unknown_github_account,
 )
-from github_activity_tracker import fetcher, services
+from github_activity_tracker import big_commit, fetcher, services
 from github_activity_tracker.models import FileChangeStatus
 from github_activity_tracker.workspace import (
     get_commit_json_path,
@@ -46,7 +48,9 @@ def _process_commit_files(
 ) -> None:
     """Create/update GitHubFile and GitCommitFileChange for each file in the commit."""
     for file_info in commit_data.get("files") or []:
-        filename = file_info.get("filename") or file_info.get("previous_filename")
+        filename = file_info.get("filename") or file_info.get(
+            "previous_filename"
+        )
         if not (filename and filename.strip()):
             continue
         filename = filename.strip()
@@ -96,7 +100,9 @@ def _process_commit_data(repo: GitHubRepository, commit_data: dict) -> None:
         )
     else:
         name, email = _commit_author_name_and_email(commit_data)
-        account, _ = get_or_create_unknown_github_account(name=name, email=email)
+        account, _ = get_or_create_unknown_github_account(
+            name=name, email=email
+        )
 
     commit_hash = commit_data.get("sha")
     comment = commit_data.get("commit", {}).get("message", "")
@@ -133,25 +139,107 @@ def _process_existing_commit_jsons(repo: GitHubRepository) -> int:
     return count
 
 
+def _process_big_commit_worker(
+    owner: str, repo_name: str, commit_data: dict
+) -> None:
+    """
+    Background worker: get full file list for big commit (300+ files) via git clone.
+
+    1. Clone repo (or fetch if already cloned).
+    2. Get full file list via git.
+    3. Write full commit JSON to workspace for later sync.
+
+    Does NOT call _process_commit_data (to avoid DB access from worker thread).
+    """
+    try:
+        sha = commit_data.get("sha")
+        logger.info(
+            "Processing big commit %s/%s:%s in background",
+            owner,
+            repo_name,
+            sha[:7],
+        )
+
+        # Get full file list via git
+        full_files = big_commit.get_full_commit_files(
+            owner, repo_name, commit_data
+        )
+
+        # Build new commit_data with full files
+        full_commit_data = commit_data.copy()
+        full_commit_data["files"] = full_files
+
+        # Write JSON to workspace (sync will pick it up in second pass)
+        json_path = get_commit_json_path(owner, repo_name, sha)
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(
+            json.dumps(full_commit_data, indent=2, default=str),
+            encoding="utf-8",
+        )
+
+        logger.info(
+            "Big commit %s/%s:%s processed: %d files written to %s",
+            owner,
+            repo_name,
+            sha[:7],
+            len(full_files),
+            json_path,
+        )
+    except Exception as e:
+        logger.exception(
+            "Failed to process big commit %s/%s:%s: %s",
+            owner,
+            repo_name,
+            commit_data.get("sha", "unknown")[:7],
+            e,
+        )
+        # Write original commit data (with 300 files) so we don't lose the commit
+        try:
+            json_path = get_commit_json_path(
+                owner, repo_name, commit_data.get("sha")
+            )
+            json_path.parent.mkdir(parents=True, exist_ok=True)
+            json_path.write_text(
+                json.dumps(commit_data, indent=2, default=str),
+                encoding="utf-8",
+            )
+            logger.warning(
+                "Wrote partial commit data (300 files) for %s after error",
+                commit_data.get("sha")[:7],
+            )
+        except Exception as write_error:
+            logger.error(
+                "Failed to write fallback commit JSON: %s", write_error
+            )
+
+
 def sync_commits(
     repo: GitHubRepository,
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
 ) -> None:
-    """1) Process existing workspace JSONs; 2) Fetch from GitHub, save as JSON, persist to DB, remove file.
+    """Sync commits for a repo.
+
+    1) Process existing workspace JSONs.
+    2) Fetch from GitHub; for normal commits, persist immediately.
+    3) For big commits (300+ files), submit background task to get full list via git.
+    4) Wait for all background tasks.
+    5) Process big commit JSONs (written by workers) in second pass.
 
     Args:
         repo: Repository to sync.
         start_date: Override start date (default: last commit date + 1s, or None if no commits).
         end_date: Override end date (default: now).
     """
-    logger.info("sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name)
+    logger.info(
+        "sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name
+    )
 
     owner = repo.owner_account.username
     repo_name = repo.repo_name
 
     try:
-        # Phase 1: process existing JSON files
+        # Phase 1: process existing JSON files (from previous runs or workers)
         n_existing = _process_existing_commit_jsons(repo)
         if n_existing:
             logger.info(
@@ -159,7 +247,7 @@ def sync_commits(
                 n_existing,
             )
 
-        # Phase 2: fetch from GitHub, write JSON, persist to DB, remove file
+        # Phase 2: fetch from GitHub
         client = get_github_client()
         if start_date is None:
             last_commit = repo.commits.order_by("-commit_at").first()
@@ -168,29 +256,88 @@ def sync_commits(
         if end_date is None:
             end_date = timezone.now()
 
-        count = 0
-        for commit_data in fetcher.fetch_commits_from_github(
-            client, owner, repo_name, start_date, end_date
-        ):
-            sha = commit_data.get("sha")
-            if not sha:
-                continue
-            json_path = get_commit_json_path(owner, repo_name, sha)
-            json_path.parent.mkdir(parents=True, exist_ok=True)
-            json_path.write_text(
-                json.dumps(commit_data, indent=2, default=str),
-                encoding="utf-8",
-            )
-            _process_commit_data(repo, commit_data)
-            save_commit_raw_source(owner, repo_name, commit_data)
-            json_path.unlink()
-            count += 1
+        # Create thread pool for big commits (max 2-4 workers to avoid heavy disk/network load)
+        executor = ThreadPoolExecutor(
+            max_workers=2, thread_name_prefix="big_commit"
+        )
+        futures = []
+
+        count_normal = 0
+        count_big = 0
+
+        try:
+            for commit_data in fetcher.fetch_commits_from_github(
+                client, owner, repo_name, start_date, end_date
+            ):
+                sha = commit_data.get("sha")
+                if not sha:
+                    continue
+
+                # Check if commit is truncated (300 files = possible truncation)
+                is_truncated = big_commit.is_commit_truncated(commit_data)
+
+                if is_truncated:
+                    # Big commit: submit to background worker
+                    logger.info(
+                        "Commit %s has 300 files (possibly truncated), submitting to background",
+                        sha[:7],
+                    )
+                    future = executor.submit(
+                        _process_big_commit_worker,
+                        owner,
+                        repo_name,
+                        commit_data,
+                    )
+                    futures.append(future)
+                    count_big += 1
+                else:
+                    # Normal commit: process immediately
+                    json_path = get_commit_json_path(owner, repo_name, sha)
+                    json_path.parent.mkdir(parents=True, exist_ok=True)
+                    json_path.write_text(
+                        json.dumps(commit_data, indent=2, default=str),
+                        encoding="utf-8",
+                    )
+                    _process_commit_data(repo, commit_data)
+                    json_path.unlink()
+                    count_normal += 1
+
+            # Phase 3: wait for all big commit tasks to finish
+            if futures:
+                logger.info(
+                    "Waiting for %d big commit task(s) to finish", len(futures)
+                )
+                executor.shutdown(wait=True)
+
+                # Check for exceptions in tasks
+                for i, future in enumerate(futures):
+                    try:
+                        future.result()  # Will raise if task raised
+                    except Exception as e:
+                        logger.error(
+                            "Big commit task %d raised exception: %s", i, e
+                        )
+
+                # Phase 4: process big commit JSONs (written by workers)
+                logger.info("Processing big commit JSONs written by workers")
+                n_big_processed = _process_existing_commit_jsons(repo)
+                logger.info(
+                    "Processed %d big commit JSON(s) from workers",
+                    n_big_processed,
+                )
+            else:
+                executor.shutdown(wait=False)
+
+        finally:
+            # Ensure executor is shut down even if exception occurs
+            executor.shutdown(wait=True)
 
         logger.info(
-            "sync_commits: finished for repo id=%s; %s existing + %s fetched",
+            "sync_commits: finished for repo id=%s; %s existing + %s normal + %s big commits",
             repo.pk,
             n_existing,
-            count,
+            count_normal,
+            count_big,
         )
 
     except (RateLimitException, ConnectionException) as e:

--- a/github_activity_tracker/sync/commits.py
+++ b/github_activity_tracker/sync/commits.py
@@ -48,9 +48,7 @@ def _process_commit_files(
 ) -> None:
     """Create/update GitHubFile and GitCommitFileChange for each file in the commit."""
     for file_info in files:
-        filename = file_info.get("filename") or file_info.get(
-            "previous_filename"
-        )
+        filename = file_info.get("filename") or file_info.get("previous_filename")
         if not (filename and filename.strip()):
             continue
         filename = filename.strip()
@@ -100,9 +98,7 @@ def _process_commit_data(repo: GitHubRepository, commit_data: dict) -> None:
         )
     else:
         name, email = _commit_author_name_and_email(commit_data)
-        account, _ = get_or_create_unknown_github_account(
-            name=name, email=email
-        )
+        account, _ = get_or_create_unknown_github_account(name=name, email=email)
 
     commit_hash = commit_data.get("sha")
     comment = commit_data.get("commit", {}).get("message", "")
@@ -143,9 +139,7 @@ def _process_existing_commit_jsons(repo: GitHubRepository) -> int:
     return count
 
 
-def _process_big_commit_worker(
-    owner: str, repo_name: str, commit_data: dict
-) -> None:
+def _process_big_commit_worker(owner: str, repo_name: str, commit_data: dict) -> None:
     """
     Background worker: get full file list for big commit (300+ files) via git clone.
 
@@ -167,9 +161,19 @@ def _process_big_commit_worker(
         # Get full file list via git
         parents = commit_data.get("parents") or []
         parent_shas = [p.get("sha") for p in parents if p.get("sha")]
-        full_files = big_commit.get_full_commit_files(
-            owner, repo_name, commit_sha=sha, parent_shas=parent_shas
-        )
+        try:
+            full_files = big_commit.get_full_commit_files(
+                owner, repo_name, commit_sha=sha, parent_shas=parent_shas
+            )
+        except Exception as e:
+            logger.exception(
+                "Failed to get full file list for big commit %s/%s:%s: %s",
+                owner,
+                repo_name,
+                sha[:7],
+                e,
+            )
+            full_files = commit_data.get("files") or []
 
         # Build new commit_data with full files
         full_commit_data = commit_data.copy()
@@ -201,9 +205,7 @@ def _process_big_commit_worker(
         )
         # Write original commit data (with 300 files) so we don't lose the commit
         try:
-            json_path = get_commit_json_path(
-                owner, repo_name, commit_data.get("sha")
-            )
+            json_path = get_commit_json_path(owner, repo_name, commit_data.get("sha"))
             json_path.parent.mkdir(parents=True, exist_ok=True)
             json_path.write_text(
                 json.dumps(commit_data, indent=2, default=str),
@@ -214,9 +216,7 @@ def _process_big_commit_worker(
                 commit_data.get("sha")[:7],
             )
         except Exception as write_error:
-            logger.error(
-                "Failed to write fallback commit JSON: %s", write_error
-            )
+            logger.error("Failed to write fallback commit JSON: %s", write_error)
 
 
 def sync_commits(
@@ -237,9 +237,7 @@ def sync_commits(
         start_date: Override start date (default: last commit date + 1s, or None if no commits).
         end_date: Override end date (default: now).
     """
-    logger.info(
-        "sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name
-    )
+    logger.info("sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name)
 
     owner = repo.owner_account.username
     repo_name = repo.repo_name
@@ -263,9 +261,7 @@ def sync_commits(
             end_date = timezone.now()
 
         # Create thread pool for big commits (max 2-4 workers to avoid heavy disk/network load)
-        executor = ThreadPoolExecutor(
-            max_workers=2, thread_name_prefix="big_commit"
-        )
+        executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="big_commit")
         futures = []
 
         count_normal = 0
@@ -310,9 +306,7 @@ def sync_commits(
 
             # Phase 3: wait for all big commit tasks to finish
             if futures:
-                logger.info(
-                    "Waiting for %d big commit task(s) to finish", len(futures)
-                )
+                logger.info("Waiting for %d big commit task(s) to finish", len(futures))
                 executor.shutdown(wait=True)
 
                 # Check for exceptions in tasks
@@ -320,9 +314,7 @@ def sync_commits(
                     try:
                         future.result()  # Will raise if task raised
                     except Exception as e:
-                        logger.error(
-                            "Big commit task %d raised exception: %s", i, e
-                        )
+                        logger.error("Big commit task %d raised exception: %s", i, e)
 
                 # Phase 4: process big commit JSONs (written by workers)
                 logger.info("Processing big commit JSONs written by workers")

--- a/github_activity_tracker/sync/commits.py
+++ b/github_activity_tracker/sync/commits.py
@@ -48,9 +48,7 @@ def _process_commit_files(
 ) -> None:
     """Create/update GitHubFile and GitCommitFileChange for each file in the commit."""
     for file_info in commit_data.get("files") or []:
-        filename = file_info.get("filename") or file_info.get(
-            "previous_filename"
-        )
+        filename = file_info.get("filename") or file_info.get("previous_filename")
         if not (filename and filename.strip()):
             continue
         filename = filename.strip()
@@ -100,9 +98,7 @@ def _process_commit_data(repo: GitHubRepository, commit_data: dict) -> None:
         )
     else:
         name, email = _commit_author_name_and_email(commit_data)
-        account, _ = get_or_create_unknown_github_account(
-            name=name, email=email
-        )
+        account, _ = get_or_create_unknown_github_account(name=name, email=email)
 
     commit_hash = commit_data.get("sha")
     comment = commit_data.get("commit", {}).get("message", "")
@@ -139,9 +135,7 @@ def _process_existing_commit_jsons(repo: GitHubRepository) -> int:
     return count
 
 
-def _process_big_commit_worker(
-    owner: str, repo_name: str, commit_data: dict
-) -> None:
+def _process_big_commit_worker(owner: str, repo_name: str, commit_data: dict) -> None:
     """
     Background worker: get full file list for big commit (300+ files) via git clone.
 
@@ -161,9 +155,7 @@ def _process_big_commit_worker(
         )
 
         # Get full file list via git
-        full_files = big_commit.get_full_commit_files(
-            owner, repo_name, commit_data
-        )
+        full_files = big_commit.get_full_commit_files(owner, repo_name, commit_data)
 
         # Build new commit_data with full files
         full_commit_data = commit_data.copy()
@@ -195,9 +187,7 @@ def _process_big_commit_worker(
         )
         # Write original commit data (with 300 files) so we don't lose the commit
         try:
-            json_path = get_commit_json_path(
-                owner, repo_name, commit_data.get("sha")
-            )
+            json_path = get_commit_json_path(owner, repo_name, commit_data.get("sha"))
             json_path.parent.mkdir(parents=True, exist_ok=True)
             json_path.write_text(
                 json.dumps(commit_data, indent=2, default=str),
@@ -208,9 +198,7 @@ def _process_big_commit_worker(
                 commit_data.get("sha")[:7],
             )
         except Exception as write_error:
-            logger.error(
-                "Failed to write fallback commit JSON: %s", write_error
-            )
+            logger.error("Failed to write fallback commit JSON: %s", write_error)
 
 
 def sync_commits(
@@ -231,9 +219,7 @@ def sync_commits(
         start_date: Override start date (default: last commit date + 1s, or None if no commits).
         end_date: Override end date (default: now).
     """
-    logger.info(
-        "sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name
-    )
+    logger.info("sync_commits: starting for repo id=%s (%s)", repo.pk, repo.repo_name)
 
     owner = repo.owner_account.username
     repo_name = repo.repo_name
@@ -257,9 +243,7 @@ def sync_commits(
             end_date = timezone.now()
 
         # Create thread pool for big commits (max 2-4 workers to avoid heavy disk/network load)
-        executor = ThreadPoolExecutor(
-            max_workers=2, thread_name_prefix="big_commit"
-        )
+        executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="big_commit")
         futures = []
 
         count_normal = 0
@@ -304,9 +288,7 @@ def sync_commits(
 
             # Phase 3: wait for all big commit tasks to finish
             if futures:
-                logger.info(
-                    "Waiting for %d big commit task(s) to finish", len(futures)
-                )
+                logger.info("Waiting for %d big commit task(s) to finish", len(futures))
                 executor.shutdown(wait=True)
 
                 # Check for exceptions in tasks
@@ -314,9 +296,7 @@ def sync_commits(
                     try:
                         future.result()  # Will raise if task raised
                     except Exception as e:
-                        logger.error(
-                            "Big commit task %d raised exception: %s", i, e
-                        )
+                        logger.error("Big commit task %d raised exception: %s", i, e)
 
                 # Phase 4: process big commit JSONs (written by workers)
                 logger.info("Processing big commit JSONs written by workers")

--- a/github_activity_tracker/tests/test_big_commit.py
+++ b/github_activity_tracker/tests/test_big_commit.py
@@ -187,7 +187,7 @@ def test_get_full_commit_files_returns_files_list(tmp_path):
             "github_activity_tracker.big_commit.get_commit_file_changes",
             return_value=mock_files,
         ):
-            files = big_commit.get_full_commit_files("owner", "repo", commit_data)
+            files = big_commit.get_full_commit_files("owner", "repo", commit_sha="commit_sha", parent_shas=["parent_sha"])
 
     assert files == mock_files
 
@@ -222,7 +222,7 @@ def test_get_full_commit_files_initial_commit_diffs_against_empty_tree(tmp_path)
             "github_activity_tracker.big_commit.get_commit_file_changes",
             return_value=mock_files,
         ) as mock_get_changes:
-            files = big_commit.get_full_commit_files("owner", "repo", commit_data)
+            files = big_commit.get_full_commit_files("owner", "repo", commit_sha="abc123", parent_shas=[])
     assert files == mock_files
     # Initial commit: parent_sha should be the empty tree
     mock_get_changes.assert_called_once()
@@ -231,13 +231,8 @@ def test_get_full_commit_files_initial_commit_diffs_against_empty_tree(tmp_path)
     assert call_args[2] == "abc123"
 
 
-def test_get_full_commit_files_initial_commit_fallback_to_api_files_on_error(tmp_path):
-    """get_full_commit_files for initial commit falls back to API files when git diff fails (if not truncated)."""
-    commit_data = {
-        "sha": "abc123",
-        "parents": [],
-        "files": [{"filename": "api_file.txt"}],
-    }
+def test_get_full_commit_files_raises_on_git_failure(tmp_path):
+    """get_full_commit_files raises RuntimeError when git diff fails."""
     with patch(
         "github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path
     ):
@@ -245,27 +240,7 @@ def test_get_full_commit_files_initial_commit_fallback_to_api_files_on_error(tmp
             "github_activity_tracker.big_commit.get_commit_file_changes",
             side_effect=RuntimeError("empty tree not found"),
         ):
-            files = big_commit.get_full_commit_files("owner", "repo", commit_data)
-    assert files == commit_data["files"]
-
-
-def test_get_full_commit_files_initial_commit_raises_when_api_truncated_and_git_fails(
-    tmp_path,
-):
-    """get_full_commit_files for initial commit raises when git diff fails and API files count is 300 (truncated)."""
-    commit_data = {
-        "sha": "abc123",
-        "parents": [],
-        "files": [{"filename": f"file{i}.txt"} for i in range(300)],
-    }
-    with patch(
-        "github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path
-    ):
-        with patch(
-            "github_activity_tracker.big_commit.get_commit_file_changes",
-            side_effect=RuntimeError("empty tree not in shallow clone"),
-        ):
             with pytest.raises(RuntimeError) as exc_info:
-                big_commit.get_full_commit_files("owner", "repo", commit_data)
+                big_commit.get_full_commit_files("owner", "repo", commit_sha="abc123", parent_shas=[])
     assert "abc123" in str(exc_info.value)
-    assert "300" in str(exc_info.value) or "truncated" in str(exc_info.value).lower()
+    assert "empty tree not found" in str(exc_info.value)

--- a/github_activity_tracker/tests/test_big_commit.py
+++ b/github_activity_tracker/tests/test_big_commit.py
@@ -1,0 +1,200 @@
+"""Tests for github_activity_tracker big_commit (handle 300+ file commits)."""
+
+from unittest.mock import MagicMock, patch
+
+from github_activity_tracker import big_commit
+
+
+def test_is_commit_truncated_returns_true_for_300_files():
+    """is_commit_truncated returns True when commit has exactly 300 files."""
+    commit_data = {"files": [{"filename": f"file{i}.txt"} for i in range(300)]}
+    assert big_commit.is_commit_truncated(commit_data) is True
+
+
+def test_is_commit_truncated_returns_false_for_less_than_300_files():
+    """is_commit_truncated returns False when commit has < 300 files."""
+    commit_data = {"files": [{"filename": "file.txt"}]}
+    assert big_commit.is_commit_truncated(commit_data) is False
+
+
+def test_is_commit_truncated_returns_false_for_no_files():
+    """is_commit_truncated returns False when commit has no files."""
+    commit_data = {"files": []}
+    assert big_commit.is_commit_truncated(commit_data) is False
+
+
+def test_get_changed_file_count_via_trees_returns_count():
+    """get_changed_file_count_via_trees returns count of changed files via trees API."""
+    mock_client = MagicMock()
+    mock_client.rest_request.side_effect = [
+        # Parent commit
+        {"commit": {"tree": {"sha": "parent_tree_sha"}}},
+        # Commit tree
+        {
+            "tree": [
+                {"path": "file1.txt", "type": "blob", "sha": "sha1"},
+                {"path": "file2.txt", "type": "blob", "sha": "sha2_new"},
+                {"path": "file3.txt", "type": "blob", "sha": "sha3"},
+            ],
+            "truncated": False,
+        },
+        # Parent tree
+        {
+            "tree": [
+                {"path": "file1.txt", "type": "blob", "sha": "sha1"},
+                {"path": "file2.txt", "type": "blob", "sha": "sha2_old"},
+            ],
+            "truncated": False,
+        },
+    ]
+    
+    commit_data = {
+        "commit": {"tree": {"sha": "commit_tree_sha"}},
+        "parents": [{"sha": "parent_sha"}],
+    }
+    
+    count = big_commit.get_changed_file_count_via_trees(
+        mock_client, "owner", "repo", commit_data
+    )
+    
+    # file2.txt modified, file3.txt added = 2 changed
+    assert count == 2
+
+
+def test_get_changed_file_count_via_trees_returns_none_when_truncated():
+    """get_changed_file_count_via_trees returns None when trees are truncated."""
+    mock_client = MagicMock()
+    mock_client.rest_request.side_effect = [
+        {"commit": {"tree": {"sha": "parent_tree_sha"}}},
+        {"tree": [], "truncated": True},
+        {"tree": [], "truncated": False},
+    ]
+    
+    commit_data = {
+        "commit": {"tree": {"sha": "commit_tree_sha"}},
+        "parents": [{"sha": "parent_sha"}],
+    }
+    
+    count = big_commit.get_changed_file_count_via_trees(
+        mock_client, "owner", "repo", commit_data
+    )
+    
+    assert count is None
+
+
+def test_get_changed_file_count_via_trees_returns_none_for_initial_commit():
+    """get_changed_file_count_via_trees returns None for commit with no parent."""
+    commit_data = {
+        "commit": {"tree": {"sha": "tree_sha"}},
+        "parents": [],
+    }
+    
+    count = big_commit.get_changed_file_count_via_trees(
+        MagicMock(), "owner", "repo", commit_data
+    )
+    
+    assert count is None
+
+
+def test_ensure_repo_cloned_clones_when_not_exists(tmp_path):
+    """ensure_repo_cloned clones repo when it doesn't exist."""
+    clone_path = tmp_path / "owner_repo"
+    
+    with patch("github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path):
+        with patch("github_activity_tracker.big_commit.clone_repo") as clone_mock:
+            with patch("github_activity_tracker.big_commit.register_clone"):
+                result = big_commit.ensure_repo_cloned("owner", "repo")
+    
+    assert result == clone_path
+    clone_mock.assert_called_once_with("owner/repo", clone_path)
+
+
+def test_ensure_repo_cloned_fetches_when_exists(tmp_path):
+    """ensure_repo_cloned runs git fetch when repo already exists."""
+    clone_path = tmp_path / "owner_repo"
+    clone_path.mkdir()
+    (clone_path / ".git").mkdir()
+
+    with patch("github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path):
+        with patch("github_activity_tracker.big_commit.subprocess.run") as run_mock:
+            with patch("github_activity_tracker.big_commit.register_clone"):
+                result = big_commit.ensure_repo_cloned("owner", "repo")
+
+    assert result == clone_path
+    run_mock.assert_called_once()
+    call_args = run_mock.call_args[0][0]
+    assert "git" in call_args
+    assert "fetch" in call_args
+
+
+def test_ensure_repo_cloned_removes_existing_non_git_dir_before_clone(tmp_path):
+    """ensure_repo_cloned removes existing dir when it has no .git (avoids clone exit 128)."""
+    clone_path = tmp_path / "owner_repo"
+    clone_path.mkdir()
+    # No .git - not a git repo (e.g. leftover from failed clone)
+    (clone_path / "some_file.txt").write_text("leftover")
+
+    with patch("github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path):
+        with patch("github_activity_tracker.big_commit.shutil.rmtree") as rmtree_mock:
+            with patch("github_activity_tracker.big_commit.clone_repo") as clone_mock:
+                with patch("github_activity_tracker.big_commit.register_clone"):
+                    result = big_commit.ensure_repo_cloned("owner", "repo")
+
+    assert result == clone_path
+    rmtree_mock.assert_called_once_with(clone_path)
+    clone_mock.assert_called_once_with("owner/repo", clone_path)
+
+
+def test_get_full_commit_files_returns_files_list(tmp_path):
+    """get_full_commit_files clones repo and returns file list."""
+    commit_data = {
+        "sha": "commit_sha",
+        "parents": [{"sha": "parent_sha"}],
+        "files": [{"filename": "file.txt"}] * 300,  # Truncated
+    }
+    
+    mock_files = [
+        {"filename": "file1.txt", "status": "modified", "additions": 1, "deletions": 0, "patch": ""},
+        {"filename": "file2.txt", "status": "added", "additions": 5, "deletions": 0, "patch": ""},
+    ]
+    
+    with patch("github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path):
+        with patch("github_activity_tracker.big_commit.get_commit_file_changes", return_value=mock_files):
+            files = big_commit.get_full_commit_files("owner", "repo", commit_data)
+    
+    assert files == mock_files
+
+
+def test_get_full_commit_files_initial_commit_diffs_against_empty_tree(tmp_path):
+    """get_full_commit_files for initial commit diffs against empty tree and returns full file list."""
+    commit_data = {
+        "sha": "abc123",
+        "parents": [],
+        "files": [{"filename": "file.txt"}],
+    }
+    mock_files = [
+        {"filename": "file1.txt", "status": "added", "additions": 10, "deletions": 0, "patch": ""},
+        {"filename": "file2.txt", "status": "added", "additions": 5, "deletions": 0, "patch": ""},
+    ]
+    with patch("github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path):
+        with patch("github_activity_tracker.big_commit.get_commit_file_changes", return_value=mock_files) as mock_get_changes:
+            files = big_commit.get_full_commit_files("owner", "repo", commit_data)
+    assert files == mock_files
+    # Initial commit: parent_sha should be the empty tree
+    mock_get_changes.assert_called_once()
+    call_args = mock_get_changes.call_args[0]
+    assert call_args[1] == big_commit._GIT_EMPTY_TREE_SHA
+    assert call_args[2] == "abc123"
+
+
+def test_get_full_commit_files_initial_commit_fallback_to_api_files_on_error(tmp_path):
+    """get_full_commit_files for initial commit falls back to API files when git diff fails."""
+    commit_data = {
+        "sha": "abc123",
+        "parents": [],
+        "files": [{"filename": "api_file.txt"}],
+    }
+    with patch("github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path):
+        with patch("github_activity_tracker.big_commit.get_commit_file_changes", side_effect=RuntimeError("empty tree not found")):
+            files = big_commit.get_full_commit_files("owner", "repo", commit_data)
+    assert files == commit_data["files"]

--- a/github_activity_tracker/tests/test_big_commit.py
+++ b/github_activity_tracker/tests/test_big_commit.py
@@ -1,6 +1,6 @@
 """Tests for github_activity_tracker big_commit (handle 300+ file commits)."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -23,79 +23,6 @@ def test_is_commit_truncated_returns_false_for_no_files():
     """is_commit_truncated returns False when commit has no files."""
     commit_data = {"files": []}
     assert big_commit.is_commit_truncated(commit_data) is False
-
-
-def test_get_changed_file_count_via_trees_returns_count():
-    """get_changed_file_count_via_trees returns count of changed files via trees API."""
-    mock_client = MagicMock()
-    mock_client.rest_request.side_effect = [
-        # Parent commit
-        {"commit": {"tree": {"sha": "parent_tree_sha"}}},
-        # Commit tree
-        {
-            "tree": [
-                {"path": "file1.txt", "type": "blob", "sha": "sha1"},
-                {"path": "file2.txt", "type": "blob", "sha": "sha2_new"},
-                {"path": "file3.txt", "type": "blob", "sha": "sha3"},
-            ],
-            "truncated": False,
-        },
-        # Parent tree
-        {
-            "tree": [
-                {"path": "file1.txt", "type": "blob", "sha": "sha1"},
-                {"path": "file2.txt", "type": "blob", "sha": "sha2_old"},
-            ],
-            "truncated": False,
-        },
-    ]
-
-    commit_data = {
-        "commit": {"tree": {"sha": "commit_tree_sha"}},
-        "parents": [{"sha": "parent_sha"}],
-    }
-
-    count = big_commit.get_changed_file_count_via_trees(
-        mock_client, "owner", "repo", commit_data
-    )
-
-    # file2.txt modified, file3.txt added = 2 changed
-    assert count == 2
-
-
-def test_get_changed_file_count_via_trees_returns_none_when_truncated():
-    """get_changed_file_count_via_trees returns None when trees are truncated."""
-    mock_client = MagicMock()
-    mock_client.rest_request.side_effect = [
-        {"commit": {"tree": {"sha": "parent_tree_sha"}}},
-        {"tree": [], "truncated": True},
-        {"tree": [], "truncated": False},
-    ]
-
-    commit_data = {
-        "commit": {"tree": {"sha": "commit_tree_sha"}},
-        "parents": [{"sha": "parent_sha"}],
-    }
-
-    count = big_commit.get_changed_file_count_via_trees(
-        mock_client, "owner", "repo", commit_data
-    )
-
-    assert count is None
-
-
-def test_get_changed_file_count_via_trees_returns_none_for_initial_commit():
-    """get_changed_file_count_via_trees returns None for commit with no parent."""
-    commit_data = {
-        "commit": {"tree": {"sha": "tree_sha"}},
-        "parents": [],
-    }
-
-    count = big_commit.get_changed_file_count_via_trees(
-        MagicMock(), "owner", "repo", commit_data
-    )
-
-    assert count is None
 
 
 def test_ensure_repo_cloned_clones_when_not_exists(tmp_path):

--- a/github_activity_tracker/tests/test_big_commit.py
+++ b/github_activity_tracker/tests/test_big_commit.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from github_activity_tracker import big_commit
 
 
@@ -141,13 +143,15 @@ def test_ensure_repo_cloned_removes_existing_non_git_dir_before_clone(tmp_path):
     with patch(
         "github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path
     ):
-        with patch("github_activity_tracker.big_commit.shutil.rmtree") as rmtree_mock:
+        with patch(
+            "github_activity_tracker.big_commit.remove_clone_dir", return_value=True
+        ) as remove_mock:
             with patch("github_activity_tracker.big_commit.clone_repo") as clone_mock:
                 with patch("github_activity_tracker.big_commit.register_clone"):
                     result = big_commit.ensure_repo_cloned("owner", "repo")
 
     assert result == clone_path
-    rmtree_mock.assert_called_once_with(clone_path)
+    remove_mock.assert_called_once_with(clone_path)
     clone_mock.assert_called_once_with("owner/repo", clone_path)
 
 
@@ -228,7 +232,7 @@ def test_get_full_commit_files_initial_commit_diffs_against_empty_tree(tmp_path)
 
 
 def test_get_full_commit_files_initial_commit_fallback_to_api_files_on_error(tmp_path):
-    """get_full_commit_files for initial commit falls back to API files when git diff fails."""
+    """get_full_commit_files for initial commit falls back to API files when git diff fails (if not truncated)."""
     commit_data = {
         "sha": "abc123",
         "parents": [],
@@ -243,3 +247,25 @@ def test_get_full_commit_files_initial_commit_fallback_to_api_files_on_error(tmp
         ):
             files = big_commit.get_full_commit_files("owner", "repo", commit_data)
     assert files == commit_data["files"]
+
+
+def test_get_full_commit_files_initial_commit_raises_when_api_truncated_and_git_fails(
+    tmp_path,
+):
+    """get_full_commit_files for initial commit raises when git diff fails and API files count is 300 (truncated)."""
+    commit_data = {
+        "sha": "abc123",
+        "parents": [],
+        "files": [{"filename": f"file{i}.txt"} for i in range(300)],
+    }
+    with patch(
+        "github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path
+    ):
+        with patch(
+            "github_activity_tracker.big_commit.get_commit_file_changes",
+            side_effect=RuntimeError("empty tree not in shallow clone"),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                big_commit.get_full_commit_files("owner", "repo", commit_data)
+    assert "abc123" in str(exc_info.value)
+    assert "300" in str(exc_info.value) or "truncated" in str(exc_info.value).lower()

--- a/github_activity_tracker/tests/test_big_commit.py
+++ b/github_activity_tracker/tests/test_big_commit.py
@@ -47,16 +47,16 @@ def test_get_changed_file_count_via_trees_returns_count():
             "truncated": False,
         },
     ]
-    
+
     commit_data = {
         "commit": {"tree": {"sha": "commit_tree_sha"}},
         "parents": [{"sha": "parent_sha"}],
     }
-    
+
     count = big_commit.get_changed_file_count_via_trees(
         mock_client, "owner", "repo", commit_data
     )
-    
+
     # file2.txt modified, file3.txt added = 2 changed
     assert count == 2
 
@@ -69,16 +69,16 @@ def test_get_changed_file_count_via_trees_returns_none_when_truncated():
         {"tree": [], "truncated": True},
         {"tree": [], "truncated": False},
     ]
-    
+
     commit_data = {
         "commit": {"tree": {"sha": "commit_tree_sha"}},
         "parents": [{"sha": "parent_sha"}],
     }
-    
+
     count = big_commit.get_changed_file_count_via_trees(
         mock_client, "owner", "repo", commit_data
     )
-    
+
     assert count is None
 
 
@@ -88,23 +88,25 @@ def test_get_changed_file_count_via_trees_returns_none_for_initial_commit():
         "commit": {"tree": {"sha": "tree_sha"}},
         "parents": [],
     }
-    
+
     count = big_commit.get_changed_file_count_via_trees(
         MagicMock(), "owner", "repo", commit_data
     )
-    
+
     assert count is None
 
 
 def test_ensure_repo_cloned_clones_when_not_exists(tmp_path):
     """ensure_repo_cloned clones repo when it doesn't exist."""
     clone_path = tmp_path / "owner_repo"
-    
-    with patch("github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path):
+
+    with patch(
+        "github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path
+    ):
         with patch("github_activity_tracker.big_commit.clone_repo") as clone_mock:
             with patch("github_activity_tracker.big_commit.register_clone"):
                 result = big_commit.ensure_repo_cloned("owner", "repo")
-    
+
     assert result == clone_path
     clone_mock.assert_called_once_with("owner/repo", clone_path)
 
@@ -115,7 +117,9 @@ def test_ensure_repo_cloned_fetches_when_exists(tmp_path):
     clone_path.mkdir()
     (clone_path / ".git").mkdir()
 
-    with patch("github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path):
+    with patch(
+        "github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path
+    ):
         with patch("github_activity_tracker.big_commit.subprocess.run") as run_mock:
             with patch("github_activity_tracker.big_commit.register_clone"):
                 result = big_commit.ensure_repo_cloned("owner", "repo")
@@ -134,7 +138,9 @@ def test_ensure_repo_cloned_removes_existing_non_git_dir_before_clone(tmp_path):
     # No .git - not a git repo (e.g. leftover from failed clone)
     (clone_path / "some_file.txt").write_text("leftover")
 
-    with patch("github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path):
+    with patch(
+        "github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path
+    ):
         with patch("github_activity_tracker.big_commit.shutil.rmtree") as rmtree_mock:
             with patch("github_activity_tracker.big_commit.clone_repo") as clone_mock:
                 with patch("github_activity_tracker.big_commit.register_clone"):
@@ -152,16 +158,33 @@ def test_get_full_commit_files_returns_files_list(tmp_path):
         "parents": [{"sha": "parent_sha"}],
         "files": [{"filename": "file.txt"}] * 300,  # Truncated
     }
-    
+
     mock_files = [
-        {"filename": "file1.txt", "status": "modified", "additions": 1, "deletions": 0, "patch": ""},
-        {"filename": "file2.txt", "status": "added", "additions": 5, "deletions": 0, "patch": ""},
+        {
+            "filename": "file1.txt",
+            "status": "modified",
+            "additions": 1,
+            "deletions": 0,
+            "patch": "",
+        },
+        {
+            "filename": "file2.txt",
+            "status": "added",
+            "additions": 5,
+            "deletions": 0,
+            "patch": "",
+        },
     ]
-    
-    with patch("github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path):
-        with patch("github_activity_tracker.big_commit.get_commit_file_changes", return_value=mock_files):
+
+    with patch(
+        "github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path
+    ):
+        with patch(
+            "github_activity_tracker.big_commit.get_commit_file_changes",
+            return_value=mock_files,
+        ):
             files = big_commit.get_full_commit_files("owner", "repo", commit_data)
-    
+
     assert files == mock_files
 
 
@@ -173,11 +196,28 @@ def test_get_full_commit_files_initial_commit_diffs_against_empty_tree(tmp_path)
         "files": [{"filename": "file.txt"}],
     }
     mock_files = [
-        {"filename": "file1.txt", "status": "added", "additions": 10, "deletions": 0, "patch": ""},
-        {"filename": "file2.txt", "status": "added", "additions": 5, "deletions": 0, "patch": ""},
+        {
+            "filename": "file1.txt",
+            "status": "added",
+            "additions": 10,
+            "deletions": 0,
+            "patch": "",
+        },
+        {
+            "filename": "file2.txt",
+            "status": "added",
+            "additions": 5,
+            "deletions": 0,
+            "patch": "",
+        },
     ]
-    with patch("github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path):
-        with patch("github_activity_tracker.big_commit.get_commit_file_changes", return_value=mock_files) as mock_get_changes:
+    with patch(
+        "github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path
+    ):
+        with patch(
+            "github_activity_tracker.big_commit.get_commit_file_changes",
+            return_value=mock_files,
+        ) as mock_get_changes:
             files = big_commit.get_full_commit_files("owner", "repo", commit_data)
     assert files == mock_files
     # Initial commit: parent_sha should be the empty tree
@@ -194,7 +234,12 @@ def test_get_full_commit_files_initial_commit_fallback_to_api_files_on_error(tmp
         "parents": [],
         "files": [{"filename": "api_file.txt"}],
     }
-    with patch("github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path):
-        with patch("github_activity_tracker.big_commit.get_commit_file_changes", side_effect=RuntimeError("empty tree not found")):
+    with patch(
+        "github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path
+    ):
+        with patch(
+            "github_activity_tracker.big_commit.get_commit_file_changes",
+            side_effect=RuntimeError("empty tree not found"),
+        ):
             files = big_commit.get_full_commit_files("owner", "repo", commit_data)
     assert files == commit_data["files"]

--- a/github_activity_tracker/tests/test_big_commit.py
+++ b/github_activity_tracker/tests/test_big_commit.py
@@ -103,7 +103,8 @@ def test_ensure_repo_cloned_clones_when_not_exists(tmp_path):
     clone_path = tmp_path / "owner_repo"
 
     with patch(
-        "github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path
+        "github_activity_tracker.big_commit.get_clone_dir",
+        return_value=clone_path,
     ):
         with patch("github_activity_tracker.big_commit.clone_repo") as clone_mock:
             with patch("github_activity_tracker.big_commit.register_clone"):
@@ -120,7 +121,8 @@ def test_ensure_repo_cloned_fetches_when_exists(tmp_path):
     (clone_path / ".git").mkdir()
 
     with patch(
-        "github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path
+        "github_activity_tracker.big_commit.get_clone_dir",
+        return_value=clone_path,
     ):
         with patch("github_activity_tracker.big_commit.subprocess.run") as run_mock:
             with patch("github_activity_tracker.big_commit.register_clone"):
@@ -133,7 +135,9 @@ def test_ensure_repo_cloned_fetches_when_exists(tmp_path):
     assert "fetch" in call_args
 
 
-def test_ensure_repo_cloned_removes_existing_non_git_dir_before_clone(tmp_path):
+def test_ensure_repo_cloned_removes_existing_non_git_dir_before_clone(
+    tmp_path,
+):
     """ensure_repo_cloned removes existing dir when it has no .git (avoids clone exit 128)."""
     clone_path = tmp_path / "owner_repo"
     clone_path.mkdir()
@@ -141,10 +145,12 @@ def test_ensure_repo_cloned_removes_existing_non_git_dir_before_clone(tmp_path):
     (clone_path / "some_file.txt").write_text("leftover")
 
     with patch(
-        "github_activity_tracker.big_commit.get_clone_dir", return_value=clone_path
+        "github_activity_tracker.big_commit.get_clone_dir",
+        return_value=clone_path,
     ):
         with patch(
-            "github_activity_tracker.big_commit.remove_clone_dir", return_value=True
+            "github_activity_tracker.big_commit.remove_clone_dir",
+            return_value=True,
         ) as remove_mock:
             with patch("github_activity_tracker.big_commit.clone_repo") as clone_mock:
                 with patch("github_activity_tracker.big_commit.register_clone"):
@@ -157,11 +163,6 @@ def test_ensure_repo_cloned_removes_existing_non_git_dir_before_clone(tmp_path):
 
 def test_get_full_commit_files_returns_files_list(tmp_path):
     """get_full_commit_files clones repo and returns file list."""
-    commit_data = {
-        "sha": "commit_sha",
-        "parents": [{"sha": "parent_sha"}],
-        "files": [{"filename": "file.txt"}] * 300,  # Truncated
-    }
 
     mock_files = [
         {
@@ -181,24 +182,27 @@ def test_get_full_commit_files_returns_files_list(tmp_path):
     ]
 
     with patch(
-        "github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path
+        "github_activity_tracker.big_commit.ensure_repo_cloned",
+        return_value=tmp_path,
     ):
         with patch(
             "github_activity_tracker.big_commit.get_commit_file_changes",
             return_value=mock_files,
         ):
-            files = big_commit.get_full_commit_files("owner", "repo", commit_sha="commit_sha", parent_shas=["parent_sha"])
+            files = big_commit.get_full_commit_files(
+                "owner",
+                "repo",
+                commit_sha="commit_sha",
+                parent_shas=["parent_sha"],
+            )
 
     assert files == mock_files
 
 
-def test_get_full_commit_files_initial_commit_diffs_against_empty_tree(tmp_path):
+def test_get_full_commit_files_initial_commit_diffs_against_empty_tree(
+    tmp_path,
+):
     """get_full_commit_files for initial commit diffs against empty tree and returns full file list."""
-    commit_data = {
-        "sha": "abc123",
-        "parents": [],
-        "files": [{"filename": "file.txt"}],
-    }
     mock_files = [
         {
             "filename": "file1.txt",
@@ -216,13 +220,16 @@ def test_get_full_commit_files_initial_commit_diffs_against_empty_tree(tmp_path)
         },
     ]
     with patch(
-        "github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path
+        "github_activity_tracker.big_commit.ensure_repo_cloned",
+        return_value=tmp_path,
     ):
         with patch(
             "github_activity_tracker.big_commit.get_commit_file_changes",
             return_value=mock_files,
         ) as mock_get_changes:
-            files = big_commit.get_full_commit_files("owner", "repo", commit_sha="abc123", parent_shas=[])
+            files = big_commit.get_full_commit_files(
+                "owner", "repo", commit_sha="abc123", parent_shas=[]
+            )
     assert files == mock_files
     # Initial commit: parent_sha should be the empty tree
     mock_get_changes.assert_called_once()
@@ -234,13 +241,16 @@ def test_get_full_commit_files_initial_commit_diffs_against_empty_tree(tmp_path)
 def test_get_full_commit_files_raises_on_git_failure(tmp_path):
     """get_full_commit_files raises RuntimeError when git diff fails."""
     with patch(
-        "github_activity_tracker.big_commit.ensure_repo_cloned", return_value=tmp_path
+        "github_activity_tracker.big_commit.ensure_repo_cloned",
+        return_value=tmp_path,
     ):
         with patch(
             "github_activity_tracker.big_commit.get_commit_file_changes",
             side_effect=RuntimeError("empty tree not found"),
         ):
             with pytest.raises(RuntimeError) as exc_info:
-                big_commit.get_full_commit_files("owner", "repo", commit_sha="abc123", parent_shas=[])
+                big_commit.get_full_commit_files(
+                    "owner", "repo", commit_sha="abc123", parent_shas=[]
+                )
     assert "abc123" in str(exc_info.value)
     assert "empty tree not found" in str(exc_info.value)

--- a/github_activity_tracker/tests/test_services.py
+++ b/github_activity_tracker/tests/test_services.py
@@ -389,6 +389,15 @@ def test_create_or_update_github_file_deleted_default_false(github_repository):
     assert gf.is_deleted is False
 
 
+@pytest.mark.django_db
+def test_create_or_update_github_file_strips_nul_from_filename(github_repository):
+    """create_or_update_github_file strips NUL bytes from filename (PostgreSQL text cannot contain 0x00)."""
+    filename_with_nul = "path\x00to\x00file.py"
+    gf, _ = services.create_or_update_github_file(github_repository, filename_with_nul)
+    assert "\x00" not in gf.filename
+    assert gf.filename == "pathtofile.py"
+
+
 # --- add_commit_file_change ---
 
 
@@ -445,6 +454,24 @@ def test_add_commit_file_change_defaults_patch_empty(github_repository, github_a
     gf, _ = services.create_or_update_github_file(github_repository, "h.py")
     fc, _ = services.add_commit_file_change(commit_obj, gf, "modified")
     assert fc.patch == ""
+
+
+@pytest.mark.django_db
+def test_add_commit_file_change_strips_nul_from_patch(github_repository, github_account):
+    """add_commit_file_change strips NUL bytes from patch (PostgreSQL text cannot contain 0x00)."""
+    commit_obj, _ = services.create_or_update_commit(
+        github_repository,
+        github_account,
+        "c_nul",
+        commit_at=datetime.now(timezone.utc),
+    )
+    gf, _ = services.create_or_update_github_file(github_repository, "f.py")
+    patch_with_nul = "diff --git a/f.py\n\x00binary\x00content\n"
+    fc, _ = services.add_commit_file_change(
+        commit_obj, gf, "modified", additions=1, deletions=0, patch=patch_with_nul
+    )
+    assert "\x00" not in fc.patch
+    assert fc.patch == "diff --git a/f.py\nbinarycontent\n"
 
 
 # --- create_or_update_issue ---

--- a/github_activity_tracker/tests/test_services.py
+++ b/github_activity_tracker/tests/test_services.py
@@ -457,7 +457,9 @@ def test_add_commit_file_change_defaults_patch_empty(github_repository, github_a
 
 
 @pytest.mark.django_db
-def test_add_commit_file_change_strips_nul_from_patch(github_repository, github_account):
+def test_add_commit_file_change_strips_nul_from_patch(
+    github_repository, github_account
+):
     """add_commit_file_change strips NUL bytes from patch (PostgreSQL text cannot contain 0x00)."""
     commit_obj, _ = services.create_or_update_commit(
         github_repository,

--- a/github_activity_tracker/tests/test_sync_commits.py
+++ b/github_activity_tracker/tests/test_sync_commits.py
@@ -1,0 +1,131 @@
+from unittest.mock import MagicMock, patch
+
+from github_activity_tracker.models import FileChangeStatus
+from github_activity_tracker.sync.commits import _process_commit_files
+
+
+def test_process_commit_files_creates_files_and_changes():
+    """_process_commit_files creates/updates GitHubFile and GitCommitFileChange for each file."""
+    mock_repo = MagicMock()
+    mock_commit = MagicMock()
+
+    files = [
+        {
+            "filename": "added.txt",
+            "status": "added",
+            "additions": 10,
+            "deletions": 0,
+            "patch": "@@ -0,0 +1,10 @@...",
+        },
+        {
+            "filename": "modified.txt",
+            "status": "modified",
+            "additions": 5,
+            "deletions": 2,
+        },
+        {
+            "filename": "deleted.txt",
+            "status": "removed",
+            "additions": 0,
+            "deletions": 100,
+        },
+        {
+            "previous_filename": "renamed.txt",
+            "status": "renamed",
+        },
+        {
+            "filename": "  spaced.txt  ",
+            "status": " unknown_status ",
+        },
+        {
+            "filename": "",  # Empty string, should be skipped
+        },
+        {
+            "filename": None,  # None, should be skipped
+        },
+        {
+            "filename": "   ",  # Whitespace, should be skipped
+        }
+    ]
+
+    mock_github_file_1 = MagicMock()
+    mock_github_file_2 = MagicMock()
+    mock_github_file_3 = MagicMock()
+    mock_github_file_4 = MagicMock()
+    mock_github_file_5 = MagicMock()
+
+    mock_create_file = MagicMock(side_effect=[
+        (mock_github_file_1, True),
+        (mock_github_file_2, False),
+        (mock_github_file_3, False),
+        (mock_github_file_4, True),
+        (mock_github_file_5, True),
+    ])
+
+    mock_add_change = MagicMock()
+
+    with patch(
+        "github_activity_tracker.sync.commits.services.create_or_update_github_file", mock_create_file
+    ), patch(
+        "github_activity_tracker.sync.commits.services.add_commit_file_change", mock_add_change
+    ):
+        _process_commit_files(mock_repo, mock_commit, files)
+
+    assert mock_create_file.call_count == 5
+    # added.txt
+    mock_create_file.assert_any_call(mock_repo, "added.txt", is_deleted=False)
+    # modified.txt
+    mock_create_file.assert_any_call(mock_repo, "modified.txt", is_deleted=False)
+    # deleted.txt
+    mock_create_file.assert_any_call(mock_repo, "deleted.txt", is_deleted=True)
+    # renamed.txt (fallback to previous_filename)
+    mock_create_file.assert_any_call(mock_repo, "renamed.txt", is_deleted=False)
+    # spaced.txt (trimmed)
+    mock_create_file.assert_any_call(mock_repo, "spaced.txt", is_deleted=False)
+
+    assert mock_add_change.call_count == 5
+    # added.txt
+    mock_add_change.assert_any_call(
+        mock_commit,
+        mock_github_file_1,
+        status="added",
+        additions=10,
+        deletions=0,
+        patch="@@ -0,0 +1,10 @@...",
+    )
+    # modified.txt
+    mock_add_change.assert_any_call(
+        mock_commit,
+        mock_github_file_2,
+        status="modified",
+        additions=5,
+        deletions=2,
+        patch="",
+    )
+    # deleted.txt
+    mock_add_change.assert_any_call(
+        mock_commit,
+        mock_github_file_3,
+        status="removed",
+        additions=0,
+        deletions=100,
+        patch="",
+    )
+    # renamed.txt
+    mock_add_change.assert_any_call(
+        mock_commit,
+        mock_github_file_4,
+        status="renamed",
+        additions=0,
+        deletions=0,
+        patch="",
+    )
+    # spaced.txt (unknown_status becomes changed)
+    mock_add_change.assert_any_call(
+        mock_commit,
+        mock_github_file_5,
+        status=FileChangeStatus.CHANGED,
+        additions=0,
+        deletions=0,
+        patch="",
+    )

--- a/github_activity_tracker/tests/test_sync_commits.py
+++ b/github_activity_tracker/tests/test_sync_commits.py
@@ -45,7 +45,7 @@ def test_process_commit_files_creates_files_and_changes():
         },
         {
             "filename": "   ",  # Whitespace, should be skipped
-        }
+        },
     ]
 
     mock_github_file_1 = MagicMock()
@@ -54,20 +54,24 @@ def test_process_commit_files_creates_files_and_changes():
     mock_github_file_4 = MagicMock()
     mock_github_file_5 = MagicMock()
 
-    mock_create_file = MagicMock(side_effect=[
-        (mock_github_file_1, True),
-        (mock_github_file_2, False),
-        (mock_github_file_3, False),
-        (mock_github_file_4, True),
-        (mock_github_file_5, True),
-    ])
+    mock_create_file = MagicMock(
+        side_effect=[
+            (mock_github_file_1, True),
+            (mock_github_file_2, False),
+            (mock_github_file_3, False),
+            (mock_github_file_4, True),
+            (mock_github_file_5, True),
+        ]
+    )
 
     mock_add_change = MagicMock()
 
     with patch(
-        "github_activity_tracker.sync.commits.services.create_or_update_github_file", mock_create_file
+        "github_activity_tracker.sync.commits.services.create_or_update_github_file",
+        mock_create_file,
     ), patch(
-        "github_activity_tracker.sync.commits.services.add_commit_file_change", mock_add_change
+        "github_activity_tracker.sync.commits.services.add_commit_file_change",
+        mock_add_change,
     ):
         _process_commit_files(mock_repo, mock_commit, files)
 

--- a/github_activity_tracker/tests/test_workspace.py
+++ b/github_activity_tracker/tests/test_workspace.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 from github_activity_tracker.workspace import (
+    get_clone_dir,
+    get_clones_root,
     get_commits_dir,
     get_commit_json_path,
     get_issues_dir,
@@ -24,6 +26,7 @@ from github_activity_tracker.workspace import (
     iter_existing_commit_jsons,
     iter_existing_issue_jsons,
     iter_existing_pr_jsons,
+    remove_clone_dir,
 )
 
 
@@ -167,7 +170,14 @@ def test_get_prs_dir_idempotent(mock_workspace_path):
 def test_get_commit_json_path_returns_commits_sha_json(mock_workspace_path):
     """get_commit_json_path returns .../commits/<sha>.json."""
     path = get_commit_json_path("owner", "repo", "abc123def")
-    assert path == mock_workspace_path / "owner" / "repo" / "commits" / "abc123def.json"
+    assert (
+        path
+        == mock_workspace_path
+        / "owner"
+        / "repo"
+        / "commits"
+        / "abc123def.json"
+    )
 
 
 def test_get_commit_json_path_does_not_create_file(mock_workspace_path):
@@ -190,7 +200,9 @@ def test_get_commit_json_path_consistent(mock_workspace_path):
 def test_get_issue_json_path_returns_issues_num_json(mock_workspace_path):
     """get_issue_json_path returns .../issues/<number>.json."""
     path = get_issue_json_path("owner", "repo", 42)
-    assert path == mock_workspace_path / "owner" / "repo" / "issues" / "42.json"
+    assert (
+        path == mock_workspace_path / "owner" / "repo" / "issues" / "42.json"
+    )
 
 
 def test_get_issue_json_path_integer_number(mock_workspace_path):
@@ -331,39 +343,58 @@ def mock_raw_workspace_path(tmp_path):
         yield tmp_path / "raw"
 
 
-def test_get_raw_source_root_returns_path_and_creates_dir(mock_raw_workspace_path):
+def test_get_raw_source_root_returns_path_and_creates_dir(
+    mock_raw_workspace_path,
+):
     """get_raw_source_root returns .../raw/github_activity_tracker/ and creates dirs."""
     root = get_raw_source_root()
     assert root == mock_raw_workspace_path / "github_activity_tracker"
     assert root.is_dir()
 
 
-def test_get_raw_source_repo_dir_returns_owner_repo_subdir(mock_raw_workspace_path):
+def test_get_raw_source_repo_dir_returns_owner_repo_subdir(
+    mock_raw_workspace_path,
+):
     """get_raw_source_repo_dir returns .../github_activity_tracker/<owner>/<repo>/."""
     path = get_raw_source_repo_dir("boostorg", "boost")
     assert (
         path
-        == mock_raw_workspace_path / "github_activity_tracker" / "boostorg" / "boost"
+        == mock_raw_workspace_path
+        / "github_activity_tracker"
+        / "boostorg"
+        / "boost"
     )
     assert path.is_dir()
 
 
-def test_get_raw_source_commits_dir_returns_commits_subdir(mock_raw_workspace_path):
+def test_get_raw_source_commits_dir_returns_commits_subdir(
+    mock_raw_workspace_path,
+):
     """get_raw_source_commits_dir returns .../<owner>/<repo>/commits/."""
     path = get_raw_source_commits_dir("o", "r")
     assert (
         path
-        == mock_raw_workspace_path / "github_activity_tracker" / "o" / "r" / "commits"
+        == mock_raw_workspace_path
+        / "github_activity_tracker"
+        / "o"
+        / "r"
+        / "commits"
     )
     assert path.is_dir()
 
 
-def test_get_raw_source_issues_dir_returns_issues_subdir(mock_raw_workspace_path):
+def test_get_raw_source_issues_dir_returns_issues_subdir(
+    mock_raw_workspace_path,
+):
     """get_raw_source_issues_dir returns .../<owner>/<repo>/issues/."""
     path = get_raw_source_issues_dir("o", "r")
     assert (
         path
-        == mock_raw_workspace_path / "github_activity_tracker" / "o" / "r" / "issues"
+        == mock_raw_workspace_path
+        / "github_activity_tracker"
+        / "o"
+        / "r"
+        / "issues"
     )
     assert path.is_dir()
 
@@ -372,7 +403,12 @@ def test_get_raw_source_prs_dir_returns_prs_subdir(mock_raw_workspace_path):
     """get_raw_source_prs_dir returns .../<owner>/<repo>/prs/."""
     path = get_raw_source_prs_dir("o", "r")
     assert (
-        path == mock_raw_workspace_path / "github_activity_tracker" / "o" / "r" / "prs"
+        path
+        == mock_raw_workspace_path
+        / "github_activity_tracker"
+        / "o"
+        / "r"
+        / "prs"
     )
     assert path.is_dir()
 
@@ -391,7 +427,9 @@ def test_get_raw_source_commit_path_returns_sha_json(mock_raw_workspace_path):
     )
 
 
-def test_get_raw_source_issue_path_returns_number_json(mock_raw_workspace_path):
+def test_get_raw_source_issue_path_returns_number_json(
+    mock_raw_workspace_path,
+):
     """get_raw_source_issue_path returns .../issues/<number>.json."""
     path = get_raw_source_issue_path("owner", "repo", 42)
     assert (
@@ -417,3 +455,53 @@ def test_get_raw_source_pr_path_returns_number_json(mock_raw_workspace_path):
         / "prs"
         / "7.json"
     )
+
+
+# --- get_clones_root, get_clone_dir ---
+
+
+def test_get_clones_root_returns_clones_subdir(mock_workspace_path):
+    """get_clones_root returns .../clones/ and creates it."""
+    root = get_clones_root()
+    assert root == mock_workspace_path / "clones"
+    assert root.is_dir()
+
+
+def test_get_clone_dir_returns_owner_repo_path(mock_workspace_path):
+    """get_clone_dir returns .../clones/{owner}_{repo}."""
+    path = get_clone_dir("boostorg", "outcome")
+    assert path == mock_workspace_path / "clones" / "boostorg_outcome"
+
+
+# --- remove_clone_dir (Windows Access denied fix) ---
+
+
+def test_remove_clone_dir_returns_true_when_path_missing(mock_workspace_path):
+    """remove_clone_dir returns True when path does not exist."""
+    missing = mock_workspace_path / "clones" / "nonexistent"
+    assert remove_clone_dir(missing) is True
+
+
+def test_remove_clone_dir_removes_dir_and_returns_true(mock_workspace_path):
+    """remove_clone_dir removes directory and returns True (no read-only files)."""
+    clone_path = mock_workspace_path / "clones" / "test_repo"
+    clone_path.mkdir(parents=True)
+    (clone_path / "file.txt").write_text("x")
+    result = remove_clone_dir(clone_path)
+    assert result is True
+    assert not clone_path.exists()
+
+
+def test_remove_clone_dir_returns_false_when_rmtree_raises(
+    mock_workspace_path,
+):
+    """remove_clone_dir returns False when shutil.rmtree raises OSError (e.g. file locked)."""
+    clone_path = mock_workspace_path / "clones" / "locked_repo"
+    clone_path.mkdir(parents=True)
+    with patch(
+        "github_activity_tracker.workspace.shutil.rmtree",
+        side_effect=OSError(5, "Access is denied"),
+    ):
+        result = remove_clone_dir(clone_path)
+    assert result is False
+    assert clone_path.exists()

--- a/github_activity_tracker/tests/test_workspace.py
+++ b/github_activity_tracker/tests/test_workspace.py
@@ -170,14 +170,7 @@ def test_get_prs_dir_idempotent(mock_workspace_path):
 def test_get_commit_json_path_returns_commits_sha_json(mock_workspace_path):
     """get_commit_json_path returns .../commits/<sha>.json."""
     path = get_commit_json_path("owner", "repo", "abc123def")
-    assert (
-        path
-        == mock_workspace_path
-        / "owner"
-        / "repo"
-        / "commits"
-        / "abc123def.json"
-    )
+    assert path == mock_workspace_path / "owner" / "repo" / "commits" / "abc123def.json"
 
 
 def test_get_commit_json_path_does_not_create_file(mock_workspace_path):
@@ -200,9 +193,7 @@ def test_get_commit_json_path_consistent(mock_workspace_path):
 def test_get_issue_json_path_returns_issues_num_json(mock_workspace_path):
     """get_issue_json_path returns .../issues/<number>.json."""
     path = get_issue_json_path("owner", "repo", 42)
-    assert (
-        path == mock_workspace_path / "owner" / "repo" / "issues" / "42.json"
-    )
+    assert path == mock_workspace_path / "owner" / "repo" / "issues" / "42.json"
 
 
 def test_get_issue_json_path_integer_number(mock_workspace_path):
@@ -359,10 +350,7 @@ def test_get_raw_source_repo_dir_returns_owner_repo_subdir(
     path = get_raw_source_repo_dir("boostorg", "boost")
     assert (
         path
-        == mock_raw_workspace_path
-        / "github_activity_tracker"
-        / "boostorg"
-        / "boost"
+        == mock_raw_workspace_path / "github_activity_tracker" / "boostorg" / "boost"
     )
     assert path.is_dir()
 
@@ -374,11 +362,7 @@ def test_get_raw_source_commits_dir_returns_commits_subdir(
     path = get_raw_source_commits_dir("o", "r")
     assert (
         path
-        == mock_raw_workspace_path
-        / "github_activity_tracker"
-        / "o"
-        / "r"
-        / "commits"
+        == mock_raw_workspace_path / "github_activity_tracker" / "o" / "r" / "commits"
     )
     assert path.is_dir()
 
@@ -390,11 +374,7 @@ def test_get_raw_source_issues_dir_returns_issues_subdir(
     path = get_raw_source_issues_dir("o", "r")
     assert (
         path
-        == mock_raw_workspace_path
-        / "github_activity_tracker"
-        / "o"
-        / "r"
-        / "issues"
+        == mock_raw_workspace_path / "github_activity_tracker" / "o" / "r" / "issues"
     )
     assert path.is_dir()
 
@@ -403,12 +383,7 @@ def test_get_raw_source_prs_dir_returns_prs_subdir(mock_raw_workspace_path):
     """get_raw_source_prs_dir returns .../<owner>/<repo>/prs/."""
     path = get_raw_source_prs_dir("o", "r")
     assert (
-        path
-        == mock_raw_workspace_path
-        / "github_activity_tracker"
-        / "o"
-        / "r"
-        / "prs"
+        path == mock_raw_workspace_path / "github_activity_tracker" / "o" / "r" / "prs"
     )
     assert path.is_dir()
 

--- a/github_activity_tracker/tests/test_workspace.py
+++ b/github_activity_tracker/tests/test_workspace.py
@@ -443,9 +443,10 @@ def test_get_clones_root_returns_clones_subdir(mock_workspace_path):
 
 
 def test_get_clone_dir_returns_owner_repo_path(mock_workspace_path):
-    """get_clone_dir returns .../clones/{owner}_{repo}."""
+    """get_clone_dir returns .../clones/<owner>/<repo> and creates parent dir."""
     path = get_clone_dir("boostorg", "outcome")
-    assert path == mock_workspace_path / "clones" / "boostorg_outcome"
+    assert path == mock_workspace_path / "clones" / "boostorg" / "outcome"
+    assert path.parent.is_dir()
 
 
 # --- remove_clone_dir (Windows Access denied fix) ---

--- a/github_activity_tracker/workspace.py
+++ b/github_activity_tracker/workspace.py
@@ -5,13 +5,23 @@ Layout: workspace/github_activity_tracker/<owner>/<repo>/
   - commits/<hash>.json
   - issues/<issue_number>.json
   - prs/<pr_number>.json
+  - clones/{owner}_{repo}/ (repo clones for big commits)
 """
 
+import os
+import stat
+import threading
 from pathlib import Path
+
+import shutil
 
 from config.workspace import get_workspace_path
 
 _APP_SLUG = "github_activity_tracker"
+
+# Clone registry: tracks clone paths to delete when run finishes
+_clone_registry: set[Path] = set()
+_clone_registry_lock = threading.Lock()
 
 
 def get_workspace_root() -> Path:
@@ -132,7 +142,9 @@ def get_raw_source_commit_path(owner: str, repo: str, commit_sha: str) -> Path:
     return get_raw_source_commits_dir(owner, repo) / f"{commit_sha}.json"
 
 
-def get_raw_source_issue_path(owner: str, repo: str, issue_number: int) -> Path:
+def get_raw_source_issue_path(
+    owner: str, repo: str, issue_number: int
+) -> Path:
     """Path for raw source issues/<number>.json."""
     return get_raw_source_issues_dir(owner, repo) / f"{issue_number}.json"
 
@@ -140,3 +152,71 @@ def get_raw_source_issue_path(owner: str, repo: str, issue_number: int) -> Path:
 def get_raw_source_pr_path(owner: str, repo: str, pr_number: int) -> Path:
     """Path for raw source prs/<number>.json."""
     return get_raw_source_prs_dir(owner, repo) / f"{pr_number}.json"
+
+
+# --- Clone management for big commits (300+ files) ---
+
+
+def get_clones_root() -> Path:
+    """Return workspace/github_activity_tracker/clones/; creates if missing."""
+    path = get_workspace_root() / "clones"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_clone_dir(owner: str, repo: str) -> Path:
+    """
+    Return clone path for a repo: workspace/.../clones/{owner}_{repo}/.
+    Does NOT create the directory (cloning creates it).
+    """
+    return get_clones_root() / f"{owner}_{repo}"
+
+
+def register_clone(clone_path: Path) -> None:
+    """Register a clone path to be deleted when the run finishes."""
+    with _clone_registry_lock:
+        _clone_registry.add(clone_path)
+
+
+def get_registered_clones() -> list[Path]:
+    """Return list of all registered clone paths (for cleanup)."""
+    with _clone_registry_lock:
+        return list(_clone_registry)
+
+
+def clear_clone_registry() -> None:
+    """Clear the clone registry (called after cleanup)."""
+    with _clone_registry_lock:
+        _clone_registry.clear()
+
+
+def remove_clone_dir(clone_path: Path) -> bool:
+    """
+    Remove a clone directory. Handles Windows read-only and locked files.
+
+    Uses shutil.rmtree with an onerror that clears read-only before retry,
+    so .git/objects pack files (often read-only on Windows) can be deleted.
+
+    Returns True if removed, False if removal failed (e.g. file locked by another process).
+    """
+    if not clone_path.exists():
+        return True
+
+    def _handle_rmtree_error(func, path, exc_info):
+        # Clear read-only so we can remove (common on Windows .git dirs)
+        if not os.access(path, os.W_OK):
+            try:
+                os.chmod(path, stat.S_IWRITE)
+            except OSError:
+                pass
+        try:
+            func(path)
+        except OSError:
+            raise exc_info[1]
+
+    try:
+        shutil.rmtree(clone_path, onerror=_handle_rmtree_error)
+        return True
+    except OSError:
+        # Read-only cleared but file may still be locked (e.g. antivirus, git)
+        return False

--- a/github_activity_tracker/workspace.py
+++ b/github_activity_tracker/workspace.py
@@ -142,9 +142,7 @@ def get_raw_source_commit_path(owner: str, repo: str, commit_sha: str) -> Path:
     return get_raw_source_commits_dir(owner, repo) / f"{commit_sha}.json"
 
 
-def get_raw_source_issue_path(
-    owner: str, repo: str, issue_number: int
-) -> Path:
+def get_raw_source_issue_path(owner: str, repo: str, issue_number: int) -> Path:
     """Path for raw source issues/<number>.json."""
     return get_raw_source_issues_dir(owner, repo) / f"{issue_number}.json"
 

--- a/github_activity_tracker/workspace.py
+++ b/github_activity_tracker/workspace.py
@@ -5,7 +5,7 @@ Layout: workspace/github_activity_tracker/<owner>/<repo>/
   - commits/<hash>.json
   - issues/<issue_number>.json
   - prs/<pr_number>.json
-  - clones/{owner}_{repo}/ (repo clones for big commits)
+  - clones/<owner>/<repo>/ (repo clones for big commits)
 """
 
 import os
@@ -164,10 +164,12 @@ def get_clones_root() -> Path:
 
 def get_clone_dir(owner: str, repo: str) -> Path:
     """
-    Return clone path for a repo: workspace/.../clones/{owner}_{repo}/.
-    Does NOT create the directory (cloning creates it).
+    Return clone path for a repo: workspace/.../clones/<owner>/<repo>/.
+    Creates parent directory (clones/<owner>/) so git clone can create the repo dir.
     """
-    return get_clones_root() / f"{owner}_{repo}"
+    path = get_clones_root() / owner / repo
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 def register_clone(clone_path: Path) -> None:

--- a/github_ops/__init__.py
+++ b/github_ops/__init__.py
@@ -11,6 +11,7 @@ from github_ops.client import (
 from github_ops.git_ops import (
     clone_repo,
     fetch_file_content,
+    get_commit_file_changes,
     push,
     upload_file,
 )
@@ -22,6 +23,7 @@ __all__ = [
     "RateLimitException",
     "clone_repo",
     "fetch_file_content",
+    "get_commit_file_changes",
     "get_github_client",
     "get_github_token",
     "push",

--- a/github_ops/git_ops.py
+++ b/github_ops/git_ops.py
@@ -57,7 +57,14 @@ def clone_repo(
     if depth is not None:
         cmd.extend(["--depth", str(depth)])
     logger.info("Cloning %s -> %s", url_or_slug, dest_dir)
-    subprocess.run(cmd, check=True, capture_output=True, text=True)
+    subprocess.run(
+        cmd,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
 
 
 def push(
@@ -77,6 +84,8 @@ def push(
         ["git", "-C", str(repo_dir), "remote", "get-url", remote],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=True,
     )
     remote_url = result.stdout.strip()
@@ -85,7 +94,14 @@ def push(
     if branch:
         cmd.append(branch)
     logger.info("Pushing %s %s", repo_dir, branch or "(current)")
-    subprocess.run(cmd, check=True, capture_output=True, text=True)
+    subprocess.run(
+        cmd,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
 
 
 def fetch_file_content(
@@ -121,7 +137,9 @@ def upload_file(
     """
     local_file_path = Path(local_file_path)
     if not local_file_path.is_file():
-        logger.error("Local file not found or is a directory: %s", local_file_path)
+        logger.error(
+            "Local file not found or is a directory: %s", local_file_path
+        )
         return None
     if client is None:
         client = get_github_client(use="write")
@@ -150,3 +168,169 @@ def upload_file(
             e,
         )
         return None
+
+
+def get_commit_file_changes(
+    repo_dir: str | Path,
+    parent_sha: str,
+    commit_sha: str,
+    *,
+    patch_size_limit: Optional[int] = None,
+) -> list[dict]:
+    """
+    Get full list of changed files between parent and commit via git diff.
+
+    For initial commits (no parent), pass git's empty tree SHA as parent_sha
+    to get all files as "added" with full patches.
+
+    Returns list of file dicts matching GitHub API 'files' shape:
+    - filename: str
+    - previous_filename: str (for renames)
+    - status: str (added, modified, removed, renamed)
+    - additions: int
+    - deletions: int
+    - patch: str
+
+    Args:
+        repo_dir: Path to cloned repo
+        parent_sha: Parent commit SHA, or empty tree SHA for initial commits
+        commit_sha: Commit SHA
+        patch_size_limit: Optional max chars per patch (None = no limit)
+    """
+    repo_dir = Path(repo_dir)
+
+    # Get file status (A=added, M=modified, D=deleted, R=renamed, etc.)
+    # Use utf-8 encoding so git diff output (e.g. patches) decodes correctly on Windows
+    result_status = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_dir),
+            "diff",
+            "--name-status",
+            f"{parent_sha}..{commit_sha}",
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+
+    # Get additions/deletions per file
+    result_numstat = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_dir),
+            "diff",
+            "--numstat",
+            f"{parent_sha}..{commit_sha}",
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+
+    # Parse status (format: "M\tpath" or "R100\told_path\tnew_path")
+    status_map = {}
+    for line in result_status.stdout.strip().split("\n"):
+        if not line:
+            continue
+        parts = line.split("\t")
+        status_code = parts[0]
+
+        if status_code.startswith("R"):  # Rename
+            old_path = parts[1]
+            new_path = parts[2]
+            status_map[new_path] = ("renamed", old_path)
+        else:
+            path = parts[1]
+            status_name = {
+                "A": "added",
+                "M": "modified",
+                "D": "removed",
+                "C": "copied",
+                "T": "changed",  # Type change
+            }.get(status_code[0], "modified")
+            status_map[path] = (status_name, None)
+
+    # Parse numstat (format: "additions\tdeletions\tpath")
+    numstat_map = {}
+    for line in result_numstat.stdout.strip().split("\n"):
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        adds = parts[0]
+        dels = parts[1]
+        path = parts[2]
+
+        # Handle binary files (marked as "-")
+        additions = 0 if adds == "-" else int(adds)
+        deletions = 0 if dels == "-" else int(dels)
+        numstat_map[path] = (additions, deletions)
+
+    # Build file list
+    files = []
+    for filename, (status, prev_filename) in status_map.items():
+        additions, deletions = numstat_map.get(filename, (0, 0))
+
+        # Get per-file patch
+        patch = ""
+        if (
+            status != "removed"
+        ):  # Can't get patch for removed files in some cases
+            try:
+                result_patch = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(repo_dir),
+                        "diff",
+                        f"{parent_sha}..{commit_sha}",
+                        "--",
+                        filename,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    check=True,
+                    timeout=30,
+                )
+                patch = result_patch.stdout
+
+                # Apply size limit if specified
+                if patch_size_limit and len(patch) > patch_size_limit:
+                    patch = patch[:patch_size_limit] + "\n... (truncated)"
+            except (
+                subprocess.TimeoutExpired,
+                subprocess.CalledProcessError,
+            ) as e:
+                logger.warning("Failed to get patch for %s: %s", filename, e)
+                patch = ""
+
+        file_dict = {
+            "filename": filename,
+            "status": status,
+            "additions": additions,
+            "deletions": deletions,
+            "patch": patch,
+        }
+
+        if prev_filename:
+            file_dict["previous_filename"] = prev_filename
+
+        files.append(file_dict)
+
+    logger.info(
+        "Extracted %d file changes from git diff %s..%s",
+        len(files),
+        parent_sha[:7],
+        commit_sha[:7],
+    )
+    return files

--- a/github_ops/git_ops.py
+++ b/github_ops/git_ops.py
@@ -72,17 +72,21 @@ def clone_repo(
             errors="replace",
             timeout=GIT_CMD_TIMEOUT_SECONDS,
         )
-    except subprocess.TimeoutExpired as e:
+    except subprocess.TimeoutExpired:
         logger.warning(
-            "git clone timed out after %ss (%s -> %s): %s",
+            "git clone timed out after %ss (%s -> %s)",
             GIT_CMD_TIMEOUT_SECONDS,
             url_or_slug,
             dest_dir,
-            e,
         )
         raise
     except subprocess.CalledProcessError as e:
-        logger.warning("git clone failed (%s -> %s): %s", url_or_slug, dest_dir, e)
+        logger.warning(
+            "git clone failed (%s -> %s), returncode=%s",
+            url_or_slug,
+            dest_dir,
+            e.returncode,
+        )
         raise
 
 
@@ -109,16 +113,17 @@ def push(
             check=True,
             timeout=GIT_CMD_TIMEOUT_SECONDS,
         )
-    except subprocess.TimeoutExpired as e:
+    except subprocess.TimeoutExpired:
         logger.warning(
-            "git remote get-url timed out after %ss (%s): %s",
+            "git remote get-url timed out after %ss (%s)",
             GIT_CMD_TIMEOUT_SECONDS,
             repo_dir,
-            e,
         )
         raise
     except subprocess.CalledProcessError as e:
-        logger.warning("git remote get-url failed (%s): %s", repo_dir, e)
+        logger.warning(
+            "git remote get-url failed (%s), returncode=%s", repo_dir, e.returncode
+        )
         raise
     remote_url = result.stdout.strip()
     push_url = _url_with_token(remote_url, token)
@@ -136,16 +141,15 @@ def push(
             errors="replace",
             timeout=GIT_CMD_TIMEOUT_SECONDS,
         )
-    except subprocess.TimeoutExpired as e:
+    except subprocess.TimeoutExpired:
         logger.warning(
-            "git push timed out after %ss (%s): %s",
+            "git push timed out after %ss (%s)",
             GIT_CMD_TIMEOUT_SECONDS,
             repo_dir,
-            e,
         )
         raise
     except subprocess.CalledProcessError as e:
-        logger.warning("git push failed (%s): %s", repo_dir, e)
+        logger.warning("git push failed (%s), returncode=%s", repo_dir, e.returncode)
         raise
 
 

--- a/github_ops/git_ops.py
+++ b/github_ops/git_ops.py
@@ -186,8 +186,8 @@ def get_commit_file_changes(
 
     Returns list of file dicts matching GitHub API 'files' shape:
     - filename: str
-    - previous_filename: str (for renames)
-    - status: str (added, modified, removed, renamed)
+    - previous_filename: str (for renames and copies)
+    - status: str (added, copied, removed, modified, renamed, changed, unmerged, unknown, broken)
     - additions: int
     - deletions: int
     - patch: str
@@ -248,30 +248,41 @@ def get_commit_file_changes(
         )
         raise
 
-    # Parse status (format: "M\tpath" or "R100\told_path\tnew_path")
+    # Parse status (format: "M\tpath" or "R100\told_path\tnew_path" or "C100\told_path\tnew_path")
+    # Git diff --name-status: A=Added, C=Copied, D=Deleted, M=Modified, R=Renamed,
+    # T=type changed, U=Unmerged, X=Unknown, B=Broken pairing.
     status_map = {}
+    _status_names = {
+        "A": "added",
+        "C": "copied",
+        "D": "removed",
+        "M": "modified",
+        "R": "renamed",
+        "T": "changed",  # type (e.g. file → symlink)
+        "U": "unmerged",
+        "X": "unknown",
+        "B": "broken",
+    }
     for line in result_status.stdout.strip().split("\n"):
         if not line:
             continue
         parts = line.split("\t")
         status_code = parts[0]
+        first_char = status_code[0] if status_code else "M"
 
-        if status_code.startswith("R"):  # Rename
+        if first_char in ("R", "C") and len(parts) >= 3:
+            # Rename / Copy: "R100\told_path\tnew_path" or "C100\told_path\tnew_path"
             old_path = parts[1]
             new_path = parts[2]
-            status_map[new_path] = ("renamed", old_path)
+            status_name = _status_names.get(first_char, "modified")
+            status_map[new_path] = (status_name, old_path)
         else:
             path = parts[1]
-            status_name = {
-                "A": "added",
-                "M": "modified",
-                "D": "removed",
-                "C": "copied",
-                "T": "changed",  # Type change
-            }.get(status_code[0], "modified")
+            status_name = _status_names.get(first_char, "modified")
             status_map[path] = (status_name, None)
 
     # Parse numstat (format: "additions\tdeletions\tpath")
+    # For renames, path can be "old => new"; use new path as key to match status_map
     numstat_map = {}
     for line in result_numstat.stdout.strip().split("\n"):
         if not line:
@@ -282,7 +293,8 @@ def get_commit_file_changes(
         adds = parts[0]
         dels = parts[1]
         path = parts[2]
-
+        if " => " in path:
+            path = path.split(" => ", 1)[1].strip()
         # Handle binary files (marked as "-")
         additions = 0 if adds == "-" else int(adds)
         deletions = 0 if dels == "-" else int(dels)

--- a/github_ops/git_ops.py
+++ b/github_ops/git_ops.py
@@ -17,6 +17,9 @@ from github_ops.tokens import get_github_client, get_github_token
 
 logger = logging.getLogger(__name__)
 
+# Timeout (seconds) for top-level git diff subprocess calls (--name-status, --numstat)
+GIT_DIFF_TIMEOUT = 60
+
 
 def _url_with_token(url: str, token: str) -> str:
     """Inject token into GitHub HTTPS URL for auth."""
@@ -193,44 +196,57 @@ def get_commit_file_changes(
         repo_dir: Path to cloned repo
         parent_sha: Parent commit SHA, or empty tree SHA for initial commits
         commit_sha: Commit SHA
-        patch_size_limit: Optional max chars per patch (None = no limit)
+        patch_size_limit: Optional max chars per patch. None or 0 = no limit (fetch full patch).
     """
     repo_dir = Path(repo_dir)
 
     # Get file status (A=added, M=modified, D=deleted, R=renamed, etc.)
     # Use utf-8 encoding so git diff output (e.g. patches) decodes correctly on Windows
-    result_status = subprocess.run(
-        [
-            "git",
-            "-C",
-            str(repo_dir),
-            "diff",
-            "--name-status",
-            f"{parent_sha}..{commit_sha}",
-        ],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=True,
-    )
+    try:
+        result_status = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_dir),
+                "diff",
+                "--name-status",
+                f"{parent_sha}..{commit_sha}",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=True,
+            timeout=GIT_DIFF_TIMEOUT,
+        )
 
-    # Get additions/deletions per file
-    result_numstat = subprocess.run(
-        [
-            "git",
-            "-C",
-            str(repo_dir),
-            "diff",
-            "--numstat",
-            f"{parent_sha}..{commit_sha}",
-        ],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=True,
-    )
+        # Get additions/deletions per file
+        result_numstat = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_dir),
+                "diff",
+                "--numstat",
+                f"{parent_sha}..{commit_sha}",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=True,
+            timeout=GIT_DIFF_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as e:
+        logger.warning(
+            "git diff timed out after %ss (repo_dir=%s, %s..%s): %s",
+            GIT_DIFF_TIMEOUT,
+            repo_dir,
+            parent_sha[:7],
+            commit_sha[:7],
+            e,
+        )
+        raise
 
     # Parse status (format: "M\tpath" or "R100\told_path\tnew_path")
     status_map = {}
@@ -301,7 +317,11 @@ def get_commit_file_changes(
                 patch = result_patch.stdout
 
                 # Apply size limit if specified
-                if patch_size_limit and len(patch) > patch_size_limit:
+                if (
+                    patch_size_limit is not None
+                    and patch_size_limit > 0
+                    and len(patch) > patch_size_limit
+                ):
                     patch = patch[:patch_size_limit] + "\n... (truncated)"
             except (
                 subprocess.TimeoutExpired,
@@ -323,7 +343,7 @@ def get_commit_file_changes(
 
         files.append(file_dict)
 
-    logger.info(
+    logger.debug(
         "Extracted %d file changes from git diff %s..%s",
         len(files),
         parent_sha[:7],

--- a/github_ops/git_ops.py
+++ b/github_ops/git_ops.py
@@ -137,9 +137,7 @@ def upload_file(
     """
     local_file_path = Path(local_file_path)
     if not local_file_path.is_file():
-        logger.error(
-            "Local file not found or is a directory: %s", local_file_path
-        )
+        logger.error("Local file not found or is a directory: %s", local_file_path)
         return None
     if client is None:
         client = get_github_client(use="write")
@@ -281,9 +279,7 @@ def get_commit_file_changes(
 
         # Get per-file patch
         patch = ""
-        if (
-            status != "removed"
-        ):  # Can't get patch for removed files in some cases
+        if status != "removed":  # Can't get patch for removed files in some cases
             try:
                 result_patch = subprocess.run(
                     [

--- a/github_ops/git_ops.py
+++ b/github_ops/git_ops.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 
 # Timeout (seconds) for top-level git diff subprocess calls (--name-status, --numstat)
 GIT_DIFF_TIMEOUT = 60
+# Timeout (seconds) for git clone and push (network I/O)
+GIT_CMD_TIMEOUT_SECONDS = 300
 
 
 def _url_with_token(url: str, token: str) -> str:
@@ -60,14 +62,28 @@ def clone_repo(
     if depth is not None:
         cmd.extend(["--depth", str(depth)])
     logger.info("Cloning %s -> %s", url_or_slug, dest_dir)
-    subprocess.run(
-        cmd,
-        check=True,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GIT_CMD_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as e:
+        logger.warning(
+            "git clone timed out after %ss (%s -> %s): %s",
+            GIT_CMD_TIMEOUT_SECONDS,
+            url_or_slug,
+            dest_dir,
+            e,
+        )
+        raise
+    except subprocess.CalledProcessError as e:
+        logger.warning("git clone failed (%s -> %s): %s", url_or_slug, dest_dir, e)
+        raise
 
 
 def push(
@@ -83,28 +99,54 @@ def push(
     repo_dir = Path(repo_dir)
     if token is None:
         token = get_github_token(use="push")
-    result = subprocess.run(
-        ["git", "-C", str(repo_dir), "remote", "get-url", remote],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_dir), "remote", "get-url", remote],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=True,
+            timeout=GIT_CMD_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as e:
+        logger.warning(
+            "git remote get-url timed out after %ss (%s): %s",
+            GIT_CMD_TIMEOUT_SECONDS,
+            repo_dir,
+            e,
+        )
+        raise
+    except subprocess.CalledProcessError as e:
+        logger.warning("git remote get-url failed (%s): %s", repo_dir, e)
+        raise
     remote_url = result.stdout.strip()
     push_url = _url_with_token(remote_url, token)
     cmd = ["git", "-C", str(repo_dir), "push", push_url]
     if branch:
         cmd.append(branch)
     logger.info("Pushing %s %s", repo_dir, branch or "(current)")
-    subprocess.run(
-        cmd,
-        check=True,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GIT_CMD_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as e:
+        logger.warning(
+            "git push timed out after %ss (%s): %s",
+            GIT_CMD_TIMEOUT_SECONDS,
+            repo_dir,
+            e,
+        )
+        raise
+    except subprocess.CalledProcessError as e:
+        logger.warning("git push failed (%s): %s", repo_dir, e)
+        raise
 
 
 def fetch_file_content(
@@ -294,7 +336,15 @@ def get_commit_file_changes(
         dels = parts[1]
         path = parts[2]
         if " => " in path:
-            path = path.split(" => ", 1)[1].strip()
+            brace_match = re.search(r"\{([^{}]*) => ([^{}]*)\}", path)
+            if brace_match:
+                path = (
+                    path[: brace_match.start()]
+                    + brace_match.group(2)
+                    + path[brace_match.end() :]
+                )
+            else:
+                path = path.split(" => ", 1)[1].strip()
         # Handle binary files (marked as "-")
         additions = 0 if adds == "-" else int(adds)
         deletions = 0 if dels == "-" else int(dels)

--- a/github_ops/tests/test_git_ops.py
+++ b/github_ops/tests/test_git_ops.py
@@ -1,4 +1,4 @@
-"""Tests for github_ops git_ops (clone, push, fetch_file_content)."""
+"""Tests for github_ops git_ops (clone, push, fetch_file_content, get_commit_file_changes)."""
 
 from unittest.mock import MagicMock, patch
 
@@ -6,6 +6,7 @@ from github_ops.git_ops import (
     _url_with_token,
     clone_repo,
     fetch_file_content,
+    get_commit_file_changes,
     push,
 )
 
@@ -185,3 +186,102 @@ def test_fetch_file_content_empty_content_returns_empty_bytes():
     mock_client.get_file_content.return_value = (b"", None)
     out = fetch_file_content("o", "r", "empty", client=mock_client)
     assert out == b""
+
+
+# --- get_commit_file_changes ---
+
+
+def test_get_commit_file_changes_returns_list_of_file_dicts(tmp_path):
+    """get_commit_file_changes returns list of file dicts with filename, status, additions, deletions, patch."""
+    # Mock git diff outputs
+    name_status_output = "M\tREADME.md\nA\tnew_file.txt\nD\told_file.txt"
+    numstat_output = "5\t2\tREADME.md\n10\t0\tnew_file.txt\n0\t3\told_file.txt"
+    patch_output = "diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n@@ patch @@"
+    
+    with patch("github_ops.git_ops.subprocess.run") as run_mock:
+        run_mock.side_effect = [
+            MagicMock(stdout=name_status_output, returncode=0),  # --name-status
+            MagicMock(stdout=numstat_output, returncode=0),  # --numstat
+            MagicMock(stdout=patch_output, returncode=0),  # patch for README.md
+            MagicMock(stdout=patch_output, returncode=0),  # patch for new_file.txt
+            MagicMock(stdout=patch_output, returncode=0),  # patch for old_file.txt
+        ]
+        
+        files = get_commit_file_changes(tmp_path, "parent_sha", "commit_sha")
+    
+    assert len(files) == 3
+    assert all("filename" in f for f in files)
+    assert all("status" in f for f in files)
+    assert all("additions" in f for f in files)
+    assert all("deletions" in f for f in files)
+    assert all("patch" in f for f in files)
+
+
+def test_get_commit_file_changes_maps_status_codes():
+    """get_commit_file_changes maps git status codes (A/M/D/R) to added/modified/removed/renamed."""
+    name_status_output = "A\tadded.txt\nM\tmodified.txt\nD\tremoved.txt\nR100\told.txt\tnew.txt"
+    numstat_output = "1\t0\tadded.txt\n2\t1\tmodified.txt\n0\t1\tremoved.txt\n0\t0\tnew.txt"
+    
+    with patch("github_ops.git_ops.subprocess.run") as run_mock:
+        run_mock.side_effect = [
+            MagicMock(stdout=name_status_output, returncode=0),
+            MagicMock(stdout=numstat_output, returncode=0),
+            MagicMock(stdout="", returncode=0),  # patches
+            MagicMock(stdout="", returncode=0),
+            MagicMock(stdout="", returncode=0),
+            MagicMock(stdout="", returncode=0),
+        ]
+        
+        files = get_commit_file_changes("/fake/path", "parent", "commit")
+    
+    statuses = {f["filename"]: f["status"] for f in files}
+    assert statuses["added.txt"] == "added"
+    assert statuses["modified.txt"] == "modified"
+    assert statuses["removed.txt"] == "removed"
+    assert statuses["new.txt"] == "renamed"
+    
+    # Check rename has previous_filename
+    renamed = [f for f in files if f["filename"] == "new.txt"][0]
+    assert renamed.get("previous_filename") == "old.txt"
+
+
+def test_get_commit_file_changes_applies_patch_size_limit():
+    """get_commit_file_changes truncates patch when patch_size_limit is provided."""
+    name_status_output = "M\tfile.txt"
+    numstat_output = "1\t1\tfile.txt"
+    large_patch = "x" * 1000
+
+    with patch("github_ops.git_ops.subprocess.run") as run_mock:
+        run_mock.side_effect = [
+            MagicMock(stdout=name_status_output, returncode=0),
+            MagicMock(stdout=numstat_output, returncode=0),
+            MagicMock(stdout=large_patch, returncode=0),
+        ]
+
+        files = get_commit_file_changes("/fake", "parent", "commit", patch_size_limit=100)
+
+    assert len(files) == 1
+    assert len(files[0]["patch"]) == 100 + len("\n... (truncated)")  # patch_size_limit + suffix
+    assert files[0]["patch"].endswith("... (truncated)")
+
+
+def test_get_commit_file_changes_uses_utf8_encoding_for_subprocess():
+    """get_commit_file_changes passes encoding=utf-8 and errors=replace to avoid UnicodeDecodeError on Windows."""
+    name_status_output = "M\tfile.txt"
+    numstat_output = "1\t1\tfile.txt"
+    # Patch containing byte that would fail cp1252 decode (e.g. 0x9d)
+    patch_output = "diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt"
+
+    with patch("github_ops.git_ops.subprocess.run") as run_mock:
+        run_mock.side_effect = [
+            MagicMock(stdout=name_status_output, returncode=0),
+            MagicMock(stdout=numstat_output, returncode=0),
+            MagicMock(stdout=patch_output, returncode=0),
+        ]
+        get_commit_file_changes("/fake", "parent", "commit")
+
+    # All subprocess.run calls must use encoding and errors (for git diff output on Windows)
+    for call in run_mock.call_args_list:
+        kwargs = call[1]
+        assert kwargs.get("encoding") == "utf-8"
+        assert kwargs.get("errors") == "replace"

--- a/github_ops/tests/test_git_ops.py
+++ b/github_ops/tests/test_git_ops.py
@@ -197,7 +197,7 @@ def test_get_commit_file_changes_returns_list_of_file_dicts(tmp_path):
     name_status_output = "M\tREADME.md\nA\tnew_file.txt\nD\told_file.txt"
     numstat_output = "5\t2\tREADME.md\n10\t0\tnew_file.txt\n0\t3\told_file.txt"
     patch_output = "diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n@@ patch @@"
-    
+
     with patch("github_ops.git_ops.subprocess.run") as run_mock:
         run_mock.side_effect = [
             MagicMock(stdout=name_status_output, returncode=0),  # --name-status
@@ -206,9 +206,9 @@ def test_get_commit_file_changes_returns_list_of_file_dicts(tmp_path):
             MagicMock(stdout=patch_output, returncode=0),  # patch for new_file.txt
             MagicMock(stdout=patch_output, returncode=0),  # patch for old_file.txt
         ]
-        
+
         files = get_commit_file_changes(tmp_path, "parent_sha", "commit_sha")
-    
+
     assert len(files) == 3
     assert all("filename" in f for f in files)
     assert all("status" in f for f in files)
@@ -219,9 +219,13 @@ def test_get_commit_file_changes_returns_list_of_file_dicts(tmp_path):
 
 def test_get_commit_file_changes_maps_status_codes():
     """get_commit_file_changes maps git status codes (A/M/D/R) to added/modified/removed/renamed."""
-    name_status_output = "A\tadded.txt\nM\tmodified.txt\nD\tremoved.txt\nR100\told.txt\tnew.txt"
-    numstat_output = "1\t0\tadded.txt\n2\t1\tmodified.txt\n0\t1\tremoved.txt\n0\t0\tnew.txt"
-    
+    name_status_output = (
+        "A\tadded.txt\nM\tmodified.txt\nD\tremoved.txt\nR100\told.txt\tnew.txt"
+    )
+    numstat_output = (
+        "1\t0\tadded.txt\n2\t1\tmodified.txt\n0\t1\tremoved.txt\n0\t0\tnew.txt"
+    )
+
     with patch("github_ops.git_ops.subprocess.run") as run_mock:
         run_mock.side_effect = [
             MagicMock(stdout=name_status_output, returncode=0),
@@ -231,15 +235,15 @@ def test_get_commit_file_changes_maps_status_codes():
             MagicMock(stdout="", returncode=0),
             MagicMock(stdout="", returncode=0),
         ]
-        
+
         files = get_commit_file_changes("/fake/path", "parent", "commit")
-    
+
     statuses = {f["filename"]: f["status"] for f in files}
     assert statuses["added.txt"] == "added"
     assert statuses["modified.txt"] == "modified"
     assert statuses["removed.txt"] == "removed"
     assert statuses["new.txt"] == "renamed"
-    
+
     # Check rename has previous_filename
     renamed = [f for f in files if f["filename"] == "new.txt"][0]
     assert renamed.get("previous_filename") == "old.txt"
@@ -258,10 +262,14 @@ def test_get_commit_file_changes_applies_patch_size_limit():
             MagicMock(stdout=large_patch, returncode=0),
         ]
 
-        files = get_commit_file_changes("/fake", "parent", "commit", patch_size_limit=100)
+        files = get_commit_file_changes(
+            "/fake", "parent", "commit", patch_size_limit=100
+        )
 
     assert len(files) == 1
-    assert len(files[0]["patch"]) == 100 + len("\n... (truncated)")  # patch_size_limit + suffix
+    assert len(files[0]["patch"]) == 100 + len(
+        "\n... (truncated)"
+    )  # patch_size_limit + suffix
     assert files[0]["patch"].endswith("... (truncated)")
 
 

--- a/github_ops/tests/test_git_ops.py
+++ b/github_ops/tests/test_git_ops.py
@@ -273,6 +273,25 @@ def test_get_commit_file_changes_applies_patch_size_limit():
     assert files[0]["patch"].endswith("... (truncated)")
 
 
+def test_get_commit_file_changes_patch_size_limit_zero_means_no_truncation():
+    """patch_size_limit=0 should behave like None (no truncation)."""
+    name_status_output = "M\tfile.txt"
+    numstat_output = "1\t1\tfile.txt"
+    large_patch = "x" * 1000
+
+    with patch("github_ops.git_ops.subprocess.run") as run_mock:
+        run_mock.side_effect = [
+            MagicMock(stdout=name_status_output, returncode=0),
+            MagicMock(stdout=numstat_output, returncode=0),
+            MagicMock(stdout=large_patch, returncode=0),
+        ]
+
+        files = get_commit_file_changes("/fake", "parent", "commit", patch_size_limit=0)
+
+    assert files[0]["patch"] == large_patch
+    assert not files[0]["patch"].endswith("... (truncated)")
+
+
 def test_get_commit_file_changes_uses_utf8_encoding_for_subprocess():
     """get_commit_file_changes passes encoding=utf-8 and errors=replace to avoid UnicodeDecodeError on Windows."""
     name_status_output = "M\tfile.txt"

--- a/github_ops/tests/test_git_ops.py
+++ b/github_ops/tests/test_git_ops.py
@@ -249,6 +249,31 @@ def test_get_commit_file_changes_maps_status_codes():
     assert renamed.get("previous_filename") == "old.txt"
 
 
+def test_get_commit_file_changes_brace_style_rename_numstat_path():
+    """Numstat brace-style paths like src/{old => new}/file.txt are normalized to src/new/file.txt for lookup."""
+    # --name-status: rename from src/old/file.txt to src/new/file.txt (key is new path)
+    name_status_output = "R100\tsrc/old/file.txt\tsrc/new/file.txt"
+    # --numstat: git uses brace notation for directory renames
+    numstat_output = "3\t2\tsrc/{old => new}/file.txt"
+
+    with patch("github_ops.git_ops.subprocess.run") as run_mock:
+        run_mock.side_effect = [
+            MagicMock(stdout=name_status_output, returncode=0),
+            MagicMock(stdout=numstat_output, returncode=0),
+            MagicMock(stdout="", returncode=0),  # patch for src/new/file.txt
+        ]
+
+        files = get_commit_file_changes("/fake/path", "parent", "commit")
+
+    assert len(files) == 1
+    assert files[0]["filename"] == "src/new/file.txt"
+    assert files[0]["status"] == "renamed"
+    assert files[0]["previous_filename"] == "src/old/file.txt"
+    # Additions/deletions must come from numstat (not fallback 0,0)
+    assert files[0]["additions"] == 3
+    assert files[0]["deletions"] == 2
+
+
 def test_get_commit_file_changes_applies_patch_size_limit():
     """get_commit_file_changes truncates patch when patch_size_limit is provided."""
     name_status_output = "M\tfile.txt"


### PR DESCRIPTION
## Solution
- **&lt;300 files**: Unchanged. We keep using the commit API response for file changes (and for commit/author metadata).
- **More than or equal 300 files**: We treat the response as truncated. For those commits we clone the repository (or use an existing clone) and derive the full list of changed files via git (e.g. git show --name-status or equivalent). We still use the commit API for author and other commit metadata; only the file list is taken from git when we detect truncation.
So we continue to rely on GitHub for author info and only use a local git clone to recover the full set of file changes when the API caps at 300.

## Expected behavior
For every synced commit, we record all file changes, not only the first 300. Commits with fewer than 300 files behave as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for commits with 300+ file changes, recovering complete file lists that were previously truncated.
  * Added backfill capability to recover and resync complete file information for previously affected commits.

* **Bug Fixes**
  * Improved database data integrity by removing invalid NUL characters from filenames and patch data.
  * Added timeout protection for repository operations to prevent system hangs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->