### PR TITLE
Fix: logger in celery work - #111

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -27,11 +27,6 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
 
 
-_app_log_level = getattr(settings, "LOG_LEVEL", "INFO")
-app.conf.worker_log_level = _app_log_level
-app.conf.beat_log_level = _app_log_level
-
-
 @setup_logging.connect
 def on_celery_setup_logging(**kwargs):
     """Apply Django LOGGING so Celery worker/beat use the same log file and handlers."""

--- a/config/celery.py
+++ b/config/celery.py
@@ -4,18 +4,40 @@ Beat schedule is in settings.CELERY_BEAT_SCHEDULE (daily 1:00 AM PST).
 
 On Windows the default worker pool (prefork) causes PermissionError [WinError 5].
 Use the solo pool on Windows so tasks run in the main process.
+
+Logging: use Django LOGGING so worker/beat log to the same file and handlers as
+management commands (console + rotating file, and optional Discord/Slack on ERROR).
 """
 
 import os
 import sys
 
+# Logger level follows Django LOG_LEVEL (worker and beat).
+from django.conf import settings
+
+from logging.config import dictConfig
+
 from celery import Celery
+from celery.signals import setup_logging
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
 app = Celery("config")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
+
+
+_app_log_level = getattr(settings, "LOG_LEVEL", "INFO")
+app.conf.worker_log_level = _app_log_level
+app.conf.beat_log_level = _app_log_level
+
+
+@setup_logging.connect
+def on_celery_setup_logging(**kwargs):
+    """Apply Django LOGGING so Celery worker/beat use the same log file and handlers."""
+    if hasattr(settings, "LOGGING") and settings.LOGGING:
+        dictConfig(settings.LOGGING)
+
 
 # Avoid PermissionError on Windows: prefork pool uses semaphores that fail there.
 if sys.platform == "win32":

--- a/config/settings.py
+++ b/config/settings.py
@@ -312,8 +312,11 @@ LOGGING = {
         "level": LOG_LEVEL,
     },
     "loggers": {
-        # Celery internals (bootsteps, timer, consumer) are noisy at DEBUG; use INFO.
-        "celery": {"level": "INFO", "propagate": True},
+        # Celery internals (bootsteps, timer, consumer) are noisy at DEBUG; use INFO only then.
+        "celery": {
+            "level": "INFO" if LOG_LEVEL == "DEBUG" else LOG_LEVEL,
+            "propagate": True,
+        },
     },
 }
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -311,6 +311,10 @@ LOGGING = {
         "handlers": ["console", "file"],
         "level": LOG_LEVEL,
     },
+    "loggers": {
+        # Celery internals (bootsteps, timer, consumer) are noisy at DEBUG; use INFO.
+        "celery": {"level": "INFO", "propagate": True},
+    },
 }
 
 # Celery


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Background workers now use the application's logging configuration, reducing noisy output while preserving important messages.
  * Added a dedicated logger for background task processing with moderate verbosity to improve observability without changing task behavior or error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->