### PR TITLE
Add Slack pinecone preprocessor in cppa_slack_tracker app (#116)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,15 +84,27 @@ DATABASE_URL=postgres://user:password@localhost:5432/boost_dashboard
 # GITHUB_TOKEN_WRITE=ghp_xxxx
 
 # =============================================================================
-# Pinecone (cppa_pinecone_sync)
+# Pinecone (cppa_pinecone_sync) - vector index for RAG (Slack, mailing list, etc.)
 # =============================================================================
+# Required for sync: set PINECONE_INDEX_NAME and PINECONE_API_KEY to enable sync.
 # Public API key (default). Used when --pinecone-instance=public or unset.
 # PINECONE_API_KEY=pc-xxxx
 # Private API key. Used when --pinecone-instance=private.
 # PINECONE_PRIVATE_API_KEY=pc-xxxx
+# Index name (required). Must be set for run_cppa_slack_tracker / run_cppa_pinecone_sync.
 # PINECONE_INDEX_NAME=boost-dashboard
+# Region and cloud (defaults: us-east-1, aws).
 # PINECONE_ENVIRONMENT=us-east-1
 # PINECONE_CLOUD=aws
+# Optional: chunking and validation (defaults shown).
+# PINECONE_BATCH_SIZE=96
+# PINECONE_CHUNK_SIZE=1000
+# PINECONE_CHUNK_OVERLAP=200
+# PINECONE_MIN_TEXT_LENGTH=50
+# PINECONE_MIN_WORDS=5
+# Optional: embedding models (defaults: multilingual-e5-large, pinecone-sparse-english-v0).
+# PINECONE_DENSE_MODEL=multilingual-e5-large
+# PINECONE_SPARSE_MODEL=pinecone-sparse-english-v0
 
 # =============================================================================
 # Boost Usage Tracker

--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,10 @@ DATABASE_URL=postgres://user:password@localhost:5432/boost_dashboard
 # PINECONE_CHUNK_OVERLAP=200
 # PINECONE_MIN_TEXT_LENGTH=50
 # PINECONE_MIN_WORDS=5
+# Slack Pinecone namespace prefix (namespace = {prefix}-{team_name}). Default: slack.
+# PINECONE_SLACK_NAMESPACE_PREFIX=slack
+# Slack Pinecone app_type prefix (app_type = {prefix}-{team_name}). Default: slack.
+# PINECONE_SLACK_APP_TYPE_PREFIX=slack
 # Optional: embedding models (defaults: multilingual-e5-large, pinecone-sparse-english-v0).
 # PINECONE_DENSE_MODEL=multilingual-e5-large
 # PINECONE_SPARSE_MODEL=pinecone-sparse-english-v0

--- a/clang_github_tracker/sync_raw.py
+++ b/clang_github_tracker/sync_raw.py
@@ -118,7 +118,10 @@ def sync_raw_only(
         for issue_data in fetcher.fetch_issues_from_github(
             client, owner, repo, start_issue, end_date
         ):
-            if issue_data.get("number") is not None:
+            issue_number = issue_data.get("number") or (
+                issue_data.get("issue_info") or {}
+            ).get("number")
+            if issue_number is not None:
                 save_issue_raw_source(owner, repo, issue_data)
                 issues_saved += 1
                 dt = _issue_date(issue_data)
@@ -131,7 +134,10 @@ def sync_raw_only(
         for pr_data in fetcher.fetch_pull_requests_from_github(
             client, owner, repo, start_pr, end_date
         ):
-            if pr_data.get("number") is not None:
+            pr_number = (pr_data.get("pr_info") or {}).get("number") or pr_data.get(
+                "number"
+            )
+            if pr_number is not None:
                 save_pr_raw_source(owner, repo, pr_data)
                 prs_saved += 1
                 dt = _pr_date(pr_data)

--- a/config/boost_collector_schedule.yaml.example
+++ b/config/boost_collector_schedule.yaml.example
@@ -25,11 +25,11 @@ groups:
       # Weekly: run every Monday at 16:10
       - command: run_weekly_report
         schedule: weekly
-        on: monday
+        "on": monday
       # Monthly: run on the 1st at 16:10
       - command: run_monthly_aggregate
         schedule: monthly
-        on: 1
+        "on": 1
       # When a new Boost release is published
       - command: run_boost_library_tracker
         schedule: on_release

--- a/config/logging_handlers.py
+++ b/config/logging_handlers.py
@@ -1,11 +1,20 @@
 """
-Custom logging handlers for Discord and Slack notifications.
-Automatically sends error logs to configured channels.
+Custom logging handlers for the Boost Data Collector project.
+
+SafeRotatingFileHandler: RotatingFileHandler that serializes emit() with a lock
+so rollover (close → rename → reopen) is not run while another thread is writing.
+Fixes PermissionError [WinError 32] on Windows when multiple threads log to the
+same file (e.g. Celery worker + ThreadPoolExecutor workers in boost_searcher).
+
+DiscordHandler / SlackHandler: send ERROR-level log records to Discord/Slack
+webhooks when ENABLE_ERROR_NOTIFICATIONS is True and webhook URLs are set.
 """
 
 import json
 import logging
+import logging.handlers
 import sys
+import threading
 import time
 import traceback
 from datetime import datetime, timezone
@@ -230,3 +239,20 @@ class SlackHandler(logging.Handler):
         except Exception as e:
             # Prevent handler from breaking the logging system
             sys.stderr.write(f"Error in SlackHandler: {e}\n")
+
+
+class SafeRotatingFileHandler(logging.handlers.RotatingFileHandler):
+    """
+    Thread-safe RotatingFileHandler. Use this when multiple threads write to
+    the same log file (e.g. Celery + thread pools). On Windows, the standard
+    RotatingFileHandler can raise PermissionError during rollover because
+    os.rename() fails if the file is still open by another thread.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._emit_lock = threading.Lock()
+
+    def emit(self, record):
+        with self._emit_lock:
+            super().emit(record)

--- a/config/settings.py
+++ b/config/settings.py
@@ -426,6 +426,37 @@ except Exception:
     )
     CELERY_BEAT_SCHEDULE = {}
 
+# =============================================================================
+# Pinecone (cppa_pinecone_sync) - vector index for RAG sync
+# =============================================================================
+# Public API key (default). Used when instance=public or unset.
+PINECONE_API_KEY = (env("PINECONE_API_KEY", default="") or "").strip()
+# Private API key. Used when instance=private.
+PINECONE_PRIVATE_API_KEY = (
+    env("PINECONE_PRIVATE_API_KEY", default="") or ""
+).strip()
+# Index name (required for sync). Set in .env to enable Slack/mailing list → Pinecone.
+PINECONE_INDEX_NAME = (env("PINECONE_INDEX_NAME", default="") or "").strip()
+PINECONE_ENVIRONMENT = (
+    env("PINECONE_ENVIRONMENT", default="us-east-1") or "us-east-1"
+).strip()
+PINECONE_CLOUD = (env("PINECONE_CLOUD", default="aws") or "aws").strip()
+PINECONE_BATCH_SIZE = int(env("PINECONE_BATCH_SIZE", default="96") or "96")
+PINECONE_CHUNK_SIZE = int(env("PINECONE_CHUNK_SIZE", default="1000") or "1000")
+PINECONE_CHUNK_OVERLAP = int(env("PINECONE_CHUNK_OVERLAP", default="200") or "200")
+PINECONE_MIN_TEXT_LENGTH = int(
+    env("PINECONE_MIN_TEXT_LENGTH", default="50") or "50"
+)
+PINECONE_MIN_WORDS = int(env("PINECONE_MIN_WORDS", default="5") or "5")
+PINECONE_DENSE_MODEL = (
+    env("PINECONE_DENSE_MODEL", default="multilingual-e5-large")
+    or "multilingual-e5-large"
+).strip()
+PINECONE_SPARSE_MODEL = (
+    env("PINECONE_SPARSE_MODEL", default="pinecone-sparse-english-v0")
+    or "pinecone-sparse-english-v0"
+).strip()
+
 # GitHub activity tracker: Redis for ETag cache (conditional GET). Use separate DB index.
 # To persist the cache across restarts, enable Redis persistence (RDB or AOF) in redis.conf:
 #   RDB: leave default "save" rules (e.g. save 900 1) and set dir/dbfilename.

--- a/config/settings.py
+++ b/config/settings.py
@@ -432,9 +432,7 @@ except Exception:
 # Public API key (default). Used when instance=public or unset.
 PINECONE_API_KEY = (env("PINECONE_API_KEY", default="") or "").strip()
 # Private API key. Used when instance=private.
-PINECONE_PRIVATE_API_KEY = (
-    env("PINECONE_PRIVATE_API_KEY", default="") or ""
-).strip()
+PINECONE_PRIVATE_API_KEY = (env("PINECONE_PRIVATE_API_KEY", default="") or "").strip()
 # Index name (required for sync). Set in .env to enable Slack/mailing list → Pinecone.
 PINECONE_INDEX_NAME = (env("PINECONE_INDEX_NAME", default="") or "").strip()
 PINECONE_ENVIRONMENT = (
@@ -444,9 +442,7 @@ PINECONE_CLOUD = (env("PINECONE_CLOUD", default="aws") or "aws").strip()
 PINECONE_BATCH_SIZE = int(env("PINECONE_BATCH_SIZE", default="96") or "96")
 PINECONE_CHUNK_SIZE = int(env("PINECONE_CHUNK_SIZE", default="1000") or "1000")
 PINECONE_CHUNK_OVERLAP = int(env("PINECONE_CHUNK_OVERLAP", default="200") or "200")
-PINECONE_MIN_TEXT_LENGTH = int(
-    env("PINECONE_MIN_TEXT_LENGTH", default="50") or "50"
-)
+PINECONE_MIN_TEXT_LENGTH = int(env("PINECONE_MIN_TEXT_LENGTH", default="50") or "50")
 PINECONE_MIN_WORDS = int(env("PINECONE_MIN_WORDS", default="5") or "5")
 PINECONE_DENSE_MODEL = (
     env("PINECONE_DENSE_MODEL", default="multilingual-e5-large")

--- a/config/settings.py
+++ b/config/settings.py
@@ -315,7 +315,10 @@ SLACK_PR_BOT_CHANNEL_NAME = (
     env("SLACK_PR_BOT_CHANNEL_NAME", default="slack-bot") or "slack-bot"
 ).strip()
 SLACK_PR_BOT_COMMENT_TEMPLATE = (
-    env("SLACK_PR_BOT_COMMENT_TEMPLATE", default="Automated comment from Slack bot.")
+    env(
+        "SLACK_PR_BOT_COMMENT_TEMPLATE",
+        default="Automated comment from Slack bot.",
+    )
     or ""
 ).strip() or "Automated comment from Slack bot."
 SLACK_PR_BOT_COMMENTS_MAX_PER_WINDOW = int(
@@ -376,7 +379,7 @@ LOGGING = {
             "formatter": "verbose",
         },
         "file": {
-            "class": "logging.handlers.RotatingFileHandler",
+            "class": "config.logging_handlers.SafeRotatingFileHandler",
             "filename": str(_LOG_FILE_PATH),
             "maxBytes": LOG_MAX_BYTES,
             "backupCount": LOG_BACKUP_COUNT,
@@ -409,7 +412,7 @@ CELERY_RESULT_BACKEND = env(
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
-CELERY_TIMEZONE = "America/Los_Angeles"
+# CELERY_TIMEZONE = "America/Los_Angeles"
 CELERY_ENABLE_UTC = True  # Beat schedule times (default_time from YAML) are UTC
 
 # Schedule from YAML (boost_collector_runner); on load error fall back to empty beat schedule ({})

--- a/config/settings.py
+++ b/config/settings.py
@@ -447,6 +447,12 @@ PINECONE_CHUNK_SIZE = int(env("PINECONE_CHUNK_SIZE", default="1000") or "1000")
 PINECONE_CHUNK_OVERLAP = int(env("PINECONE_CHUNK_OVERLAP", default="200") or "200")
 PINECONE_MIN_TEXT_LENGTH = int(env("PINECONE_MIN_TEXT_LENGTH", default="50") or "50")
 PINECONE_MIN_WORDS = int(env("PINECONE_MIN_WORDS", default="5") or "5")
+PINECONE_SLACK_NAMESPACE_PREFIX = (
+    env("PINECONE_SLACK_NAMESPACE_PREFIX", default="slack") or "slack"
+).strip()
+PINECONE_SLACK_APP_TYPE_PREFIX = (
+    env("PINECONE_SLACK_APP_TYPE_PREFIX", default="slack") or "slack"
+).strip()
 PINECONE_DENSE_MODEL = (
     env("PINECONE_DENSE_MODEL", default="multilingual-e5-large")
     or "multilingual-e5-large"

--- a/cppa_pinecone_sync/ingestion.py
+++ b/cppa_pinecone_sync/ingestion.py
@@ -74,6 +74,7 @@ class PineconeIngestion:
             settings, "PINECONE_SPARSE_MODEL", "pinecone-sparse-english-v0"
         )
 
+        self._validate_config()
         self._setup_client()
         self._initialize_text_splitter()
         self._setup_indexes()
@@ -95,6 +96,26 @@ class PineconeIngestion:
     # ------------------------------------------------------------------
     # Initialization helpers
     # ------------------------------------------------------------------
+
+    def _validate_config(self) -> None:
+        """Ensure required Pinecone settings are set; raise ValueError with clear message if not."""
+        if not (self.index_name or "").strip():
+            raise ValueError(
+                "PINECONE_INDEX_NAME is not set or is empty. "
+                "Set PINECONE_INDEX_NAME in .env (e.g. PINECONE_INDEX_NAME=boost-dashboard) "
+                "to enable Pinecone sync."
+            )
+        active_key = self._active_api_key
+        if not (active_key or "").strip():
+            key_name = (
+                "PINECONE_PRIVATE_API_KEY"
+                if self.instance == PineconeInstance.PRIVATE
+                else "PINECONE_API_KEY"
+            )
+            raise ValueError(
+                f"{key_name} is not set or is empty. "
+                f"Set {key_name}=pc-xxxx in .env to enable Pinecone sync."
+            )
 
     @staticmethod
     def _validate_imports() -> None:

--- a/cppa_pinecone_sync/ingestion.py
+++ b/cppa_pinecone_sync/ingestion.py
@@ -74,7 +74,6 @@ class PineconeIngestion:
             settings, "PINECONE_SPARSE_MODEL", "pinecone-sparse-english-v0"
         )
 
-        self._validate_config()
         self._setup_client()
         self._initialize_text_splitter()
         self._setup_indexes()
@@ -166,6 +165,8 @@ class PineconeIngestion:
 
     def _get_or_create_indexes(self) -> None:
         """Get existing indexes or create new ones."""
+        self._validate_config()
+
         if self._dense_index_initialized and self._sparse_index_initialized:
             return
 
@@ -194,7 +195,9 @@ class PineconeIngestion:
         self, existing_indexes: set, dense_name: str, sparse_name: str
     ) -> None:
         logger.info(
-            "Creating indexes: %s (dense) and %s (sparse)", dense_name, sparse_name
+            "Creating indexes: %s (dense) and %s (sparse)",
+            dense_name,
+            sparse_name,
         )
         if self.pc is None:
             raise RuntimeError("Pinecone client not initialized")
@@ -384,7 +387,8 @@ class PineconeIngestion:
         record_idx: int,
     ) -> str:
         original_doc_id = metadata.get(
-            "doc_id", metadata.get("url", f"doc_{batch_start_idx}_{record_idx}")
+            "doc_id",
+            metadata.get("url", f"doc_{batch_start_idx}_{record_idx}"),
         )
         if "start_index" in metadata:
             original_doc_id = f"{original_doc_id}_{metadata['start_index']}"
@@ -611,9 +615,15 @@ class PineconeIngestion:
                 logger.error(error_msg)
                 errors.append(error_msg)
 
-        result = {"deleted": total_deleted, "total": len(ids), "errors": errors}
+        result = {
+            "deleted": total_deleted,
+            "total": len(ids),
+            "errors": errors,
+        }
         logger.info(
-            "Delete complete: %d/%d documents", result["deleted"], result["total"]
+            "Delete complete: %d/%d documents",
+            result["deleted"],
+            result["total"],
         )
         return result
 
@@ -640,7 +650,10 @@ class PineconeIngestion:
             index.delete(ids=ids, namespace=namespace)
         except Exception as e:
             logger.error(
-                "Failed to delete batch %d from %s index: %s", batch_num, index_type, e
+                "Failed to delete batch %d from %s index: %s",
+                batch_num,
+                index_type,
+                e,
             )
             raise
 
@@ -649,7 +662,9 @@ class PineconeIngestion:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _format_single_index_stats(stats_dict: dict[str, Any]) -> dict[str, Any]:
+    def _format_single_index_stats(
+        stats_dict: dict[str, Any],
+    ) -> dict[str, Any]:
         """Format one index's describe_index_stats() into a standard dict."""
         return {
             "total_vectors": stats_dict.get("total_vector_count", 0),

--- a/cppa_slack_tracker/management/commands/run_cppa_slack_tracker.py
+++ b/cppa_slack_tracker/management/commands/run_cppa_slack_tracker.py
@@ -138,24 +138,24 @@ class Command(BaseCommand):
         # --sync-channel-users, and --sync-messages runs its corresponding sync
         # when set; multiple flags can be combined. If none are set, default to
         # syncing users, channels, and messages.
-        # if options.get("sync_users"):
-        #     self.sync_users(options, team)
-        # if options.get("sync_channels"):
-        #     self.sync_channels(options, team)
-        # if options.get("sync_channel_users"):
-        #     self.sync_channel_users(options, team)
-        # if options.get("sync_messages"):
-        #     self.sync_messages(options, team)
+        if options.get("sync_users"):
+            self.sync_users(options, team)
+        if options.get("sync_channels"):
+            self.sync_channels(options, team)
+        if options.get("sync_channel_users"):
+            self.sync_channel_users(options, team)
+        if options.get("sync_messages"):
+            self.sync_messages(options, team)
 
-        # if (
-        #     not options.get("sync_users")
-        #     and not options.get("sync_channels")
-        #     and not options.get("sync_channel_users")
-        #     and not options.get("sync_messages")
-        # ):
-        #     self.sync_users(options, team)
-        #     self.sync_channels(options, team)
-        #     self.sync_messages(options, team)
+        if (
+            not options.get("sync_users")
+            and not options.get("sync_channels")
+            and not options.get("sync_channel_users")
+            and not options.get("sync_messages")
+        ):
+            self.sync_users(options, team)
+            self.sync_channels(options, team)
+            self.sync_messages(options, team)
 
         # Sync to Pinecone after message sync (unless --ignore-pinecone is set)
         if not options.get("ignore_pinecone"):
@@ -435,5 +435,7 @@ class Command(BaseCommand):
                 "Install with: pip install pinecone langchain-text-splitters langchain-core",
                 e,
             )
+        except ValueError as e:
+            logger.warning("Pinecone sync skipped: %s", e)
         except Exception:
             logger.exception("Error during Pinecone sync")

--- a/cppa_slack_tracker/management/commands/run_cppa_slack_tracker.py
+++ b/cppa_slack_tracker/management/commands/run_cppa_slack_tracker.py
@@ -387,9 +387,10 @@ class Command(BaseCommand):
                 team.team_id,
             )
 
-            namespace = f"slack-{team.team_name}"
+            namespace = f"{settings.PINECONE_SLACK_NAMESPACE_PREFIX}-{team.team_name}"
+            app_type = f"{settings.PINECONE_SLACK_APP_TYPE_PREFIX}-{team.team_name}"
             result = sync_to_pinecone(
-                app_type="slack",
+                app_type=app_type,
                 namespace=namespace,
                 preprocess_fn=preprocess_slack_for_pinecone,
                 instance=PineconeInstance.PUBLIC,

--- a/cppa_slack_tracker/management/commands/run_cppa_slack_tracker.py
+++ b/cppa_slack_tracker/management/commands/run_cppa_slack_tracker.py
@@ -42,9 +42,7 @@ def _parse_date(date_str: Optional[str]) -> Optional[datetime]:
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
             return dt.astimezone(timezone.utc)
-        return datetime.strptime(date_str, "%Y-%m-%d").replace(
-            tzinfo=timezone.utc
-        )
+        return datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
     except ValueError:
         return None
 
@@ -180,27 +178,17 @@ class Command(BaseCommand):
         if options.get("sync_channels"):
             logger.info(
                 "  Would run: sync channels%s",
-                (
-                    f" (channel_id={channel_id})"
-                    if channel_id
-                    else " (all channels)"
-                ),
+                (f" (channel_id={channel_id})" if channel_id else " (all channels)"),
             )
             printed = True
         if options.get("sync_channel_users"):
             logger.info(
                 "  Would run: sync channel memberships%s",
-                (
-                    f" (channel_id={channel_id})"
-                    if channel_id
-                    else " (all channels)"
-                ),
+                (f" (channel_id={channel_id})" if channel_id else " (all channels)"),
             )
             printed = True
         if options.get("sync_messages"):
-            start_str = (
-                options.get("start_date") or ""
-            ).strip() or "from DB or today"
+            start_str = (options.get("start_date") or "").strip() or "from DB or today"
             end_str = (options.get("end_date") or "").strip() or "today"
             logger.info(
                 "  Would run: sync messages (start=%s, end=%s)",
@@ -215,15 +203,11 @@ class Command(BaseCommand):
             printed = True
         if printed:
             return
-        logger.info(
-            "  Would run: sync users, channels, and messages (default)"
-        )
+        logger.info("  Would run: sync users, channels, and messages (default)")
         logger.info("    channel memberships require --sync-channel-users")
         if channel_id:
             logger.info("    (channel_id=%s)", channel_id)
-        start_str = (
-            options.get("start_date") or ""
-        ).strip() or "from DB or today"
+        start_str = (options.get("start_date") or "").strip() or "from DB or today"
         end_str = (options.get("end_date") or "").strip() or "today"
         logger.info("    start=%s, end=%s", start_str, end_str)
         if options.get("messages_json"):
@@ -297,9 +281,7 @@ class Command(BaseCommand):
                     data = json.load(f)
                 _append_payload(data)
             except (OSError, json.JSONDecodeError):
-                logger.exception(
-                    "Failed to load legacy messages JSON: %s", path
-                )
+                logger.exception("Failed to load legacy messages JSON: %s", path)
         elif os.path.isdir(path):
             for name in sorted(os.listdir(path)):
                 if name.endswith(".json"):
@@ -329,9 +311,7 @@ class Command(BaseCommand):
 
         start_date_str = (options.get("start_date") or "").strip() or None
         end_date_str = (options.get("end_date") or "").strip() or None
-        messages_json_path = (
-            options.get("messages_json") or ""
-        ).strip() or None
+        messages_json_path = (options.get("messages_json") or "").strip() or None
 
         start_dt = _parse_date(start_date_str)
         end_dt = _parse_date(end_date_str)

--- a/cppa_slack_tracker/management/commands/run_cppa_slack_tracker.py
+++ b/cppa_slack_tracker/management/commands/run_cppa_slack_tracker.py
@@ -42,7 +42,9 @@ def _parse_date(date_str: Optional[str]) -> Optional[datetime]:
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
             return dt.astimezone(timezone.utc)
-        return datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        return datetime.strptime(date_str, "%Y-%m-%d").replace(
+            tzinfo=timezone.utc
+        )
     except ValueError:
         return None
 
@@ -109,6 +111,11 @@ class Command(BaseCommand):
             action="store_true",
             help="Print what would be synced without making changes.",
         )
+        parser.add_argument(
+            "--ignore-pinecone",
+            action="store_true",
+            help="Skip Pinecone sync after message sync (default: sync to Pinecone)",
+        )
 
     def handle(self, *_args, **options):
         """Run the requested sync(s) for the given team (and optional channel)."""
@@ -131,24 +138,33 @@ class Command(BaseCommand):
         # --sync-channel-users, and --sync-messages runs its corresponding sync
         # when set; multiple flags can be combined. If none are set, default to
         # syncing users, channels, and messages.
-        if options.get("sync_users"):
-            self.sync_users(options, team)
-        if options.get("sync_channels"):
-            self.sync_channels(options, team)
-        if options.get("sync_channel_users"):
-            self.sync_channel_users(options, team)
-        if options.get("sync_messages"):
-            self.sync_messages(options, team)
+        # if options.get("sync_users"):
+        #     self.sync_users(options, team)
+        # if options.get("sync_channels"):
+        #     self.sync_channels(options, team)
+        # if options.get("sync_channel_users"):
+        #     self.sync_channel_users(options, team)
+        # if options.get("sync_messages"):
+        #     self.sync_messages(options, team)
 
-        if (
-            not options.get("sync_users")
-            and not options.get("sync_channels")
-            and not options.get("sync_channel_users")
-            and not options.get("sync_messages")
-        ):
-            self.sync_users(options, team)
-            self.sync_channels(options, team)
-            self.sync_messages(options, team)
+        # if (
+        #     not options.get("sync_users")
+        #     and not options.get("sync_channels")
+        #     and not options.get("sync_channel_users")
+        #     and not options.get("sync_messages")
+        # ):
+        #     self.sync_users(options, team)
+        #     self.sync_channels(options, team)
+        #     self.sync_messages(options, team)
+
+        # Sync to Pinecone after message sync (unless --ignore-pinecone is set)
+        if not options.get("ignore_pinecone"):
+            if options.get("sync_messages") or (
+                not options.get("sync_users")
+                and not options.get("sync_channels")
+                and not options.get("sync_channel_users")
+            ):
+                self.sync_to_pinecone(team)
 
     def _print_dry_run(self, options, team_id: str) -> None:
         """Log what would be synced when --dry-run is set."""
@@ -164,17 +180,27 @@ class Command(BaseCommand):
         if options.get("sync_channels"):
             logger.info(
                 "  Would run: sync channels%s",
-                f" (channel_id={channel_id})" if channel_id else " (all channels)",
+                (
+                    f" (channel_id={channel_id})"
+                    if channel_id
+                    else " (all channels)"
+                ),
             )
             printed = True
         if options.get("sync_channel_users"):
             logger.info(
                 "  Would run: sync channel memberships%s",
-                f" (channel_id={channel_id})" if channel_id else " (all channels)",
+                (
+                    f" (channel_id={channel_id})"
+                    if channel_id
+                    else " (all channels)"
+                ),
             )
             printed = True
         if options.get("sync_messages"):
-            start_str = (options.get("start_date") or "").strip() or "from DB or today"
+            start_str = (
+                options.get("start_date") or ""
+            ).strip() or "from DB or today"
             end_str = (options.get("end_date") or "").strip() or "today"
             logger.info(
                 "  Would run: sync messages (start=%s, end=%s)",
@@ -189,11 +215,15 @@ class Command(BaseCommand):
             printed = True
         if printed:
             return
-        logger.info("  Would run: sync users, channels, and messages (default)")
+        logger.info(
+            "  Would run: sync users, channels, and messages (default)"
+        )
         logger.info("    channel memberships require --sync-channel-users")
         if channel_id:
             logger.info("    (channel_id=%s)", channel_id)
-        start_str = (options.get("start_date") or "").strip() or "from DB or today"
+        start_str = (
+            options.get("start_date") or ""
+        ).strip() or "from DB or today"
         end_str = (options.get("end_date") or "").strip() or "today"
         logger.info("    start=%s, end=%s", start_str, end_str)
         if options.get("messages_json"):
@@ -267,7 +297,9 @@ class Command(BaseCommand):
                     data = json.load(f)
                 _append_payload(data)
             except (OSError, json.JSONDecodeError):
-                logger.exception("Failed to load legacy messages JSON: %s", path)
+                logger.exception(
+                    "Failed to load legacy messages JSON: %s", path
+                )
         elif os.path.isdir(path):
             for name in sorted(os.listdir(path)):
                 if name.endswith(".json"):
@@ -297,7 +329,9 @@ class Command(BaseCommand):
 
         start_date_str = (options.get("start_date") or "").strip() or None
         end_date_str = (options.get("end_date") or "").strip() or None
-        messages_json_path = (options.get("messages_json") or "").strip() or None
+        messages_json_path = (
+            options.get("messages_json") or ""
+        ).strip() or None
 
         start_dt = _parse_date(start_date_str)
         end_dt = _parse_date(end_date_str)
@@ -357,3 +391,49 @@ class Command(BaseCommand):
                 s,
                 e,
             )
+
+    def sync_to_pinecone(self, team: SlackTeam):
+        """Sync Slack messages to Pinecone after message sync."""
+        try:
+            from cppa_pinecone_sync.sync import sync_to_pinecone
+            from cppa_pinecone_sync.ingestion import PineconeInstance
+            from cppa_slack_tracker.preprocessor import (
+                preprocess_slack_for_pinecone,
+            )
+
+            logger.info(
+                "Syncing Slack messages to Pinecone (team=%s, team_id=%s)...",
+                team.team_name,
+                team.team_id,
+            )
+
+            namespace = f"slack-{team.team_name}"
+            result = sync_to_pinecone(
+                app_type="slack",
+                namespace=namespace,
+                preprocess_fn=preprocess_slack_for_pinecone,
+                instance=PineconeInstance.PUBLIC,
+            )
+
+            logger.info(
+                "Pinecone sync complete: upserted=%d, total=%d, failed=%d",
+                result["upserted"],
+                result["total"],
+                result["failed_count"],
+            )
+
+            if result.get("errors"):
+                logger.warning(
+                    "Pinecone sync had %d errors: %s",
+                    len(result["errors"]),
+                    result["errors"][:3],  # Log first 3 errors
+                )
+
+        except ImportError as e:
+            logger.warning(
+                "Pinecone sync skipped: missing dependencies (%s). "
+                "Install with: pip install pinecone langchain-text-splitters langchain-core",
+                e,
+            )
+        except Exception:
+            logger.exception("Error during Pinecone sync")

--- a/cppa_slack_tracker/preprocessor.py
+++ b/cppa_slack_tracker/preprocessor.py
@@ -18,6 +18,7 @@ import logging
 from datetime import datetime
 from typing import Any, Optional, Dict, List
 
+from django.conf import settings
 from django.db.models import Q
 
 from cppa_slack_tracker.models import SlackMessage
@@ -88,7 +89,7 @@ def _filter_unessential_words(text: str) -> str:
     for s in sentences:
         if not s.strip():
             continue
-        f = filter_sentence(s)
+        f = filter_sentence(s, min_words_after=settings.PINECONE_MIN_WORDS)
         if f:
             filtered.append(f)
     return ". ".join(filtered).strip()
@@ -118,7 +119,9 @@ def _extract_valid_messages(
         if not text:
             continue
         filtered = _filter_unessential_words(text)
-        if filtered and validate_content_length(filtered, min_length=10):
+        if filtered and validate_content_length(
+            filtered, min_length=settings.PINECONE_MIN_TEXT_LENGTH
+        ):
             merged_parts.append(filtered)
             if msg.ts:
                 message_ids.append(msg.ts)
@@ -276,7 +279,7 @@ def filter_and_group_messages(
 def _build_document_content(group: Dict[str, Any]) -> str:
     """Build plain-text content for embedding."""
     text = group.get("text", "").strip()
-    if not validate_content_length(text, min_length=10):
+    if not validate_content_length(text, min_length=settings.PINECONE_MIN_TEXT_LENGTH):
         return ""
     return text
 

--- a/cppa_slack_tracker/preprocessor.py
+++ b/cppa_slack_tracker/preprocessor.py
@@ -310,6 +310,10 @@ def preprocess_slack_for_pinecone(
     if final_sync_at is None and not normalized_failed:
         # First sync - get all messages
         candidates_new = queryset
+        messages_new = list(candidates_new)
+        logger.info(
+            f"Loaded {len(messages_new)} Slack messages for preprocessing (first sync)"
+        )
     else:
         if final_sync_at is not None:
             # Incremental sync: get messages created/updated after last sync

--- a/cppa_slack_tracker/preprocessor.py
+++ b/cppa_slack_tracker/preprocessor.py
@@ -1,0 +1,392 @@
+"""
+Pinecone preprocess function for cppa_slack_tracker.
+
+Guideline source:
+- docs/Pinecone_preprocess_guideline.md
+
+This module returns whole-document payloads (is_chunked=False) so the sync
+pipeline can apply its configured chunking strategy.
+
+Adapted from workspace/slack_preprocessor.py to use Django ORM instead of
+direct PostgreSQL queries.
+"""
+
+from __future__ import annotations
+
+import re
+import logging
+from datetime import datetime
+from typing import Any, Optional, Dict, List
+
+from django.db.models import Q
+
+from cppa_slack_tracker.models import SlackMessage
+from cppa_slack_tracker.utils.text_processing import (
+    clean_text,
+    filter_sentence,
+    validate_content_length,
+)
+
+logger = logging.getLogger(__name__)
+
+# Maximum seconds between messages to consider them "consecutive" (same user merge)
+CONSECUTIVE_MESSAGE_WINDOW_SECONDS = 3600  # 1 hour
+
+
+def _normalize_failed_ids(failed_ids: list[str]) -> list[str]:
+    """Return stripped, non-empty, de-duplicated failed IDs preserving order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in failed_ids:
+        value = (raw or "").strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return out
+
+
+def _get_user_name(message: SlackMessage) -> str:
+    """Extract user name from message."""
+    if message.user:
+        return message.user.display_name or message.user.username or "unknown"
+    return "unknown"
+
+
+def _clean_slack_text(text: str) -> str:
+    """Clean Slack-specific formatting from text."""
+    # Remove user mentions <@U123456>
+    text = re.sub(r"<@[A-Z0-9]+>", "", text)
+
+    # Convert channel mentions <#C123456|channel-name> to #channel-name
+    text = re.sub(r"<#([A-Z0-9]+)\|([^>]+)>", r"#\2", text)
+
+    # Convert URLs <https://example.com|link text> to link text
+    text = re.sub(r"<([^|>]+)\|([^>]+)>", r"\2", text)
+    text = re.sub(r"<([^>]+)>", r"\1", text)
+
+    # Remove emoji codes :emoji_name:
+    text = re.sub(r":[\w+-]+:", "", text)
+
+    # Clean up extra whitespace
+    text = re.sub(r"\s+", " ", text).strip()
+
+    return text
+
+
+def _filter_unessential_words(text: str) -> str:
+    """Remove greeting words, unessential words, and emoji patterns from text."""
+    if not text:
+        return ""
+
+    text = _clean_slack_text(text)
+    text = re.sub(r":[\w+-]+:", "", text)  # Remove emoji patterns
+    text = clean_text(text, remove_extra_spaces=True)
+
+    sentences = re.split(r"[.!?]\s+", text)
+    filtered = []
+    for s in sentences:
+        if not s.strip():
+            continue
+        f = filter_sentence(s)
+        if f:
+            filtered.append(f)
+    return ". ".join(filtered).strip()
+
+
+def _group_by_thread(
+    messages: List[SlackMessage],
+) -> Dict[Optional[str], List[SlackMessage]]:
+    """Group messages by thread_ts."""
+    groups: Dict[Optional[str], List[SlackMessage]] = {}
+    for msg in messages:
+        thread_ts = msg.thread_ts
+        if thread_ts not in groups:
+            groups[thread_ts] = []
+        groups[thread_ts].append(msg)
+    return groups
+
+
+def _extract_valid_messages(
+    messages: List[SlackMessage],
+) -> tuple[List[str], List[str]]:
+    """Extract and filter valid messages, returning text parts and message IDs."""
+    merged_parts = []
+    message_ids = []
+    for msg in messages:
+        text = (msg.message or "").strip()
+        if not text:
+            continue
+        filtered = _filter_unessential_words(text)
+        if filtered and validate_content_length(filtered, min_length=10):
+            merged_parts.append(filtered)
+            if msg.ts:
+                message_ids.append(msg.ts)
+    return merged_parts, message_ids
+
+
+def _merge_thread_messages(
+    thread_messages: List[SlackMessage], thread_ts: str
+) -> Optional[Dict[str, Any]]:
+    """Merge all messages in a thread into one text after filtering unessential words."""
+    if not thread_messages:
+        return None
+
+    merged_parts, message_ids = _extract_valid_messages(thread_messages)
+    if not merged_parts:
+        return None
+
+    first_msg = thread_messages[0]
+    return {
+        "id": first_msg.ts or "",
+        "message_ids": message_ids,
+        "text": " ".join(merged_parts),
+        "user_name": _get_user_name(first_msg),
+        "channel_id": (
+            first_msg.channel.channel_id if first_msg.channel else ""
+        ),
+        "ts": first_msg.ts,
+        "thread_ts": thread_ts,
+        "is_grouped": True,
+        "team_id": first_msg.channel.team.team_id if first_msg.channel else "",
+    }
+
+
+def _is_consecutive_message(
+    current_group: Dict[str, Any], next_msg: SlackMessage
+) -> bool:
+    """Check if next message is consecutive (within 60 minutes) to current group."""
+    try:
+        start_ts = float(current_group.get("start_ts", 0))
+        next_ts = float(next_msg.ts or 0)
+
+        # Consider consecutive if within CONSECUTIVE_MESSAGE_WINDOW_SECONDS
+        time_diff = next_ts - start_ts
+        return 0 < time_diff <= CONSECUTIVE_MESSAGE_WINDOW_SECONDS
+    except (ValueError, TypeError):
+        return False
+
+
+def _create_message_group(
+    msg: SlackMessage, user_name: str, text: str
+) -> Dict[str, Any]:
+    """Create a new message group dictionary."""
+    return {
+        "id": msg.ts,
+        "message_ids": [msg.ts] if msg.ts else [],
+        "text": text,
+        "user_name": user_name,
+        "channel_id": msg.channel.channel_id if msg.channel else "",
+        "ts": msg.ts,
+        "thread_ts": msg.thread_ts,
+        "is_grouped": True,
+        "start_ts": msg.ts,
+        "team_id": msg.channel.team.team_id if msg.channel else "",
+    }
+
+
+def _merge_by_user_name(messages: List[SlackMessage]) -> List[Dict[str, Any]]:
+    """Merge messages from the same user."""
+    merged_groups = []
+    current_group: Optional[Dict[str, Any]] = None
+
+    for msg in messages:
+        text = _filter_unessential_words((msg.message or "").strip())
+        if not text:
+            continue
+
+        user_name = _get_user_name(msg)
+        if (
+            current_group is not None
+            and current_group.get("user_name") == user_name
+            and _is_consecutive_message(current_group, msg)
+        ):
+            assert current_group is not None  # Type narrowing
+            current_group["text"] += " " + text
+            if msg.ts:
+                current_group["message_ids"].append(msg.ts)
+            current_group["ts"] = msg.ts
+        else:
+            if current_group is not None:
+                merged_groups.append(current_group)
+            current_group = _create_message_group(msg, user_name, text)
+
+    if current_group is not None:
+        merged_groups.append(current_group)
+    return merged_groups
+
+
+def _merge_consecutive_messages(
+    groups: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Merge consecutive message groups that are close in time."""
+    if not groups:
+        return []
+    merged_groups = []
+    current_group = groups[0].copy()
+    for group in groups[1:]:
+        # Check if consecutive based on timestamps
+        try:
+            current_ts = float(current_group.get("ts", 0))
+            group_ts = float(group.get("ts", 0))
+            time_diff = group_ts - current_ts
+            if 0 < time_diff <= CONSECUTIVE_MESSAGE_WINDOW_SECONDS:
+                current_group["text"] += " " + group["text"]
+                current_group["message_ids"].extend(group["message_ids"])
+                current_group["ts"] = group["ts"]
+            else:
+                merged_groups.append(current_group)
+                current_group = group.copy()
+        except (ValueError, TypeError):
+            merged_groups.append(current_group)
+            current_group = group.copy()
+    merged_groups.append(current_group)
+    return merged_groups
+
+
+def _merge_none_thread_messages(
+    messages: List[SlackMessage],
+) -> List[Dict[str, Any]]:
+    """Merge consecutive messages from the same user."""
+    if not messages:
+        return []
+    first_group = _merge_by_user_name(messages)
+    final_group = _merge_consecutive_messages(first_group)
+    return final_group
+
+
+def filter_and_group_messages(
+    messages: List[SlackMessage],
+) -> List[Dict[str, Any]]:
+    """Filter and group messages by thread, merging consecutive messages from same user."""
+    if not messages:
+        return []
+
+    thread_groups = _group_by_thread(messages)
+    grouped_messages = []
+    for thread_ts, thread_messages in thread_groups.items():
+        # Sort by timestamp
+        thread_messages.sort(key=lambda m: float(m.ts or 0))
+        if thread_ts is not None:
+            if group := _merge_thread_messages(thread_messages, thread_ts):
+                grouped_messages.append(group)
+        else:
+            grouped_messages.extend(
+                _merge_none_thread_messages(thread_messages)
+            )
+    return grouped_messages
+
+
+def _build_document_content(group: Dict[str, Any]) -> str:
+    """Build plain-text content for embedding."""
+    text = group.get("text", "").strip()
+    if not validate_content_length(text, min_length=10):
+        return ""
+    return text
+
+
+def preprocess_slack_for_pinecone(
+    failed_ids: list[str],
+    final_sync_at: datetime | None,
+) -> tuple[list[dict[str, Any]], bool]:
+    """
+    Build Pinecone sync documents for Slack messages.
+
+    Args:
+        failed_ids: Previous-run failed source IDs (we store/retry ts values).
+        final_sync_at: Last sync timestamp for incremental sync; None means first sync.
+
+    Returns:
+        (documents, is_chunked)
+        - documents: list[{"content": str, "metadata": dict}]
+        - is_chunked: False (whole docs; ingestion pipeline may chunk later)
+    """
+    normalized_failed = _normalize_failed_ids(failed_ids or [])
+
+    # Query SlackMessage with efficient joins
+    queryset = SlackMessage.objects.select_related(
+        "channel__team", "user"
+    ).order_by("ts")
+
+    messages_new = []
+    messages_failed = []
+
+    if final_sync_at is None and not normalized_failed:
+        # First sync - get all messages
+        candidates_new = queryset
+    else:
+        if final_sync_at is not None:
+            # Incremental sync: get messages created/updated after last sync
+            # Use slack_message_created_at since SlackMessage doesn't have created_at
+            criteria_new = Q(slack_message_created_at__gt=final_sync_at)
+            candidates_new = queryset.filter(criteria_new)
+            messages_new = list(candidates_new)
+            logger.info(
+                f"Loaded {len(messages_new)} new Slack messages for preprocessing"
+            )
+        if normalized_failed:
+            # Retry failed messages
+            criteria_failed = Q(ts__in=normalized_failed)
+            candidates_failed = queryset.filter(criteria_failed)
+            messages_failed = list(candidates_failed)
+            logger.info(
+                f"Loaded {len(messages_failed)} failed Slack messages for preprocessing"
+            )
+
+    # Group and filter messages
+    grouped_messages = []
+    if messages_new:
+        grouped_messages.extend(filter_and_group_messages(messages_new))
+    if messages_failed:
+        grouped_messages.extend(filter_and_group_messages(messages_failed))
+
+    logger.info(
+        f"Grouped into {len(grouped_messages)} document groups after filtering"
+    )
+
+    # Build document dicts
+    docs: list[dict[str, Any]] = []
+    seen_ts: set[str] = set()
+
+    for group in grouped_messages:
+        ts = group.get("ts", "").strip()
+        if not ts or ts in seen_ts:
+            continue
+        seen_ts.add(ts)
+
+        content = _build_document_content(group)
+        if not content:
+            continue
+
+        message_ids = group.get("message_ids", [ts] if ts else [])
+        channel_id = group.get("channel_id", "")
+        user_name = group.get("user_name", "unknown")
+        thread_ts = group.get("thread_ts", "")
+        is_grouped = group.get("is_grouped", False)
+        team_id = group.get("team_id", "")
+
+        # Convert timestamp string to int for metadata
+        try:
+            safe_timestamp = int(float(ts))
+        except (ValueError, TypeError):
+            safe_timestamp = 0
+
+        metadata: dict[str, Any] = {
+            "doc_id": ts,
+            "type": "slack",
+            "channel_id": channel_id,
+            "user_name": user_name,
+            "timestamp": safe_timestamp,
+            "is_grouped": is_grouped,
+            "thread_ts": thread_ts if thread_ts else "",
+            "group_size": len(message_ids),
+            "team_id": team_id,
+            # ids should reference message timestamps for sync bookkeeping
+            "ids": ",".join(message_ids),
+        }
+
+        docs.append({"content": content, "metadata": metadata})
+
+    logger.info(f"Built {len(docs)} documents for Pinecone sync")
+
+    return docs, False

--- a/cppa_slack_tracker/preprocessor.py
+++ b/cppa_slack_tracker/preprocessor.py
@@ -318,7 +318,7 @@ def preprocess_slack_for_pinecone(
         if final_sync_at is not None:
             # Incremental sync: get messages created/updated after last sync
             # Use slack_message_created_at since SlackMessage doesn't have created_at
-            criteria_new = Q(slack_message_created_at__gt=final_sync_at)
+            criteria_new = Q(slack_message_updated_at__gt=final_sync_at)
             candidates_new = queryset.filter(criteria_new)
             messages_new = list(candidates_new)
             logger.info(

--- a/cppa_slack_tracker/preprocessor.py
+++ b/cppa_slack_tracker/preprocessor.py
@@ -142,9 +142,7 @@ def _merge_thread_messages(
         "message_ids": message_ids,
         "text": " ".join(merged_parts),
         "user_name": _get_user_name(first_msg),
-        "channel_id": (
-            first_msg.channel.channel_id if first_msg.channel else ""
-        ),
+        "channel_id": (first_msg.channel.channel_id if first_msg.channel else ""),
         "ts": first_msg.ts,
         "thread_ts": thread_ts,
         "is_grouped": True,
@@ -271,9 +269,7 @@ def filter_and_group_messages(
             if group := _merge_thread_messages(thread_messages, thread_ts):
                 grouped_messages.append(group)
         else:
-            grouped_messages.extend(
-                _merge_none_thread_messages(thread_messages)
-            )
+            grouped_messages.extend(_merge_none_thread_messages(thread_messages))
     return grouped_messages
 
 
@@ -304,9 +300,9 @@ def preprocess_slack_for_pinecone(
     normalized_failed = _normalize_failed_ids(failed_ids or [])
 
     # Query SlackMessage with efficient joins
-    queryset = SlackMessage.objects.select_related(
-        "channel__team", "user"
-    ).order_by("ts")
+    queryset = SlackMessage.objects.select_related("channel__team", "user").order_by(
+        "ts"
+    )
 
     messages_new = []
     messages_failed = []
@@ -340,9 +336,7 @@ def preprocess_slack_for_pinecone(
     if messages_failed:
         grouped_messages.extend(filter_and_group_messages(messages_failed))
 
-    logger.info(
-        f"Grouped into {len(grouped_messages)} document groups after filtering"
-    )
+    logger.info(f"Grouped into {len(grouped_messages)} document groups after filtering")
 
     # Build document dicts
     docs: list[dict[str, Any]] = []

--- a/cppa_slack_tracker/tests/test_preprocessor.py
+++ b/cppa_slack_tracker/tests/test_preprocessor.py
@@ -236,5 +236,5 @@ def test_preprocessor_cleans_slack_formatting(
     if docs:
         # Content should not contain raw Slack formatting
         content = docs[0]["content"]
-        assert "<@" not in content or "@" not in content  # Mentions cleaned
-        assert "<#" not in content or "#" not in content  # Channels cleaned
+        assert "<@" not in content  # User mentions cleaned
+        assert "<#" not in content  # Channel mentions cleaned (but #channel-name is OK)

--- a/cppa_slack_tracker/tests/test_preprocessor.py
+++ b/cppa_slack_tracker/tests/test_preprocessor.py
@@ -1,6 +1,6 @@
 """Tests for cppa_slack_tracker.preprocessor."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 
 import pytest
 from django.utils import timezone as django_timezone
@@ -59,7 +59,7 @@ def test_preprocessor_incremental_by_created_at(
     now = django_timezone.now()
 
     # Create old message
-    old_msg = SlackMessage.objects.create(
+    _old_msg = SlackMessage.objects.create(
         channel=sample_slack_channel,
         ts="1234567890.111111",
         user=sample_slack_user,
@@ -69,7 +69,7 @@ def test_preprocessor_incremental_by_created_at(
     )
 
     # Create new message
-    new_msg = SlackMessage.objects.create(
+    _new_msg = SlackMessage.objects.create(
         channel=sample_slack_channel,
         ts="1234567890.222222",
         user=sample_slack_user,
@@ -95,7 +95,7 @@ def test_preprocessor_retries_failed_ids(
     now = django_timezone.now()
 
     # Create old message
-    retry_msg = SlackMessage.objects.create(
+    _retry_msg = SlackMessage.objects.create(
         channel=sample_slack_channel,
         ts="1234567890.111111",
         user=sample_slack_user,
@@ -122,7 +122,7 @@ def test_preprocessor_deduplicates_failed_ids(
     """Same message in failed_ids and incremental set is emitted once."""
     now = django_timezone.now()
 
-    msg = SlackMessage.objects.create(
+    _msg = SlackMessage.objects.create(
         channel=sample_slack_channel,
         ts="1234567890.111111",
         user=sample_slack_user,
@@ -149,7 +149,7 @@ def test_preprocessor_document_shape_and_metadata_fields(
     """Each output item has required top-level keys and guideline-compatible metadata."""
     now = django_timezone.now()
 
-    msg = SlackMessage.objects.create(
+    _msg = SlackMessage.objects.create(
         channel=sample_slack_channel,
         ts="1234567890.123456",
         user=sample_slack_user,

--- a/cppa_slack_tracker/tests/test_preprocessor.py
+++ b/cppa_slack_tracker/tests/test_preprocessor.py
@@ -1,0 +1,240 @@
+"""Tests for cppa_slack_tracker.preprocessor."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from django.utils import timezone as django_timezone
+
+from cppa_slack_tracker.preprocessor import preprocess_slack_for_pinecone
+from cppa_slack_tracker.models import SlackMessage
+
+
+@pytest.mark.django_db
+def test_preprocessor_returns_empty_when_no_messages():
+    """No source rows -> empty docs and is_chunked=False."""
+    docs, is_chunked = preprocess_slack_for_pinecone([], None)
+    assert docs == []
+    assert is_chunked is False
+
+
+@pytest.mark.django_db
+def test_preprocessor_first_sync_returns_all_messages(
+    sample_slack_channel,
+    sample_slack_user,
+):
+    """final_sync_at=None returns all messages on first run."""
+    now = django_timezone.now()
+
+    # Create two messages
+    SlackMessage.objects.create(
+        channel=sample_slack_channel,
+        ts="1234567890.111111",
+        user=sample_slack_user,
+        message="This is the first test message with enough content to pass validation",
+        slack_message_created_at=now,
+        slack_message_updated_at=now,
+    )
+    SlackMessage.objects.create(
+        channel=sample_slack_channel,
+        ts="1234567890.222222",
+        user=sample_slack_user,
+        message="This is the second test message with enough content to pass validation",
+        slack_message_created_at=now,
+        slack_message_updated_at=now,
+    )
+
+    docs, is_chunked = preprocess_slack_for_pinecone([], None)
+    assert is_chunked is False
+    # Note: docs might be empty if messages are filtered out due to length/content validation
+    # or grouped together
+    assert isinstance(docs, list)
+
+
+@pytest.mark.django_db
+def test_preprocessor_incremental_by_created_at(
+    sample_slack_channel,
+    sample_slack_user,
+):
+    """Only messages created after final_sync_at are included for incremental runs."""
+    now = django_timezone.now()
+
+    # Create old message
+    old_msg = SlackMessage.objects.create(
+        channel=sample_slack_channel,
+        ts="1234567890.111111",
+        user=sample_slack_user,
+        message="Old message with enough content to pass validation and filtering",
+        slack_message_created_at=now - timedelta(days=2),
+        slack_message_updated_at=now - timedelta(days=2),
+    )
+
+    # Create new message
+    new_msg = SlackMessage.objects.create(
+        channel=sample_slack_channel,
+        ts="1234567890.222222",
+        user=sample_slack_user,
+        message="New message with enough content to pass validation and filtering",
+        slack_message_created_at=now - timedelta(hours=1),
+        slack_message_updated_at=now - timedelta(hours=1),
+    )
+
+    # Query with final_sync_at set to 1 day ago
+    docs, _ = preprocess_slack_for_pinecone([], now - timedelta(days=1))
+
+    # Should only get the new message (if not filtered out)
+    # The exact count depends on filtering logic
+    assert isinstance(docs, list)
+
+
+@pytest.mark.django_db
+def test_preprocessor_retries_failed_ids(
+    sample_slack_channel,
+    sample_slack_user,
+):
+    """failed_ids are re-included even when older than final_sync_at."""
+    now = django_timezone.now()
+
+    # Create old message
+    retry_msg = SlackMessage.objects.create(
+        channel=sample_slack_channel,
+        ts="1234567890.111111",
+        user=sample_slack_user,
+        message="Retry message with enough content to pass validation and filtering",
+        slack_message_created_at=now - timedelta(days=10),
+        slack_message_updated_at=now - timedelta(days=10),
+    )
+
+    # Query with failed_ids
+    docs, _ = preprocess_slack_for_pinecone(
+        failed_ids=["1234567890.111111"],
+        final_sync_at=now - timedelta(days=1),
+    )
+
+    # Should get the retry message
+    assert isinstance(docs, list)
+
+
+@pytest.mark.django_db
+def test_preprocessor_deduplicates_failed_ids(
+    sample_slack_channel,
+    sample_slack_user,
+):
+    """Same message in failed_ids and incremental set is emitted once."""
+    now = django_timezone.now()
+
+    msg = SlackMessage.objects.create(
+        channel=sample_slack_channel,
+        ts="1234567890.111111",
+        user=sample_slack_user,
+        message="Dedupe message with enough content to pass validation and filtering",
+        slack_message_created_at=now,
+        slack_message_updated_at=now,
+    )
+
+    # Pass the same ts twice in failed_ids
+    docs, _ = preprocess_slack_for_pinecone(
+        failed_ids=["1234567890.111111", "  1234567890.111111  "],
+        final_sync_at=now - timedelta(days=1),
+    )
+
+    # Should deduplicate and return only one document
+    assert isinstance(docs, list)
+
+
+@pytest.mark.django_db
+def test_preprocessor_document_shape_and_metadata_fields(
+    sample_slack_channel,
+    sample_slack_user,
+):
+    """Each output item has required top-level keys and guideline-compatible metadata."""
+    now = django_timezone.now()
+
+    msg = SlackMessage.objects.create(
+        channel=sample_slack_channel,
+        ts="1234567890.123456",
+        user=sample_slack_user,
+        message="Test message with enough content to pass validation and filtering rules",
+        thread_ts="1234567890.000000",
+        slack_message_created_at=now,
+        slack_message_updated_at=now,
+    )
+
+    docs, is_chunked = preprocess_slack_for_pinecone([], None)
+    assert is_chunked is False
+
+    if docs:  # If any documents were created after filtering
+        target = docs[0]
+
+        # Check top-level structure
+        assert "content" in target
+        assert "metadata" in target
+        assert isinstance(target["content"], str)
+        assert target["content"] != ""
+
+        # Check required metadata fields per Pinecone guideline
+        assert "doc_id" in target["metadata"]
+        assert "type" in target["metadata"]
+        assert target["metadata"]["type"] == "slack"
+
+        # Check Slack-specific metadata
+        assert "channel_id" in target["metadata"]
+        assert "user_name" in target["metadata"]
+        assert "timestamp" in target["metadata"]
+        assert "team_id" in target["metadata"]
+
+        # Check ids field for retry tracking
+        assert "ids" in target["metadata"]
+        assert isinstance(target["metadata"]["ids"], str)
+
+
+@pytest.mark.django_db
+def test_preprocessor_filters_short_messages(
+    sample_slack_channel,
+    sample_slack_user,
+):
+    """Very short messages are filtered out."""
+    now = django_timezone.now()
+
+    # Create a very short message
+    SlackMessage.objects.create(
+        channel=sample_slack_channel,
+        ts="1234567890.111111",
+        user=sample_slack_user,
+        message="Hi",  # Too short
+        slack_message_created_at=now,
+        slack_message_updated_at=now,
+    )
+
+    docs, _ = preprocess_slack_for_pinecone([], None)
+
+    # Short message should be filtered out
+    assert isinstance(docs, list)
+
+
+@pytest.mark.django_db
+def test_preprocessor_cleans_slack_formatting(
+    sample_slack_channel,
+    sample_slack_user,
+):
+    """Slack-specific formatting (mentions, channels, URLs) is cleaned."""
+    now = django_timezone.now()
+
+    # Create message with Slack formatting
+    SlackMessage.objects.create(
+        channel=sample_slack_channel,
+        ts="1234567890.111111",
+        user=sample_slack_user,
+        message="<@U12345678> check <#C12345678|general> and <https://example.com|this link> for more information about the topic",
+        slack_message_created_at=now,
+        slack_message_updated_at=now,
+    )
+
+    docs, _ = preprocess_slack_for_pinecone([], None)
+
+    # Formatting should be cleaned
+    assert isinstance(docs, list)
+    if docs:
+        # Content should not contain raw Slack formatting
+        content = docs[0]["content"]
+        assert "<@" not in content or "@" not in content  # Mentions cleaned
+        assert "<#" not in content or "#" not in content  # Channels cleaned

--- a/cppa_slack_tracker/tests/test_text_processing.py
+++ b/cppa_slack_tracker/tests/test_text_processing.py
@@ -52,11 +52,12 @@ def test_clean_text_handles_empty_input():
 
 
 def test_filter_sentence_removes_greetings():
-    """filter_sentence removes greeting words."""
+    """filter_sentence removes greeting words as whole phrases (keeps 'hi' inside 'this')."""
     sentence = "Hi there, can you help me with this?"
     result = filter_sentence(sentence)
-    assert "hi" not in result.lower()
+    assert result.startswith("there")  # standalone "Hi" removed
     assert "help" in result
+    assert "this" in result  # "hi" inside "this" is not removed
 
 
 def test_filter_sentence_removes_unessential_words():

--- a/cppa_slack_tracker/tests/test_text_processing.py
+++ b/cppa_slack_tracker/tests/test_text_processing.py
@@ -1,0 +1,136 @@
+"""Tests for cppa_slack_tracker.utils.text_processing."""
+
+import pytest
+
+from cppa_slack_tracker.utils.text_processing import (
+    clean_text,
+    filter_sentence,
+    validate_content_length,
+    SLACK_GREETING_WORDS,
+    SLACK_UNESSENTIAL_WORDS,
+)
+
+
+def test_clean_text_removes_invisible_characters():
+    """clean_text removes soft hyphens and zero-width spaces."""
+    text = "Hello\xadworld\u200b"
+    result = clean_text(text)
+    assert result == "Helloworld"
+
+
+def test_clean_text_normalizes_line_breaks():
+    """clean_text normalizes different line break styles."""
+    text = "Line1\r\nLine2\rLine3\nLine4"
+    result = clean_text(text)
+    assert "\r" not in result
+    assert result.count("\n") == 3
+
+
+def test_clean_text_removes_extra_spaces():
+    """clean_text removes multiple spaces when remove_extra_spaces=True."""
+    text = "Hello    world   test"
+    result = clean_text(text, remove_extra_spaces=True)
+    assert result == "Hello world test"
+
+
+def test_clean_text_limits_newlines():
+    """clean_text limits consecutive newlines to max 2."""
+    text = "Line1\n\n\n\n\nLine2"
+    result = clean_text(text, remove_extra_spaces=True)
+    assert result == "Line1\n\nLine2"
+
+
+def test_clean_text_strips_line_whitespace():
+    """clean_text removes spaces at start/end of lines."""
+    text = "  Line1  \n  Line2  "
+    result = clean_text(text, remove_extra_spaces=True)
+    assert result == "Line1\nLine2"
+
+
+def test_clean_text_handles_empty_input():
+    """clean_text returns empty string for empty input."""
+    assert clean_text("") == ""
+    assert clean_text(None) == ""
+
+
+def test_filter_sentence_removes_greetings():
+    """filter_sentence removes greeting words."""
+    sentence = "Hi there, can you help me with this?"
+    result = filter_sentence(sentence)
+    assert "hi" not in result.lower()
+    assert "help" in result
+
+
+def test_filter_sentence_removes_unessential_words():
+    """filter_sentence removes unessential words like 'ok', 'lol'."""
+    sentence = "Ok sure, that sounds great lol"
+    result = filter_sentence(sentence)
+    # After filtering, should have remaining meaningful content
+    assert isinstance(result, str)
+
+
+def test_filter_sentence_returns_empty_for_short_result():
+    """filter_sentence returns empty string if result is too short."""
+    sentence = "Hi ok"  # Only greeting and unessential words
+    result = filter_sentence(sentence, min_words_after=3)
+    assert result == ""
+
+
+def test_filter_sentence_handles_empty_input():
+    """filter_sentence returns empty string for empty input."""
+    assert filter_sentence("") == ""
+    assert filter_sentence("   ") == ""
+
+
+def test_filter_sentence_custom_word_lists():
+    """filter_sentence accepts custom greeting and unessential word lists."""
+    sentence = "Hello world test example"
+    result = filter_sentence(
+        sentence,
+        greeting_words=["hello"],
+        unessential_words=["world"],
+        min_words_after=1,
+    )
+    assert "test" in result or "example" in result
+    assert "hello" not in result.lower()
+    assert "world" not in result.lower()
+
+
+def test_validate_content_length_accepts_long_text():
+    """validate_content_length returns True for text meeting minimum length."""
+    long_text = "This is a much longer text that definitely exceeds the minimum length requirement"
+    assert validate_content_length(long_text, min_length=50) is True
+
+
+def test_validate_content_length_rejects_short_text():
+    """validate_content_length returns False for text below minimum length."""
+    short_text = "Hi"
+    assert validate_content_length(short_text, min_length=50) is False
+
+
+def test_validate_content_length_handles_empty_input():
+    """validate_content_length returns False for empty input."""
+    assert validate_content_length("") is False
+    assert validate_content_length(None) is False
+
+
+def test_validate_content_length_strips_whitespace():
+    """validate_content_length strips whitespace before checking length."""
+    text_with_spaces = "   Short   "
+    assert validate_content_length(text_with_spaces, min_length=10) is False
+
+
+def test_slack_greeting_words_constant():
+    """SLACK_GREETING_WORDS contains expected greeting words."""
+    assert "hi" in SLACK_GREETING_WORDS
+    assert "hello" in SLACK_GREETING_WORDS
+    assert "thanks" in SLACK_GREETING_WORDS
+    assert "goodbye" in SLACK_GREETING_WORDS
+
+
+def test_slack_unessential_words_constant():
+    """SLACK_UNESSENTIAL_WORDS contains expected unessential words."""
+    assert "ok" in SLACK_UNESSENTIAL_WORDS
+    assert "lol" in SLACK_UNESSENTIAL_WORDS
+    assert "yeah" in SLACK_UNESSENTIAL_WORDS
+    assert "awesome" in SLACK_UNESSENTIAL_WORDS

--- a/cppa_slack_tracker/tests/test_text_processing.py
+++ b/cppa_slack_tracker/tests/test_text_processing.py
@@ -1,7 +1,5 @@
 """Tests for cppa_slack_tracker.utils.text_processing."""
 
-import pytest
-
 from cppa_slack_tracker.utils.text_processing import (
     clean_text,
     filter_sentence,

--- a/cppa_slack_tracker/utils/__init__.py
+++ b/cppa_slack_tracker/utils/__init__.py
@@ -1,0 +1,19 @@
+"""
+Utility functions for cppa_slack_tracker.
+"""
+
+from .text_processing import (
+    clean_text,
+    filter_sentence,
+    validate_content_length,
+    SLACK_GREETING_WORDS,
+    SLACK_UNESSENTIAL_WORDS,
+)
+
+__all__ = [
+    "clean_text",
+    "filter_sentence",
+    "validate_content_length",
+    "SLACK_GREETING_WORDS",
+    "SLACK_UNESSENTIAL_WORDS",
+]

--- a/cppa_slack_tracker/utils/text_processing.py
+++ b/cppa_slack_tracker/utils/text_processing.py
@@ -151,10 +151,10 @@ def filter_sentence(
         sentence: Input sentence to filter.
         greeting_words: Phrases to remove (e.g. "hi", "thank you"). Default: SLACK_GREETING_WORDS.
         unessential_words: Phrases to remove (e.g. "ok", "lol"). Default: SLACK_UNESSENTIAL_WORDS.
-        min_words_after: Minimum word count to keep; otherwise return "". Default: 3.
+        min_words_after: Minimum word count to keep (inclusive); return "" if fewer. Default: 3.
 
     Returns:
-        Filtered sentence (lowercased, stripped), or "" if empty or below min_words_after.
+        Filtered sentence (lowercased, stripped), or "" if empty or fewer than min_words_after words.
 
     Examples:
         >>> filter_sentence("Hi there, can you help?")
@@ -167,23 +167,25 @@ def filter_sentence(
         return ""
 
     greeting = (
-        set(greeting_words) if greeting_words is not None else SLACK_GREETING_WORDS
+        {word.lower() for word in greeting_words}
+        if greeting_words is not None
+        else SLACK_GREETING_WORDS
     )
     unessential = (
-        set(unessential_words)
+        {word.lower() for word in unessential_words}
         if unessential_words is not None
         else SLACK_UNESSENTIAL_WORDS
     )
 
     sentence_lower = sentence.lower()
-    greeting_found = [w for w in greeting if w in sentence_lower]
-    unessential_found = [w for w in unessential if w in sentence_lower]
+    removable_phrases = sorted(greeting | unessential, key=len, reverse=True)
+    for phrase in removable_phrases:
+        pattern = rf"(?<!\w){re.escape(phrase)}(?!\w)"
+        sentence_lower = re.sub(pattern, "", sentence_lower)
 
-    if greeting_found or unessential_found:
-        for word in greeting_found + unessential_found:
-            sentence_lower = sentence_lower.replace(word, "")
+    sentence_lower = re.sub(r"\s{2,}", " ", sentence_lower).strip()
 
-    if len(sentence_lower.strip().split()) <= min_words_after:
+    if len(sentence_lower.strip().split()) < min_words_after:
         return ""
 
     return sentence_lower.strip()

--- a/cppa_slack_tracker/utils/text_processing.py
+++ b/cppa_slack_tracker/utils/text_processing.py
@@ -1,0 +1,213 @@
+"""
+Text processing utilities for Slack message preprocessing.
+
+Adapted from workspace/utility.py for Django integration.
+Contains functions for cleaning, filtering, and validating Slack message content.
+"""
+
+import re
+import logging
+from typing import Optional, Iterable, FrozenSet
+
+logger = logging.getLogger(__name__)
+
+
+# Default greeting/unessential words for filter_sentence (Slack message cleaning)
+SLACK_GREETING_WORDS: FrozenSet[str] = frozenset(
+    {
+        "hi",
+        "hello",
+        "hey",
+        "good morning",
+        "good afternoon",
+        "good evening",
+        "greetings",
+        "howdy",
+        "sup",
+        "what's up",
+        "yo",
+        "hii",
+        "helloo",
+        "thanks",
+        "thank you",
+        "thx",
+        "ty",
+        "appreciate it",
+        "cheers",
+        "nice to meet you",
+        "happy to be here",
+        "happy to have you here",
+        "glad to see you",
+        "glad to see you here",
+        "glad to be here",
+        "bye",
+        "goodbye",
+        "see you later",
+        "see you soon",
+        "see you tomorrow",
+        "see you next week",
+        "see you next month",
+        "see you next year",
+        "see you in the future",
+    }
+)
+
+SLACK_UNESSENTIAL_WORDS: FrozenSet[str] = frozenset(
+    {
+        "ok",
+        "okay",
+        "sure",
+        "yeah",
+        "yep",
+        "yup",
+        "nope",
+        "nah",
+        "lol",
+        "haha",
+        "hahaha",
+        "hehe",
+        "lmao",
+        "rofl",
+        "👍",
+        "👎",
+        "😊",
+        "😄",
+        "😀",
+        "👍🏻",
+        "👌",
+        "got it",
+        "gotcha",
+        "nice",
+        "awesome",
+        "great",
+        "uhm",
+        "um",
+        "uh",
+        "erm",
+        "of course",
+    }
+)
+
+
+def clean_text(text: str, remove_extra_spaces: bool = True) -> str:
+    """
+    Clean and normalize text content.
+
+    Removes invisible characters, normalizes line breaks, and optionally
+    removes extra whitespace.
+
+    Args:
+        text: Input text to clean
+        remove_extra_spaces: Whether to remove extra whitespace
+
+    Returns:
+        Cleaned text
+
+    Examples:
+        >>> clean_text("  Hello   world  ")
+        'Hello world'
+        >>> clean_text("Text\\n\\n\\nMore text")
+        'Text\\n\\nMore text'
+    """
+    if not text:
+        return ""
+
+    # Remove soft hyphens and other invisible characters
+    text = (
+        text.replace("\xad", "")
+        .replace("\u200b", "")
+        .replace("\u200c", "")
+        .replace("\u200d", "")
+    )
+
+    # Normalize line breaks
+    text = re.sub(r"\r\n", "\n", text)  # Windows line breaks
+    text = re.sub(r"\r", "\n", text)  # Old Mac line breaks
+
+    if remove_extra_spaces:
+        # Remove multiple spaces
+        text = re.sub(r" +", " ", text)
+        # Remove multiple newlines (keep max 2)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        # Remove spaces at start/end of lines
+        text = "\n".join(line.strip() for line in text.split("\n"))
+
+    return text.strip()
+
+
+def filter_sentence(
+    sentence: str,
+    greeting_words: Optional[Iterable[str]] = None,
+    unessential_words: Optional[Iterable[str]] = None,
+    min_words_after: int = 3,
+) -> str:
+    """
+    Filter a single sentence by removing greeting/unessential words.
+
+    Removes phrases from greeting_words and unessential_words (case-insensitive),
+    then returns the stripped sentence, or "" if too few words remain.
+
+    Args:
+        sentence: Input sentence to filter.
+        greeting_words: Phrases to remove (e.g. "hi", "thank you"). Default: SLACK_GREETING_WORDS.
+        unessential_words: Phrases to remove (e.g. "ok", "lol"). Default: SLACK_UNESSENTIAL_WORDS.
+        min_words_after: Minimum word count to keep; otherwise return "". Default: 3.
+
+    Returns:
+        Filtered sentence (lowercased, stripped), or "" if empty or below min_words_after.
+
+    Examples:
+        >>> filter_sentence("Hi there, can you help?")
+        'there, can you help?'
+        >>> filter_sentence("ok sure")
+        ''
+    """
+    sentence = sentence.strip()
+    if not sentence:
+        return ""
+
+    greeting = (
+        set(greeting_words) if greeting_words is not None else SLACK_GREETING_WORDS
+    )
+    unessential = (
+        set(unessential_words)
+        if unessential_words is not None
+        else SLACK_UNESSENTIAL_WORDS
+    )
+
+    sentence_lower = sentence.lower()
+    greeting_found = [w for w in greeting if w in sentence_lower]
+    unessential_found = [w for w in unessential if w in sentence_lower]
+
+    if greeting_found or unessential_found:
+        for word in greeting_found + unessential_found:
+            sentence_lower = sentence_lower.replace(word, "")
+
+    if len(sentence_lower.strip().split()) <= min_words_after:
+        return ""
+
+    return sentence_lower.strip()
+
+
+def validate_content_length(content: str, min_length: int = 50) -> bool:
+    """
+    Validate that content meets minimum length requirement.
+
+    Args:
+        content: Content string to validate
+        min_length: Minimum required length (default: 50)
+
+    Returns:
+        True if content is valid, False otherwise
+
+    Examples:
+        >>> validate_content_length("This is a short text")
+        False
+        >>> validate_content_length("This is a much longer text that exceeds the minimum length requirement")
+        True
+    """
+    if not content:
+        return False
+
+    cleaned = content.strip()
+    return len(cleaned) >= min_length

--- a/github_ops/client.py
+++ b/github_ops/client.py
@@ -196,9 +196,10 @@ class GitHubAPIClient:
     ) -> requests.Response:
         """Perform one HTTP request. Retries on 429/403 rate limit (wait then retry).
         Retries on 5xx only when allow_retry_on_5xx=True; retries on connection errors
-        only when allow_retry_on_connection_errors=True. Mutating methods (POST, DELETE,
-        GraphQL) should not pass allow_retry_on_connection_errors=True to avoid replaying
-        writes that may have succeeded on the server despite a transient failure.
+        only when allow_retry_on_connection_errors=True. Mutating methods (e.g. REST POST/DELETE)
+        should not pass allow_retry_on_connection_errors=True to avoid replaying writes that
+        may have succeeded on the server despite a transient failure. GraphQL is retried
+        because this client uses it only for read-only queries (e.g. file content).
         """
         attempts_5xx = self.max_retries if allow_retry_on_5xx else 1
         attempts_conn = self.max_retries if allow_retry_on_connection_errors else 1
@@ -542,7 +543,9 @@ class GitHubAPIClient:
         )
 
     def graphql_request(self, query: str, variables: Optional[dict] = None) -> dict:
-        """Make GraphQL API request with rate limit and connection error handling."""
+        """Make GraphQL API request with rate limit and connection error handling.
+        Connection errors are retried (used for read-only queries only).
+        """
         payload: dict = {"query": query}
         if variables:
             payload["variables"] = variables
@@ -554,7 +557,7 @@ class GitHubAPIClient:
             headers={"Content-Type": "application/json"},
             timeout=30,
             allow_retry_on_5xx=True,
-            allow_retry_on_connection_errors=False,
+            allow_retry_on_connection_errors=True,
         )
         self._raise_if_error_and_update_rate_limit(response, "GraphQL request")
         data = response.json()

--- a/github_ops/tests/test_client.py
+++ b/github_ops/tests/test_client.py
@@ -469,15 +469,15 @@ def test_graphql_request_sends_query_and_variables():
     assert post_mock.call_args[0][0] == "POST"
 
 
-def test_graphql_request_connection_error_raises_without_retry():
-    """graphql_request raises ConnectionException immediately on connection error (no retries for mutating methods)."""
+def test_graphql_request_connection_error_retries_then_raises():
+    """graphql_request retries on connection error, then raises ConnectionException after retries exhausted."""
     from requests.exceptions import ConnectionError as ReqConnectionError
 
     client = GitHubAPIClient("token")
     client.session.request = MagicMock(side_effect=ReqConnectionError("fail"))
-    with pytest.raises(ConnectionException):
+    with patch("github_ops.client.time.sleep"), pytest.raises(ConnectionException):
         client.graphql_request("query { x }")
-    assert client.session.request.call_count == 1
+    assert client.session.request.call_count == client.max_retries
 
 
 # --- get_repository_info ---


### PR DESCRIPTION
- Add Slack pinecone preprocessor in cppa_slack_tracker app.
- Add constant for pinecone app in settings.py.
- Add tests for new add functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pinecone settings for configurable sync (API keys, index, region/cloud, batching, chunking, model selection)
  * Early config validation to surface missing Pinecone settings
  * CLI flag to optionally skip Pinecone synchronization
  * Message preprocessing and text utilities for cleaning, filtering, and content validation

* **Documentation**
  * Expanded environment example with guidance for enabling and tuning Pinecone sync

* **Tests**
  * Added tests for preprocessing and text-processing behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->