### PR TITLE
Add compose CI smoke job, make health target, and post-deploy health check

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -115,3 +115,36 @@ jobs:
         with:
           name: pytest-results
           path: junit.xml
+
+  compose-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create .env for CI
+        run: |
+          cp .env.example .env
+          echo "DATABASE_URL=postgres://boost:boost@db:5432/boost_dashboard" >> .env
+          echo "SECRET_KEY=ci-only-secret-key" >> .env
+          echo "DEBUG=True" >> .env
+
+      - name: Build images
+        run: make build
+
+      - name: Start stack and wait for health
+        run: docker compose up -d --wait
+
+      - name: Run migrations
+        run: docker compose exec -T web python manage.py migrate --noinput
+
+      - name: Health check
+        run: make health
+
+      - name: Tear down
+        if: always()
+        run: make down

--- a/.github/workflows/deploy-script/deploy.sh
+++ b/.github/workflows/deploy-script/deploy.sh
@@ -46,4 +46,18 @@ log "Building and starting stack..."
 make build
 make up
 
+log "Waiting for stack to be healthy..."
+max_attempts=12
+attempt=0
+until make health >/dev/null 2>&1; do
+  attempt=$((attempt + 1))
+  if [[ $attempt -ge $max_attempts ]]; then
+    log "ERROR: Health check failed after ${max_attempts} attempts. Aborting."
+    exit 1
+  fi
+  log "  Health check attempt ${attempt}/${max_attempts} failed, retrying in 5 s..."
+  sleep 5
+done
+log "Stack is healthy."
+
 log "Deploy completed."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,13 +17,10 @@ jobs:
   deploy:
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     environment: ${{ github.event.workflow_run.head_branch == 'main' && 'production' || (github.event.workflow_run.head_branch == 'develop' && 'staging' || '')}}
     env:
       BRANCH: ${{ github.event.workflow_run.head_branch }}
-      SSH_HOST: ${{ secrets.SSH_HOST }}
-      SSH_USER: ${{ secrets.SSH_USER }}
-      SSH_PORT: ${{ secrets.SSH_PORT || '22' }}
       REPO_URL: https://github.com/${{ github.repository }}.git
       SCRIPT_URL: ${{ secrets.DEPLOY_SCRIPT_URL || format('https://raw.githubusercontent.com/{0}/{1}/.github/workflows/deploy-script/deploy.sh', github.repository, github.event.workflow_run.head_sha) }}
     steps:
@@ -36,7 +33,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           passphrase: ${{ secrets.SSH_KEY_PASSPHRASE }}
-          port: ${{ env.SSH_PORT }}
+          port: ${{ secrets.SSH_PORT || '22' }}
           envs: SCRIPT_URL,DEPLOY_SCRIPT_TOKEN,BRANCH,REPO_URL
           script: |
             set -euo pipefail

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ ps:
 health:
 	$(COMPOSE) exec -T $(APP) python manage.py check --database default
 	$(COMPOSE) exec -T redis redis-cli ping | grep -q PONG
-	$(COMPOSE) exec -T selenium curl -sf http://localhost:4444/status | grep -q '"ready": true'
+	$(COMPOSE) exec -T selenium curl -sf http://localhost:4444/status | grep -qE '"ready"[[:space:]]*:[[:space:]]*true'
 	$(COMPOSE) ps --status running celery_worker | grep -q celery_worker
 	$(COMPOSE) ps --status running celery_beat | grep -q celery_beat
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ help:
 	@echo ""
 	@echo "  Logs & status"
 	@echo "    ps             Show running containers"
+	@echo "    health         Verify DB, Redis, Selenium, and Celery containers"
 	@echo "    logs           Follow logs for all services"
 	@echo "    logs-web       Follow logs for the web service"
 	@echo "    logs-worker    Follow logs for the Celery worker"
@@ -91,6 +92,14 @@ reset:
 .PHONY: ps
 ps:
 	$(COMPOSE) ps
+
+.PHONY: health
+health:
+	$(COMPOSE) exec -T $(APP) python manage.py check --database default
+	$(COMPOSE) exec -T redis redis-cli ping | grep -q PONG
+	$(COMPOSE) exec -T selenium curl -sf http://localhost:4444/status | grep -q '"ready": true'
+	$(COMPOSE) ps --status running celery_worker | grep -q celery_worker
+	$(COMPOSE) ps --status running celery_beat | grep -q celery_beat
 
 .PHONY: logs
 logs:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,29 @@
+# CI-only overlay: enables Postgres (base compose references @db but db is commented out).
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: boost
+      POSTGRES_PASSWORD: boost
+      POSTGRES_DB: boost_dashboard
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U boost -d boost_dashboard"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  web:
+    depends_on:
+      db: { condition: service_healthy }
+      redis: { condition: service_healthy }
+
+  celery_worker:
+    depends_on:
+      db: { condition: service_healthy }
+      redis: { condition: service_healthy }
+
+  celery_beat:
+    depends_on:
+      db: { condition: service_healthy }
+      redis: { condition: service_healthy }
+      celery_worker: { condition: service_started }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,12 +38,12 @@ services:
       test:
         [
           "CMD-SHELL",
-          'curl -sf http://localhost:4444/status | grep -q ''"ready":true'' || exit 1',
+          'curl -sf http://localhost:4444/status | grep -qE ''"ready"[[:space:]]*:[[:space:]]*true'' || exit 1',
         ]
       interval: 10s
-      timeout: 5s
+      timeout: 10s
       retries: 12
-      start_period: 15s
+      start_period: 60s
 
   web:
     build: .


### PR DESCRIPTION
Add Docker Compose smoke tests and deploy health verification

- Add docker-compose.ci.yml with Postgres and service depends_on for CI
- Add compose-smoke job: build, up --wait, migrate, make health, make down
- Add Makefile health target (Django check, Redis, Selenium, Celery ps)
- Retry make health in deploy.sh after make up
- Adjust deploy workflow (deploy.yml)