### PR TITLE
Link pagination, client helpers, logging, clang sync dates (#121)

### DIFF
--- a/clang_github_tracker/sync_raw.py
+++ b/clang_github_tracker/sync_raw.py
@@ -56,7 +56,8 @@ def _issue_date(issue_data: dict) -> datetime | None:
 
 def _pr_date(pr_data: dict) -> datetime | None:
     """Extract updated_at or created_at from GitHub PR payload.
-    Fetcher yields {pr_info: <detail>, comments: [...], reviews: [...]}, so check nested first."""
+    Fetcher yields {pr_info: <detail>, comments: [...], reviews: [...]}, so check nested first.
+    """
     info = pr_data.get("pr_info") or pr_data
     date_str = info.get("updated_at") or info.get("created_at")
     if not date_str:

--- a/clang_github_tracker/sync_raw.py
+++ b/clang_github_tracker/sync_raw.py
@@ -45,16 +45,20 @@ def _commit_date(commit_data: dict) -> datetime | None:
 
 
 def _issue_date(issue_data: dict) -> datetime | None:
-    """Extract updated_at or created_at from GitHub issue payload."""
-    date_str = issue_data.get("updated_at") or issue_data.get("created_at")
+    """Extract updated_at or created_at from GitHub issue payload.
+    Fetcher yields {issue_info: <detail>, comments: [...]}, so check nested first."""
+    info = issue_data.get("issue_info") or issue_data
+    date_str = info.get("updated_at") or info.get("created_at")
     if not date_str:
         return None
     return clang_state.parse_iso(date_str)
 
 
 def _pr_date(pr_data: dict) -> datetime | None:
-    """Extract updated_at or created_at from GitHub PR payload."""
-    date_str = pr_data.get("updated_at") or pr_data.get("created_at")
+    """Extract updated_at or created_at from GitHub PR payload.
+    Fetcher yields {pr_info: <detail>, comments: [...], reviews: [...]}, so check nested first."""
+    info = pr_data.get("pr_info") or pr_data
+    date_str = info.get("updated_at") or info.get("created_at")
     if not date_str:
         return None
     return clang_state.parse_iso(date_str)

--- a/config/logging_handlers.py
+++ b/config/logging_handlers.py
@@ -3,8 +3,8 @@ Custom logging handlers for the Boost Data Collector project.
 
 SafeRotatingFileHandler: RotatingFileHandler that serializes emit() with a lock
 so rollover (close → rename → reopen) is not run while another thread is writing.
-Fixes PermissionError [WinError 32] on Windows when multiple threads log to the
-same file (e.g. Celery worker + ThreadPoolExecutor workers in boost_searcher).
+On Windows, rename() is retried on PermissionError [WinError 32] because the file
+can remain locked briefly after close (or another process may have it open).
 
 DiscordHandler / SlackHandler: send ERROR-level log records to Discord/Slack
 webhooks when ENABLE_ERROR_NOTIFICATIONS is True and webhook URLs are set.
@@ -13,6 +13,7 @@ webhooks when ENABLE_ERROR_NOTIFICATIONS is True and webhook URLs are set.
 import json
 import logging
 import logging.handlers
+import os
 import sys
 import threading
 import time
@@ -241,12 +242,18 @@ class SlackHandler(logging.Handler):
             sys.stderr.write(f"Error in SlackHandler: {e}\n")
 
 
+# Retry rollover rename on Windows when file is still locked (PermissionError 32).
+_ROTATE_RETRY_COUNT = 10
+_ROTATE_RETRY_DELAY_SEC = 0.5
+
+
 class SafeRotatingFileHandler(logging.handlers.RotatingFileHandler):
     """
     Thread-safe RotatingFileHandler. Use this when multiple threads write to
     the same log file (e.g. Celery + thread pools). On Windows, the standard
     RotatingFileHandler can raise PermissionError during rollover because
-    os.rename() fails if the file is still open by another thread.
+    os.rename() fails if the file is still open. This handler serializes emit()
+    and retries the rename on PermissionError so rollover succeeds.
     """
 
     def __init__(self, *args, **kwargs):
@@ -256,3 +263,28 @@ class SafeRotatingFileHandler(logging.handlers.RotatingFileHandler):
     def emit(self, record):
         with self._emit_lock:
             super().emit(record)
+
+    def rotate(self, source, dest):
+        """Rename source to dest, retrying on Windows PermissionError [WinError 32].
+        If rename still fails after retries (e.g. another process has the file),
+        skip rollover so logging continues without archiving the current file.
+        """
+        for attempt in range(_ROTATE_RETRY_COUNT):
+            try:
+                os.rename(source, dest)
+                return
+            except OSError as e:
+                # WinError 32: "file is being used by another process"
+                if getattr(e, "winerror", None) != 32:
+                    raise
+                if attempt == _ROTATE_RETRY_COUNT - 1:
+                    # Skip rollover instead of raising so logging does not break
+                    try:
+                        sys.stderr.write(
+                            "SafeRotatingFileHandler: rollover skipped "
+                            "(file in use). Logging continues.\n"
+                        )
+                    except Exception:
+                        pass
+                    return
+                time.sleep(_ROTATE_RETRY_DELAY_SEC)

--- a/config/logging_handlers.py
+++ b/config/logging_handlers.py
@@ -3,11 +3,11 @@ Custom logging handlers for the Boost Data Collector project.
 
 SafeRotatingFileHandler: RotatingFileHandler that serializes emit() with a lock
 so rollover (close → rename → reopen) is not run while another thread is writing.
-On Windows, every rollover rename (including .1 → .2, etc.) is retried on
-PermissionError [WinError 32] because files can stay locked briefly after close
-(or another process may have them open). The base RotatingFileHandler only uses
-custom rotate() for the final move; this subclass overrides doRollover() so all
-renames share the same safe path.
+On Windows, every rollover rename (including .1 → .2, etc.) and removal of
+existing backup targets is retried on PermissionError [WinError 32] because files
+can stay locked briefly after close (or another process may have them open). The
+base RotatingFileHandler only uses custom rotate() for the final move; this
+subclass overrides doRollover() so all renames and deletes share the same safe path.
 
 DiscordHandler / SlackHandler: send ERROR-level log records to Discord/Slack
 webhooks when ENABLE_ERROR_NOTIFICATIONS is True and webhook URLs are set.
@@ -245,7 +245,7 @@ class SlackHandler(logging.Handler):
             sys.stderr.write(f"Error in SlackHandler: {e}\n")
 
 
-# Retry rollover rename on Windows when file is still locked (PermissionError 32).
+# Retry rollover rename/remove on Windows when file is still locked (PermissionError 32).
 _ROTATE_RETRY_COUNT = 10
 _ROTATE_RETRY_DELAY_SEC = 0.5
 
@@ -255,8 +255,9 @@ class SafeRotatingFileHandler(logging.handlers.RotatingFileHandler):
     Thread-safe RotatingFileHandler. Use this when multiple threads write to
     the same log file (e.g. Celery + thread pools). On Windows, the standard
     RotatingFileHandler can raise PermissionError during rollover because
-    os.rename() fails if the file is still open. This handler serializes emit()
-    and retries the rename on PermissionError so rollover succeeds.
+    os.rename() / os.remove() can fail if the file is still open. This handler
+    serializes emit() and retries rename and remove on WinError 32 so rollover
+    usually succeeds; otherwise it skips and logging continues.
     """
 
     def __init__(self, *args, **kwargs):
@@ -291,6 +292,33 @@ class SafeRotatingFileHandler(logging.handlers.RotatingFileHandler):
                     return
                 time.sleep(_ROTATE_RETRY_DELAY_SEC)
 
+    def _safe_remove(self, path):
+        """Remove path, retrying on Windows PermissionError [WinError 32].
+        If remove still fails after retries, log and return so rollover continues.
+        No-op if path is already absent (including races with other processes).
+        """
+        if not os.path.exists(path):
+            return
+        for attempt in range(_ROTATE_RETRY_COUNT):
+            try:
+                os.remove(path)
+                return
+            except OSError as e:
+                if not os.path.exists(path):
+                    return
+                if getattr(e, "winerror", None) != 32:
+                    raise
+                if attempt == _ROTATE_RETRY_COUNT - 1:
+                    try:
+                        sys.stderr.write(
+                            "SafeRotatingFileHandler: rollover skipped "
+                            "(file in use). Logging continues.\n"
+                        )
+                    except Exception:
+                        pass
+                    return
+                time.sleep(_ROTATE_RETRY_DELAY_SEC)
+
     def rotate(self, source, dest):
         """Delegate to _safe_rename (used for the final base → .1 move)."""
         self._safe_rename(source, dest)
@@ -306,11 +334,11 @@ class SafeRotatingFileHandler(logging.handlers.RotatingFileHandler):
                 dfn = self.rotation_filename("%s.%d" % (self.baseFilename, i + 1))
                 if os.path.exists(sfn):
                     if os.path.exists(dfn):
-                        os.remove(dfn)
+                        self._safe_remove(dfn)
                     self._safe_rename(sfn, dfn)
             dfn = self.rotation_filename(self.baseFilename + ".1")
             if os.path.exists(dfn):
-                os.remove(dfn)
+                self._safe_remove(dfn)
             self.rotate(self.baseFilename, dfn)
         if not self.delay:
             self.stream = self._open()

--- a/config/logging_handlers.py
+++ b/config/logging_handlers.py
@@ -3,8 +3,11 @@ Custom logging handlers for the Boost Data Collector project.
 
 SafeRotatingFileHandler: RotatingFileHandler that serializes emit() with a lock
 so rollover (close → rename → reopen) is not run while another thread is writing.
-On Windows, rename() is retried on PermissionError [WinError 32] because the file
-can remain locked briefly after close (or another process may have it open).
+On Windows, every rollover rename (including .1 → .2, etc.) is retried on
+PermissionError [WinError 32] because files can stay locked briefly after close
+(or another process may have them open). The base RotatingFileHandler only uses
+custom rotate() for the final move; this subclass overrides doRollover() so all
+renames share the same safe path.
 
 DiscordHandler / SlackHandler: send ERROR-level log records to Discord/Slack
 webhooks when ENABLE_ERROR_NOTIFICATIONS is True and webhook URLs are set.
@@ -264,10 +267,10 @@ class SafeRotatingFileHandler(logging.handlers.RotatingFileHandler):
         with self._emit_lock:
             super().emit(record)
 
-    def rotate(self, source, dest):
+    def _safe_rename(self, source, dest):
         """Rename source to dest, retrying on Windows PermissionError [WinError 32].
         If rename still fails after retries (e.g. another process has the file),
-        skip rollover so logging continues without archiving the current file.
+        skip this rename so rollover / logging can continue.
         """
         for attempt in range(_ROTATE_RETRY_COUNT):
             try:
@@ -278,7 +281,6 @@ class SafeRotatingFileHandler(logging.handlers.RotatingFileHandler):
                 if getattr(e, "winerror", None) != 32:
                     raise
                 if attempt == _ROTATE_RETRY_COUNT - 1:
-                    # Skip rollover instead of raising so logging does not break
                     try:
                         sys.stderr.write(
                             "SafeRotatingFileHandler: rollover skipped "
@@ -288,3 +290,27 @@ class SafeRotatingFileHandler(logging.handlers.RotatingFileHandler):
                         pass
                     return
                 time.sleep(_ROTATE_RETRY_DELAY_SEC)
+
+    def rotate(self, source, dest):
+        """Delegate to _safe_rename (used for the final base → .1 move)."""
+        self._safe_rename(source, dest)
+
+    def doRollover(self):
+        """Like RotatingFileHandler.doRollover but safe renames for all backup steps."""
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+        if self.backupCount > 0:
+            for i in range(self.backupCount - 1, 0, -1):
+                sfn = self.rotation_filename("%s.%d" % (self.baseFilename, i))
+                dfn = self.rotation_filename("%s.%d" % (self.baseFilename, i + 1))
+                if os.path.exists(sfn):
+                    if os.path.exists(dfn):
+                        os.remove(dfn)
+                    self._safe_rename(sfn, dfn)
+            dfn = self.rotation_filename(self.baseFilename + ".1")
+            if os.path.exists(dfn):
+                os.remove(dfn)
+            self.rotate(self.baseFilename, dfn)
+        if not self.delay:
+            self.stream = self._open()

--- a/github_activity_tracker/fetcher.py
+++ b/github_activity_tracker/fetcher.py
@@ -53,9 +53,7 @@ def fetch_commits_from_github(
     """Fetch commits from GitHub API (paginated). Yields commit dicts with stats.
     If etag_cache is provided, uses rest_request_conditional for the list GET.
     """
-    logger.debug(
-        f"Fetching commits for {owner}/{repo} from {start_time} to {end_time}"
-    )
+    logger.debug(f"Fetching commits for {owner}/{repo} from {start_time} to {end_time}")
     page = 1
     per_page = 100
     since_iso = start_time.isoformat() if start_time else ""
@@ -78,17 +76,13 @@ def fetch_commits_from_github(
                 f"/repos/{owner}/{repo}/commits", params=params, etag=etag
             )
             if data is None:
-                logger.debug(
-                    "Commits list page %s: 304 Not Modified, skipping", page
-                )
+                logger.debug("Commits list page %s: 304 Not Modified, skipping", page)
                 page += 1
                 time.sleep(0.2)
                 continue
             commits = data
         else:
-            commits = client.rest_request(
-                f"/repos/{owner}/{repo}/commits", params
-            )
+            commits = client.rest_request(f"/repos/{owner}/{repo}/commits", params)
 
         if not commits:
             logger.debug(f"No more commits found at page {page}")
@@ -151,9 +145,7 @@ def fetch_commits_from_github(
             yield commit_with_stats
 
         if etag_cache is not None and response_etag:
-            etag_cache.set(
-                "commits", page, since_iso, until_iso, response_etag
-            )
+            etag_cache.set("commits", page, since_iso, until_iso, response_etag)
 
         if len(commits) < per_page:
             logger.debug(
@@ -207,9 +199,7 @@ def fetch_comments_from_github(
             created_str = comment.get("created_at")
             if created_str:
                 try:
-                    c_dt = datetime.fromisoformat(
-                        created_str.replace("Z", "+00:00")
-                    )
+                    c_dt = datetime.fromisoformat(created_str.replace("Z", "+00:00"))
 
                     if start_time:
                         start_time_aware = (
@@ -229,9 +219,7 @@ def fetch_comments_from_github(
                         if c_dt > end_time_aware:
                             continue
                 except Exception as e:
-                    logger.debug(
-                        f"Failed to parse comment date '{created_str}': {e}"
-                    )
+                    logger.debug(f"Failed to parse comment date '{created_str}': {e}")
 
             results.append(comment)
 
@@ -240,9 +228,7 @@ def fetch_comments_from_github(
         page += 1
         time.sleep(0.1)
 
-    logger.debug(
-        f"Total comments fetched for issue #{issue_number}: {len(results)}"
-    )
+    logger.debug(f"Total comments fetched for issue #{issue_number}: {len(results)}")
     return results
 
 
@@ -258,9 +244,7 @@ def fetch_issues_from_github(
     Uses GitHub's Link header (rel=\"next\") for pagination per API docs.
     If etag_cache is provided, uses conditional GET for the first page when using endpoint+params.
     """
-    logger.debug(
-        f"Fetching issues for {owner}/{repo} from {start_time} to {end_time}"
-    )
+    logger.debug(f"Fetching issues for {owner}/{repo} from {start_time} to {end_time}")
     per_page = 100
     since_iso = start_time.isoformat() if start_time else ""
     endpoint = f"/repos/{owner}/{repo}/issues"
@@ -300,9 +284,7 @@ def fetch_issues_from_github(
                         continue
                     issues = data
                 else:
-                    issues, next_url = client.rest_request_with_link(
-                        endpoint, params
-                    )
+                    issues, next_url = client.rest_request_with_link(endpoint, params)
         except requests.exceptions.HTTPError as e:
             if e.response is not None and e.response.status_code == 422:
                 logger.debug(
@@ -329,13 +311,9 @@ def fetch_issues_from_github(
             if not updated_str:
                 continue
             try:
-                issue_dt = datetime.fromisoformat(
-                    updated_str.replace("Z", "+00:00")
-                )
+                issue_dt = datetime.fromisoformat(updated_str.replace("Z", "+00:00"))
             except (ValueError, TypeError) as e:
-                logger.debug(
-                    f"Failed to parse issue date '{updated_str}': {e}"
-                )
+                logger.debug(f"Failed to parse issue date '{updated_str}': {e}")
                 continue
 
             if start_time:
@@ -365,9 +343,7 @@ def fetch_issues_from_github(
                     if full_issue and isinstance(full_issue, dict):
                         issue = full_issue
                 except Exception as e:
-                    logger.debug(
-                        "Failed to fetch full issue #%s: %s", issue_number, e
-                    )
+                    logger.debug("Failed to fetch full issue #%s: %s", issue_number, e)
                 logger.debug(f"Fetching comments for issue #{issue_number}")
                 comments = fetch_comments_from_github(
                     client, owner, repo, issue_number, start_time, end_time
@@ -443,9 +419,7 @@ def fetch_pr_reviews_from_github(
                         if review_dt > end_time_aware:
                             continue
                 except Exception as e:
-                    logger.debug(
-                        f"Failed to parse review date '{updated_str}': {e}"
-                    )
+                    logger.debug(f"Failed to parse review date '{updated_str}': {e}")
 
             results.append(review)
 
@@ -474,9 +448,7 @@ def fetch_pull_requests_from_github(
     """Fetch pull requests from GitHub API (paginated). Yields PR dicts with comments and reviews.
     If etag_cache is provided, uses rest_request_conditional for the list GET.
     """
-    logger.debug(
-        f"Fetching PRs for {owner}/{repo} from {start_time} to {end_time}"
-    )
+    logger.debug(f"Fetching PRs for {owner}/{repo} from {start_time} to {end_time}")
     page = 1
     per_page = 100
 
@@ -495,9 +467,7 @@ def fetch_pull_requests_from_github(
                 f"/repos/{owner}/{repo}/pulls", params=params, etag=etag
             )
             if data is None:
-                logger.debug(
-                    "Pulls list page %s: 304 Not Modified, skipping", page
-                )
+                logger.debug("Pulls list page %s: 304 Not Modified, skipping", page)
                 page += 1
                 time.sleep(0.2)
                 continue
@@ -513,14 +483,10 @@ def fetch_pull_requests_from_github(
         for pr in prs:
             updated_str = pr.get("updated_at") or pr.get("created_at")
             pr_number = pr.get("number")
-            logger.debug(
-                "Fetching PR #%s with updated_str: %s", pr_number, updated_str
-            )
+            logger.debug("Fetching PR #%s with updated_str: %s", pr_number, updated_str)
             if updated_str:
                 try:
-                    pr_dt = datetime.fromisoformat(
-                        updated_str.replace("Z", "+00:00")
-                    )
+                    pr_dt = datetime.fromisoformat(updated_str.replace("Z", "+00:00"))
 
                     if start_time:
                         start_time_aware = (
@@ -541,9 +507,7 @@ def fetch_pull_requests_from_github(
                         if pr_dt > end_time_aware:
                             continue
                 except Exception as e:
-                    logger.debug(
-                        "Failed to parse PR date '%s': %s", updated_str, e
-                    )
+                    logger.debug("Failed to parse PR date '%s': %s", updated_str, e)
                     continue
 
             if pr_number is None:
@@ -576,9 +540,7 @@ def fetch_pull_requests_from_github(
             etag_cache.set("pulls", page, "", "", response_etag)
 
         if len(prs) < per_page or flag:
-            logger.debug(
-                f"Last page reached (got {len(prs)} PRs, expected {per_page})"
-            )
+            logger.debug(f"Last page reached (got {len(prs)} PRs, expected {per_page})")
             break
         page += 1
         time.sleep(0.2)

--- a/github_activity_tracker/fetcher.py
+++ b/github_activity_tracker/fetcher.py
@@ -53,7 +53,9 @@ def fetch_commits_from_github(
     """Fetch commits from GitHub API (paginated). Yields commit dicts with stats.
     If etag_cache is provided, uses rest_request_conditional for the list GET.
     """
-    logger.debug(f"Fetching commits for {owner}/{repo} from {start_time} to {end_time}")
+    logger.debug(
+        f"Fetching commits for {owner}/{repo} from {start_time} to {end_time}"
+    )
     page = 1
     per_page = 100
     since_iso = start_time.isoformat() if start_time else ""
@@ -76,13 +78,17 @@ def fetch_commits_from_github(
                 f"/repos/{owner}/{repo}/commits", params=params, etag=etag
             )
             if data is None:
-                logger.debug("Commits list page %s: 304 Not Modified, skipping", page)
+                logger.debug(
+                    "Commits list page %s: 304 Not Modified, skipping", page
+                )
                 page += 1
                 time.sleep(0.2)
                 continue
             commits = data
         else:
-            commits = client.rest_request(f"/repos/{owner}/{repo}/commits", params)
+            commits = client.rest_request(
+                f"/repos/{owner}/{repo}/commits", params
+            )
 
         if not commits:
             logger.debug(f"No more commits found at page {page}")
@@ -127,7 +133,11 @@ def fetch_commits_from_github(
                     f"/repos/{owner}/{repo}/commits/{commit['sha']}"
                 )
             except requests.exceptions.HTTPError as e:
-                if e.response is not None and e.response.status_code in (502, 503, 504):
+                if e.response is not None and e.response.status_code in (
+                    502,
+                    503,
+                    504,
+                ):
                     logger.warning(
                         "Aborting commit sync at %s for %s/%s after HTTP %s: %s",
                         commit["sha"][:7],
@@ -141,7 +151,9 @@ def fetch_commits_from_github(
             yield commit_with_stats
 
         if etag_cache is not None and response_etag:
-            etag_cache.set("commits", page, since_iso, until_iso, response_etag)
+            etag_cache.set(
+                "commits", page, since_iso, until_iso, response_etag
+            )
 
         if len(commits) < per_page:
             logger.debug(
@@ -195,7 +207,9 @@ def fetch_comments_from_github(
             created_str = comment.get("created_at")
             if created_str:
                 try:
-                    c_dt = datetime.fromisoformat(created_str.replace("Z", "+00:00"))
+                    c_dt = datetime.fromisoformat(
+                        created_str.replace("Z", "+00:00")
+                    )
 
                     if start_time:
                         start_time_aware = (
@@ -215,7 +229,9 @@ def fetch_comments_from_github(
                         if c_dt > end_time_aware:
                             continue
                 except Exception as e:
-                    logger.debug(f"Failed to parse comment date '{created_str}': {e}")
+                    logger.debug(
+                        f"Failed to parse comment date '{created_str}': {e}"
+                    )
 
             results.append(comment)
 
@@ -224,7 +240,9 @@ def fetch_comments_from_github(
         page += 1
         time.sleep(0.1)
 
-    logger.debug(f"Total comments fetched for issue #{issue_number}: {len(results)}")
+    logger.debug(
+        f"Total comments fetched for issue #{issue_number}: {len(results)}"
+    )
     return results
 
 
@@ -237,56 +255,87 @@ def fetch_issues_from_github(
     etag_cache: Optional[Any] = None,
 ) -> Iterator[dict]:
     """Fetch issues from GitHub API (paginated). Yields issue dicts with comments.
-    If etag_cache is provided, uses rest_request_conditional for the list GET.
+    Uses GitHub's Link header (rel=\"next\") for pagination per API docs.
+    If etag_cache is provided, uses conditional GET for the first page when using endpoint+params.
     """
-    logger.debug(f"Fetching issues for {owner}/{repo} from {start_time} to {end_time}")
-    page = 1
+    logger.debug(
+        f"Fetching issues for {owner}/{repo} from {start_time} to {end_time}"
+    )
     per_page = 100
     since_iso = start_time.isoformat() if start_time else ""
+    endpoint = f"/repos/{owner}/{repo}/issues"
+    next_url: Optional[str] = None
+    page_num = 1
+    response_etag: Optional[str] = None
 
     while True:
-        params = {
-            "state": "all",
-            "per_page": per_page,
-            "page": page,
-            "sort": "updated",
-            "direction": "asc",
-        }
-        if start_time:
-            params["since"] = start_time.isoformat()
-
-        response_etag = None
-        if etag_cache is not None:
-            etag = etag_cache.get("issues", page, since_iso, "")
-            data, response_etag = client.rest_request_conditional(
-                f"/repos/{owner}/{repo}/issues", params=params, etag=etag
-            )
-            if data is None:
-                logger.debug("Issues list page %s: 304 Not Modified, skipping", page)
-                page += 1
-                time.sleep(0.2)
-                continue
-            issues = data
-        else:
-            issues = client.rest_request(f"/repos/{owner}/{repo}/issues", params)
+        try:
+            if next_url is not None:
+                issues, next_url = client.rest_request_url(next_url)
+                page_num += 1
+            else:
+                params = {
+                    "state": "all",
+                    "per_page": per_page,
+                    "page": page_num,
+                    "sort": "updated",
+                    "direction": "asc",
+                }
+                if start_time:
+                    params["since"] = start_time.isoformat()
+                if etag_cache is not None:
+                    etag = etag_cache.get("issues", page_num, since_iso, "")
+                    data, response_etag, next_url = (
+                        client.rest_request_conditional_with_link(
+                            endpoint, params=params, etag=etag
+                        )
+                    )
+                    if data is None:
+                        logger.debug(
+                            "Issues list page %s: 304 Not Modified, skipping",
+                            page_num,
+                        )
+                        page_num += 1
+                        time.sleep(0.2)
+                        continue
+                    issues = data
+                else:
+                    issues, next_url = client.rest_request_with_link(
+                        endpoint, params
+                    )
+        except requests.exceptions.HTTPError as e:
+            if e.response is not None and e.response.status_code == 422:
+                logger.debug(
+                    "Issues list: 422 Unprocessable Entity, stopping pagination"
+                )
+                break
+            raise
 
         if not issues:
-            logger.debug(f"No more issues found at page {page}")
+            logger.debug("No more issues found")
             break
 
         # Filter out PRs (issues endpoint returns both issues and PRs)
         raw_issues = issues
         issues = [i for i in raw_issues if "pull_request" not in i]
-        logger.debug(f"Fetched {len(issues)} issues (excluding PRs) from page {page}")
+        logger.debug(
+            "Fetched %s issues (excluding PRs) from page %s",
+            len(issues),
+            page_num,
+        )
 
         for issue in issues:
             updated_str = issue.get("updated_at") or issue.get("created_at")
             if not updated_str:
                 continue
             try:
-                issue_dt = datetime.fromisoformat(updated_str.replace("Z", "+00:00"))
+                issue_dt = datetime.fromisoformat(
+                    updated_str.replace("Z", "+00:00")
+                )
             except (ValueError, TypeError) as e:
-                logger.debug(f"Failed to parse issue date '{updated_str}': {e}")
+                logger.debug(
+                    f"Failed to parse issue date '{updated_str}': {e}"
+                )
                 continue
 
             if start_time:
@@ -316,7 +365,9 @@ def fetch_issues_from_github(
                     if full_issue and isinstance(full_issue, dict):
                         issue = full_issue
                 except Exception as e:
-                    logger.debug("Failed to fetch full issue #%s: %s", issue_number, e)
+                    logger.debug(
+                        "Failed to fetch full issue #%s: %s", issue_number, e
+                    )
                 logger.debug(f"Fetching comments for issue #{issue_number}")
                 comments = fetch_comments_from_github(
                     client, owner, repo, issue_number, start_time, end_time
@@ -328,14 +379,11 @@ def fetch_issues_from_github(
                 yield {"issue_info": issue, "comments": comments}
 
         if etag_cache is not None and response_etag:
-            etag_cache.set("issues", page, since_iso, "", response_etag)
+            etag_cache.set("issues", page_num, since_iso, "", response_etag)
 
-        if len(raw_issues) < per_page:
-            logger.debug(
-                f"Last page reached (got {len(issues)} issues, expected {per_page})"
-            )
+        if next_url is None:
+            logger.debug('Last page reached (no Link rel="next")')
             break
-        page += 1
         time.sleep(0.2)
 
 
@@ -395,7 +443,9 @@ def fetch_pr_reviews_from_github(
                         if review_dt > end_time_aware:
                             continue
                 except Exception as e:
-                    logger.debug(f"Failed to parse review date '{updated_str}': {e}")
+                    logger.debug(
+                        f"Failed to parse review date '{updated_str}': {e}"
+                    )
 
             results.append(review)
 
@@ -424,7 +474,9 @@ def fetch_pull_requests_from_github(
     """Fetch pull requests from GitHub API (paginated). Yields PR dicts with comments and reviews.
     If etag_cache is provided, uses rest_request_conditional for the list GET.
     """
-    logger.debug(f"Fetching PRs for {owner}/{repo} from {start_time} to {end_time}")
+    logger.debug(
+        f"Fetching PRs for {owner}/{repo} from {start_time} to {end_time}"
+    )
     page = 1
     per_page = 100
 
@@ -443,7 +495,9 @@ def fetch_pull_requests_from_github(
                 f"/repos/{owner}/{repo}/pulls", params=params, etag=etag
             )
             if data is None:
-                logger.debug("Pulls list page %s: 304 Not Modified, skipping", page)
+                logger.debug(
+                    "Pulls list page %s: 304 Not Modified, skipping", page
+                )
                 page += 1
                 time.sleep(0.2)
                 continue
@@ -459,10 +513,14 @@ def fetch_pull_requests_from_github(
         for pr in prs:
             updated_str = pr.get("updated_at") or pr.get("created_at")
             pr_number = pr.get("number")
-            logger.debug("Fetching PR #%s with updated_str: %s", pr_number, updated_str)
+            logger.debug(
+                "Fetching PR #%s with updated_str: %s", pr_number, updated_str
+            )
             if updated_str:
                 try:
-                    pr_dt = datetime.fromisoformat(updated_str.replace("Z", "+00:00"))
+                    pr_dt = datetime.fromisoformat(
+                        updated_str.replace("Z", "+00:00")
+                    )
 
                     if start_time:
                         start_time_aware = (
@@ -483,7 +541,9 @@ def fetch_pull_requests_from_github(
                         if pr_dt > end_time_aware:
                             continue
                 except Exception as e:
-                    logger.debug("Failed to parse PR date '%s': %s", updated_str, e)
+                    logger.debug(
+                        "Failed to parse PR date '%s': %s", updated_str, e
+                    )
                     continue
 
             if pr_number is None:
@@ -516,7 +576,9 @@ def fetch_pull_requests_from_github(
             etag_cache.set("pulls", page, "", "", response_etag)
 
         if len(prs) < per_page or flag:
-            logger.debug(f"Last page reached (got {len(prs)} PRs, expected {per_page})")
+            logger.debug(
+                f"Last page reached (got {len(prs)} PRs, expected {per_page})"
+            )
             break
         page += 1
         time.sleep(0.2)

--- a/github_activity_tracker/fetcher.py
+++ b/github_activity_tracker/fetcher.py
@@ -250,9 +250,11 @@ def fetch_issues_from_github(
     endpoint = f"/repos/{owner}/{repo}/issues"
     next_url: Optional[str] = None
     page_num = 1
-    response_etag: Optional[str] = None
 
     while True:
+        # Fresh each page: rest_request_url does not return an ETag; do not reuse
+        # page N-1's tag when caching page N (conditional path sets this below).
+        response_etag: Optional[str] = None
         try:
             if next_url is not None:
                 issues, next_url = client.rest_request_url(next_url)

--- a/github_activity_tracker/tests/test_fetcher.py
+++ b/github_activity_tracker/tests/test_fetcher.py
@@ -275,9 +275,12 @@ def test_fetch_comments_from_github_calls_correct_endpoint():
 def test_fetch_issues_from_github_yields_issue_dicts():
     """fetch_issues_from_github yields nested { issue_info, comments } dicts."""
     client = MagicMock()
-    # List returns one issue; then full issue GET; then comments
-    client.rest_request.side_effect = [
+    # First page via Link-header API (list + next_url); then full issue GET; then comments
+    client.rest_request_with_link.return_value = (
         [{"number": 1, "title": "Issue 1", "updated_at": "2024-06-01T00:00:00Z"}],
+        None,
+    )
+    client.rest_request.side_effect = [
         {"number": 1, "title": "Issue 1", "updated_at": "2024-06-01T00:00:00Z"},
         [],  # comments for issue 1
     ]
@@ -291,11 +294,14 @@ def test_fetch_issues_from_github_yields_issue_dicts():
 def test_fetch_issues_from_github_filters_out_pulls():
     """fetch_issues_from_github filters out items that have pull_request key."""
     client = MagicMock()
-    client.rest_request.side_effect = [
+    client.rest_request_with_link.return_value = (
         [
             {"number": 1, "pull_request": {}},
             {"number": 2, "updated_at": "2024-06-01T00:00:00Z"},
         ],
+        None,
+    )
+    client.rest_request.side_effect = [
         {"number": 2, "updated_at": "2024-06-01T00:00:00Z"},  # full issue for #2
         [],  # comments for issue 2
     ]
@@ -307,9 +313,10 @@ def test_fetch_issues_from_github_filters_out_pulls():
 def test_fetch_issues_from_github_stops_on_empty_page():
     """fetch_issues_from_github stops when API returns empty list."""
     client = MagicMock()
-    client.rest_request.return_value = []
+    client.rest_request_with_link.return_value = ([], None)
     items = list(fetch_issues_from_github(client, "owner", "repo"))
     assert items == []
+    client.rest_request.assert_not_called()
 
 
 # --- fetch_pr_reviews_from_github ---

--- a/github_ops/client.py
+++ b/github_ops/client.py
@@ -7,10 +7,11 @@ from __future__ import annotations
 
 import base64
 import logging
+import re
 import time
 from email.utils import parsedate_to_datetime
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Optional, Union
 
 import requests
 from requests.exceptions import ConnectionError, RequestException, Timeout
@@ -20,7 +21,7 @@ from core.utils.datetime_parsing import parse_iso_datetime
 
 logger = logging.getLogger(__name__)
 
-MAX_RATE_LIMIT_RETRIES = 5
+MAX_RATE_LIMIT_RETRIES = 15
 # Extra seconds added to API reset-based wait so we don't retry before the window opens.
 RATE_LIMIT_WAIT_SAFETY_MARGIN_SEC = 10
 
@@ -65,8 +66,12 @@ class GitHubAPIClient:
                 )
                 if response.status_code == 200:
                     data = response.json()
-                    self.rate_limit_remaining = data["resources"]["core"]["remaining"]
-                    self.rate_limit_reset_time = data["resources"]["core"]["reset"]
+                    self.rate_limit_remaining = data["resources"]["core"][
+                        "remaining"
+                    ]
+                    self.rate_limit_reset_time = data["resources"]["core"][
+                        "reset"
+                    ]
 
                     if self.rate_limit_remaining == 0:
                         wait_time = max(
@@ -80,7 +85,9 @@ class GitHubAPIClient:
                 return True
             except (ConnectionError, ProtocolError, Timeout) as e:
                 if attempt < self.max_retries - 1:
-                    wait_time = self.retry_delay * (2**attempt)  # Exponential backoff
+                    wait_time = self.retry_delay * (
+                        2**attempt
+                    )  # Exponential backoff
                     logger.warning(
                         f"Connection error checking rate limit (attempt {attempt + 1}/{self.max_retries}): {e}"
                     )
@@ -97,7 +104,9 @@ class GitHubAPIClient:
                 logger.error(f"Request error checking rate limit: {e}")
                 raise
 
-    def _parse_rate_limit_wait(self, response: requests.Response) -> Optional[int]:
+    def _parse_rate_limit_wait(
+        self, response: requests.Response
+    ) -> Optional[int]:
         """If response is 403/429 with rate limit or Retry-After, return seconds to wait; else None.
 
         Also handles HTTP 200 GraphQL throttle responses, which GitHub returns with
@@ -110,7 +119,9 @@ class GitHubAPIClient:
                 # consumed the last token, not that it was throttled.
                 try:
                     body = response.json()
-                    body_throttled = isinstance(body, dict) and "errors" in body
+                    body_throttled = (
+                        isinstance(body, dict) and "errors" in body
+                    )
                 except (ValueError, KeyError):
                     body_throttled = False
                 if not body_throttled:
@@ -121,14 +132,21 @@ class GitHubAPIClient:
         if retry_after is not None:
             retry_after = retry_after.strip()
             try:
-                return max(0, int(retry_after))
+                remaining = max(0, int(retry_after))
+                if remaining != 0:
+                    return remaining
+                else:
+                    return None
             except ValueError:
                 try:
                     dt = parsedate_to_datetime(retry_after)
                     if dt.tzinfo is None:
                         dt = dt.replace(tzinfo=timezone.utc)
                     wait = (dt - datetime.now(timezone.utc)).total_seconds()
-                    return max(0, int(wait))
+                    if wait > 0:
+                        return wait
+                    else:
+                        return None
                 except (ValueError, TypeError):
                     pass
         remaining = response.headers.get("X-RateLimit-Remaining")
@@ -147,10 +165,14 @@ class GitHubAPIClient:
             reset_int = int(reset)
         except (TypeError, ValueError):
             return None
-        wait = max(0, reset_int - int(time.time()) + RATE_LIMIT_WAIT_SAFETY_MARGIN_SEC)
+        wait = max(
+            0, reset_int - int(time.time()) + RATE_LIMIT_WAIT_SAFETY_MARGIN_SEC
+        )
         return wait
 
-    def _update_rate_limit_from_response(self, response: requests.Response) -> None:
+    def _update_rate_limit_from_response(
+        self, response: requests.Response
+    ) -> None:
         """Update rate limit state from response headers if present."""
         remaining = response.headers.get("X-RateLimit-Remaining")
         reset = response.headers.get("X-RateLimit-Reset")
@@ -204,7 +226,9 @@ class GitHubAPIClient:
         because this client uses it only for read-only queries (e.g. file content).
         """
         attempts_5xx = self.max_retries if allow_retry_on_5xx else 1
-        attempts_conn = self.max_retries if allow_retry_on_connection_errors else 1
+        attempts_conn = (
+            self.max_retries if allow_retry_on_connection_errors else 1
+        )
         for rate_limit_attempt in range(MAX_RATE_LIMIT_RETRIES + 1):
             rate_limited = False
             attempt_5xx = 0
@@ -225,11 +249,14 @@ class GitHubAPIClient:
                             raise RateLimitException(
                                 f"Rate limit retries exhausted for {endpoint_for_log}"
                             )
-                        self._handle_rate_limit(wait)
                         rate_limited = True
+                        self._handle_rate_limit(wait)
                         break
                     if resp.status_code in (500, 502, 503, 504):
-                        if allow_retry_on_5xx and attempt_5xx < attempts_5xx - 1:
+                        if (
+                            allow_retry_on_5xx
+                            and attempt_5xx < attempts_5xx - 1
+                        ):
                             wait_time = self.retry_delay * (2**attempt_5xx)
                             logger.warning(
                                 "HTTP %s on %s (attempt %s/%s), retrying in %ss...",
@@ -278,6 +305,7 @@ class GitHubAPIClient:
                         f"Connection error for {endpoint_for_log}: {e}"
                     ) from e
             if rate_limited:
+                time.sleep(1)
                 continue
             raise ConnectionException(
                 f"Connection error for {endpoint_for_log}: max retries exceeded"
@@ -339,7 +367,9 @@ class GitHubAPIClient:
         self._update_rate_limit_from_response(response)
         return (response, response.headers.get("ETag"))
 
-    def rest_request(self, endpoint: str, params: Optional[dict] = None) -> dict:
+    def rest_request(
+        self, endpoint: str, params: Optional[dict] = None
+    ) -> dict:
         """Make REST API request with rate limit and connection error handling."""
         response, _ = self._rest_get(endpoint, params=params)
         if response is None:
@@ -355,7 +385,9 @@ class GitHubAPIClient:
         """Make GET request with optional If-None-Match. Returns (data, etag).
         On 304: (None, response ETag). On 200: (response.json(), response ETag header).
         """
-        response, response_etag = self._rest_get(endpoint, params=params, etag=etag)
+        response, response_etag = self._rest_get(
+            endpoint, params=params, etag=etag
+        )
         if response is None:
             return (None, response_etag)
         return (response.json(), response_etag)
@@ -378,17 +410,90 @@ class GitHubAPIClient:
             return None
         return response.content
 
-    def rest_post(self, endpoint: str, json_data: Optional[dict] = None) -> dict:
+    def rest_request_conditional_with_link(
+        self,
+        endpoint: str,
+        params: Optional[dict] = None,
+        etag: Optional[str] = None,
+    ) -> tuple[Optional[dict], Optional[str], Optional[str]]:
+        """Like rest_request_conditional but also returns next_page_url from Link header.
+        Returns (data, response_etag, next_page_url). On 304: (None, etag, None).
+        """
+        response, response_etag = self._rest_get(
+            endpoint, params=params, etag=etag
+        )
+        if response is None:
+            return (None, response_etag, None)
+        next_url = self._parse_link_next(response.headers.get("Link"))
+        return (response.json(), response_etag, next_url)
+
+    @staticmethod
+    def _parse_link_next(link_header: Optional[str]) -> Optional[str]:
+        """Parse GitHub Link response header; return URL for rel=\"next\" or None.
+        See: https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api
+        """
+        if not link_header or 'rel="next"' not in link_header:
+            return None
+        match = re.search(r'<([^>]+)>;\s*rel="next"', link_header)
+        return match.group(1) if match else None
+
+    def rest_request_with_link(
+        self, endpoint: str, params: Optional[dict] = None
+    ) -> tuple[Union[list, dict], Optional[str]]:
+        """GET request that returns (data, next_page_url) using the Link header.
+        next_page_url is None when there is no next page. Use rest_request_url(next_page_url) for the next page.
+        """
+        response, _ = self._rest_get(endpoint, params=params)
+        if response is None:
+            return ({}, None)
+        data = response.json()
+        next_url = self._parse_link_next(response.headers.get("Link"))
+        return (data, next_url)
+
+    def rest_request_url(
+        self, full_url: str
+    ) -> tuple[Union[list, dict], Optional[str]]:
+        """GET full_url (e.g. from Link rel=\"next\"). Returns (data, next_page_url).
+        Uses same session (auth, rate limit). next_page_url is None when no more pages.
+        """
+        response = self._rest_get_url(full_url)
+        data = response.json()
+        next_url = self._parse_link_next(response.headers.get("Link"))
+        return (data, next_url)
+
+    def _rest_get_url(self, full_url: str) -> requests.Response:
+        """GET by full URL (e.g. from Link rel=\"next\"). For pagination only."""
+        response = self._do_request(
+            "GET",
+            full_url,
+            "GET (paginated)",
+            params=None,
+            headers=None,
+            timeout=30,
+            allow_retry_on_5xx=True,
+            allow_retry_on_connection_errors=True,
+        )
+        response.raise_for_status()
+        self._update_rate_limit_from_response(response)
+        return response
+
+    def rest_post(
+        self, endpoint: str, json_data: Optional[dict] = None
+    ) -> dict:
         """POST to REST API with rate limit and connection error handling."""
         url = f"{self.rest_base_url}{endpoint}"
         payload = json_data or {}
         response = self._do_request(
             "POST", url, f"POST {endpoint}", json_data=payload, timeout=30
         )
-        self._raise_if_error_and_update_rate_limit(response, f"POST {endpoint}")
+        self._raise_if_error_and_update_rate_limit(
+            response, f"POST {endpoint}"
+        )
         return response.json()
 
-    def rest_put(self, endpoint: str, json_data: Optional[dict] = None) -> dict:
+    def rest_put(
+        self, endpoint: str, json_data: Optional[dict] = None
+    ) -> dict:
         """PUT to REST API with rate limit and connection error handling."""
         url = f"{self.rest_base_url}{endpoint}"
         payload = json_data or {}
@@ -407,7 +512,9 @@ class GitHubAPIClient:
         response = self._do_request(
             "DELETE", url, f"DELETE {endpoint}", json_data=payload, timeout=30
         )
-        self._raise_if_error_and_update_rate_limit(response, f"DELETE {endpoint}")
+        self._raise_if_error_and_update_rate_limit(
+            response, f"DELETE {endpoint}"
+        )
         if response.status_code == 204:
             return None
         return response.json()
@@ -546,7 +653,9 @@ class GitHubAPIClient:
             },
         )
 
-    def create_issue(self, owner: str, repo: str, title: str, body: str = "") -> dict:
+    def create_issue(
+        self, owner: str, repo: str, title: str, body: str = ""
+    ) -> dict:
         """Create an issue. Use client from get_github_client(use='write')."""
         return self.rest_post(
             f"/repos/{owner}/{repo}/issues",
@@ -562,7 +671,9 @@ class GitHubAPIClient:
             json_data={"body": body},
         )
 
-    def graphql_request(self, query: str, variables: Optional[dict] = None) -> dict:
+    def graphql_request(
+        self, query: str, variables: Optional[dict] = None
+    ) -> dict:
         """Make GraphQL API request with rate limit and connection error handling.
         Connection errors are retried (used for read-only queries only).
         """
@@ -637,9 +748,9 @@ class GitHubAPIClient:
                 current_submodule["repo_url"] = url.replace(
                     "../", "https://github.com/boostorg/"
                 )
-                current_submodule["repo_name"] = url.replace("../", "").replace(
-                    ".git", ""
-                )
+                current_submodule["repo_name"] = url.replace(
+                    "../", ""
+                ).replace(".git", "")
 
         if current_submodule:
             submodules.append(current_submodule)
@@ -652,15 +763,23 @@ class GitHubAPIClient:
         """Get submodules from .gitmodules file (local file or GitHub API)."""
         if local_file:
             logger.debug(f"Reading submodules from local file: {local_file}")
-            submodules = self.get_submodules_from_file(local_file, default_owner=owner)
+            submodules = self.get_submodules_from_file(
+                local_file, default_owner=owner
+            )
             if submodules:
-                logger.debug(f"Found {len(submodules)} submodule(s) from local file")
+                logger.debug(
+                    f"Found {len(submodules)} submodule(s) from local file"
+                )
                 return submodules
             else:
-                logger.debug("No submodules found in local file, trying GitHub API...")
+                logger.debug(
+                    "No submodules found in local file, trying GitHub API..."
+                )
 
         try:
-            content = self.rest_request(f"/repos/{owner}/{repo}/contents/.gitmodules")
+            content = self.rest_request(
+                f"/repos/{owner}/{repo}/contents/.gitmodules"
+            )
 
             if isinstance(content, list):
                 logger.warning(
@@ -670,9 +789,9 @@ class GitHubAPIClient:
 
             if content.get("type") == "file":
                 try:
-                    gitmodules_content = base64.b64decode(content["content"]).decode(
-                        "utf-8"
-                    )
+                    gitmodules_content = base64.b64decode(
+                        content["content"]
+                    ).decode("utf-8")
                 except Exception as e:
                     logger.error(
                         f"Failed to decode .gitmodules content for {owner}/{repo}: {e}"
@@ -706,7 +825,9 @@ class GitHubAPIClient:
 
     def get_tag_sha(self, owner: str, repo: str, tag: str) -> Optional[str]:
         """Get the SHA of a tag."""
-        response = self.rest_request(f"/repos/{owner}/{repo}/git/ref/tags/{tag}")
+        response = self.rest_request(
+            f"/repos/{owner}/{repo}/git/ref/tags/{tag}"
+        )
         if not response:
             return None
         return response.get("object", {}).get("sha")
@@ -715,7 +836,9 @@ class GitHubAPIClient:
         self, owner: str, repo: str, sha: str
     ) -> Optional[datetime]:
         """Get the published at date of a tag."""
-        response = self.rest_request(f"/repos/{owner}/{repo}/git/commits/{sha}")
+        response = self.rest_request(
+            f"/repos/{owner}/{repo}/git/commits/{sha}"
+        )
         if not response:
             return None
         author = response.get("author", {}) or response.get("committer", {})

--- a/github_ops/client.py
+++ b/github_ops/client.py
@@ -66,12 +66,8 @@ class GitHubAPIClient:
                 )
                 if response.status_code == 200:
                     data = response.json()
-                    self.rate_limit_remaining = data["resources"]["core"][
-                        "remaining"
-                    ]
-                    self.rate_limit_reset_time = data["resources"]["core"][
-                        "reset"
-                    ]
+                    self.rate_limit_remaining = data["resources"]["core"]["remaining"]
+                    self.rate_limit_reset_time = data["resources"]["core"]["reset"]
 
                     if self.rate_limit_remaining == 0:
                         wait_time = max(
@@ -85,9 +81,7 @@ class GitHubAPIClient:
                 return True
             except (ConnectionError, ProtocolError, Timeout) as e:
                 if attempt < self.max_retries - 1:
-                    wait_time = self.retry_delay * (
-                        2**attempt
-                    )  # Exponential backoff
+                    wait_time = self.retry_delay * (2**attempt)  # Exponential backoff
                     logger.warning(
                         f"Connection error checking rate limit (attempt {attempt + 1}/{self.max_retries}): {e}"
                     )
@@ -104,9 +98,7 @@ class GitHubAPIClient:
                 logger.error(f"Request error checking rate limit: {e}")
                 raise
 
-    def _parse_rate_limit_wait(
-        self, response: requests.Response
-    ) -> Optional[int]:
+    def _parse_rate_limit_wait(self, response: requests.Response) -> Optional[int]:
         """If response is 403/429 with rate limit or Retry-After, return seconds to wait; else None.
 
         Also handles HTTP 200 GraphQL throttle responses, which GitHub returns with
@@ -119,9 +111,7 @@ class GitHubAPIClient:
                 # consumed the last token, not that it was throttled.
                 try:
                     body = response.json()
-                    body_throttled = (
-                        isinstance(body, dict) and "errors" in body
-                    )
+                    body_throttled = isinstance(body, dict) and "errors" in body
                 except (ValueError, KeyError):
                     body_throttled = False
                 if not body_throttled:
@@ -165,14 +155,10 @@ class GitHubAPIClient:
             reset_int = int(reset)
         except (TypeError, ValueError):
             return None
-        wait = max(
-            0, reset_int - int(time.time()) + RATE_LIMIT_WAIT_SAFETY_MARGIN_SEC
-        )
+        wait = max(0, reset_int - int(time.time()) + RATE_LIMIT_WAIT_SAFETY_MARGIN_SEC)
         return wait
 
-    def _update_rate_limit_from_response(
-        self, response: requests.Response
-    ) -> None:
+    def _update_rate_limit_from_response(self, response: requests.Response) -> None:
         """Update rate limit state from response headers if present."""
         remaining = response.headers.get("X-RateLimit-Remaining")
         reset = response.headers.get("X-RateLimit-Reset")
@@ -226,9 +212,7 @@ class GitHubAPIClient:
         because this client uses it only for read-only queries (e.g. file content).
         """
         attempts_5xx = self.max_retries if allow_retry_on_5xx else 1
-        attempts_conn = (
-            self.max_retries if allow_retry_on_connection_errors else 1
-        )
+        attempts_conn = self.max_retries if allow_retry_on_connection_errors else 1
         for rate_limit_attempt in range(MAX_RATE_LIMIT_RETRIES + 1):
             rate_limited = False
             attempt_5xx = 0
@@ -253,10 +237,7 @@ class GitHubAPIClient:
                         self._handle_rate_limit(wait)
                         break
                     if resp.status_code in (500, 502, 503, 504):
-                        if (
-                            allow_retry_on_5xx
-                            and attempt_5xx < attempts_5xx - 1
-                        ):
+                        if allow_retry_on_5xx and attempt_5xx < attempts_5xx - 1:
                             wait_time = self.retry_delay * (2**attempt_5xx)
                             logger.warning(
                                 "HTTP %s on %s (attempt %s/%s), retrying in %ss...",
@@ -367,9 +348,7 @@ class GitHubAPIClient:
         self._update_rate_limit_from_response(response)
         return (response, response.headers.get("ETag"))
 
-    def rest_request(
-        self, endpoint: str, params: Optional[dict] = None
-    ) -> dict:
+    def rest_request(self, endpoint: str, params: Optional[dict] = None) -> dict:
         """Make REST API request with rate limit and connection error handling."""
         response, _ = self._rest_get(endpoint, params=params)
         if response is None:
@@ -385,9 +364,7 @@ class GitHubAPIClient:
         """Make GET request with optional If-None-Match. Returns (data, etag).
         On 304: (None, response ETag). On 200: (response.json(), response ETag header).
         """
-        response, response_etag = self._rest_get(
-            endpoint, params=params, etag=etag
-        )
+        response, response_etag = self._rest_get(endpoint, params=params, etag=etag)
         if response is None:
             return (None, response_etag)
         return (response.json(), response_etag)
@@ -419,9 +396,7 @@ class GitHubAPIClient:
         """Like rest_request_conditional but also returns next_page_url from Link header.
         Returns (data, response_etag, next_page_url). On 304: (None, etag, None).
         """
-        response, response_etag = self._rest_get(
-            endpoint, params=params, etag=etag
-        )
+        response, response_etag = self._rest_get(endpoint, params=params, etag=etag)
         if response is None:
             return (None, response_etag, None)
         next_url = self._parse_link_next(response.headers.get("Link"))
@@ -477,23 +452,17 @@ class GitHubAPIClient:
         self._update_rate_limit_from_response(response)
         return response
 
-    def rest_post(
-        self, endpoint: str, json_data: Optional[dict] = None
-    ) -> dict:
+    def rest_post(self, endpoint: str, json_data: Optional[dict] = None) -> dict:
         """POST to REST API with rate limit and connection error handling."""
         url = f"{self.rest_base_url}{endpoint}"
         payload = json_data or {}
         response = self._do_request(
             "POST", url, f"POST {endpoint}", json_data=payload, timeout=30
         )
-        self._raise_if_error_and_update_rate_limit(
-            response, f"POST {endpoint}"
-        )
+        self._raise_if_error_and_update_rate_limit(response, f"POST {endpoint}")
         return response.json()
 
-    def rest_put(
-        self, endpoint: str, json_data: Optional[dict] = None
-    ) -> dict:
+    def rest_put(self, endpoint: str, json_data: Optional[dict] = None) -> dict:
         """PUT to REST API with rate limit and connection error handling."""
         url = f"{self.rest_base_url}{endpoint}"
         payload = json_data or {}
@@ -512,9 +481,7 @@ class GitHubAPIClient:
         response = self._do_request(
             "DELETE", url, f"DELETE {endpoint}", json_data=payload, timeout=30
         )
-        self._raise_if_error_and_update_rate_limit(
-            response, f"DELETE {endpoint}"
-        )
+        self._raise_if_error_and_update_rate_limit(response, f"DELETE {endpoint}")
         if response.status_code == 204:
             return None
         return response.json()
@@ -653,9 +620,7 @@ class GitHubAPIClient:
             },
         )
 
-    def create_issue(
-        self, owner: str, repo: str, title: str, body: str = ""
-    ) -> dict:
+    def create_issue(self, owner: str, repo: str, title: str, body: str = "") -> dict:
         """Create an issue. Use client from get_github_client(use='write')."""
         return self.rest_post(
             f"/repos/{owner}/{repo}/issues",
@@ -671,9 +636,7 @@ class GitHubAPIClient:
             json_data={"body": body},
         )
 
-    def graphql_request(
-        self, query: str, variables: Optional[dict] = None
-    ) -> dict:
+    def graphql_request(self, query: str, variables: Optional[dict] = None) -> dict:
         """Make GraphQL API request with rate limit and connection error handling.
         Connection errors are retried (used for read-only queries only).
         """
@@ -748,9 +711,9 @@ class GitHubAPIClient:
                 current_submodule["repo_url"] = url.replace(
                     "../", "https://github.com/boostorg/"
                 )
-                current_submodule["repo_name"] = url.replace(
-                    "../", ""
-                ).replace(".git", "")
+                current_submodule["repo_name"] = url.replace("../", "").replace(
+                    ".git", ""
+                )
 
         if current_submodule:
             submodules.append(current_submodule)
@@ -763,23 +726,15 @@ class GitHubAPIClient:
         """Get submodules from .gitmodules file (local file or GitHub API)."""
         if local_file:
             logger.debug(f"Reading submodules from local file: {local_file}")
-            submodules = self.get_submodules_from_file(
-                local_file, default_owner=owner
-            )
+            submodules = self.get_submodules_from_file(local_file, default_owner=owner)
             if submodules:
-                logger.debug(
-                    f"Found {len(submodules)} submodule(s) from local file"
-                )
+                logger.debug(f"Found {len(submodules)} submodule(s) from local file")
                 return submodules
             else:
-                logger.debug(
-                    "No submodules found in local file, trying GitHub API..."
-                )
+                logger.debug("No submodules found in local file, trying GitHub API...")
 
         try:
-            content = self.rest_request(
-                f"/repos/{owner}/{repo}/contents/.gitmodules"
-            )
+            content = self.rest_request(f"/repos/{owner}/{repo}/contents/.gitmodules")
 
             if isinstance(content, list):
                 logger.warning(
@@ -789,9 +744,9 @@ class GitHubAPIClient:
 
             if content.get("type") == "file":
                 try:
-                    gitmodules_content = base64.b64decode(
-                        content["content"]
-                    ).decode("utf-8")
+                    gitmodules_content = base64.b64decode(content["content"]).decode(
+                        "utf-8"
+                    )
                 except Exception as e:
                     logger.error(
                         f"Failed to decode .gitmodules content for {owner}/{repo}: {e}"
@@ -825,9 +780,7 @@ class GitHubAPIClient:
 
     def get_tag_sha(self, owner: str, repo: str, tag: str) -> Optional[str]:
         """Get the SHA of a tag."""
-        response = self.rest_request(
-            f"/repos/{owner}/{repo}/git/ref/tags/{tag}"
-        )
+        response = self.rest_request(f"/repos/{owner}/{repo}/git/ref/tags/{tag}")
         if not response:
             return None
         return response.get("object", {}).get("sha")
@@ -836,9 +789,7 @@ class GitHubAPIClient:
         self, owner: str, repo: str, sha: str
     ) -> Optional[datetime]:
         """Get the published at date of a tag."""
-        response = self.rest_request(
-            f"/repos/{owner}/{repo}/git/commits/{sha}"
-        )
+        response = self.rest_request(f"/repos/{owner}/{repo}/git/commits/{sha}")
         if not response:
             return None
         author = response.get("author", {}) or response.get("committer", {})

--- a/github_ops/client.py
+++ b/github_ops/client.py
@@ -287,7 +287,7 @@ class GitHubAPIClient:
                         f"Connection error for {endpoint_for_log}: {e}"
                     ) from e
             if rate_limited:
-                time.sleep(1)
+                time.sleep(2 * rate_limit_attempt)
                 continue
             raise ConnectionException(
                 f"Connection error for {endpoint_for_log}: max retries exceeded"

--- a/github_ops/client.py
+++ b/github_ops/client.py
@@ -123,11 +123,9 @@ class GitHubAPIClient:
         if retry_after is not None:
             retry_after = retry_after.strip()
             try:
-                remaining = max(0, int(retry_after))
-                if remaining != 0:
-                    return remaining
-                else:
-                    return None
+                retry_secs = int(retry_after)
+                if retry_secs > 0:
+                    return retry_secs
             except ValueError:
                 try:
                     dt = parsedate_to_datetime(retry_after)
@@ -136,10 +134,9 @@ class GitHubAPIClient:
                     wait = (dt - datetime.now(timezone.utc)).total_seconds()
                     if wait > 0:
                         return wait
-                    else:
-                        return None
                 except (ValueError, TypeError):
                     pass
+        # Retry-After missing or did not yield a positive delay; try X-RateLimit-*.
         remaining = response.headers.get("X-RateLimit-Remaining")
         if remaining is None:
             return None

--- a/github_ops/client.py
+++ b/github_ops/client.py
@@ -12,6 +12,7 @@ import time
 from email.utils import parsedate_to_datetime
 from datetime import datetime, timezone
 from typing import Optional, Union
+from urllib.parse import urlparse
 
 import requests
 from requests.exceptions import ConnectionError, RequestException, Timeout
@@ -436,8 +437,33 @@ class GitHubAPIClient:
         next_url = self._parse_link_next(response.headers.get("Link"))
         return (data, next_url)
 
+    def _validate_rest_pagination_url(self, full_url: str) -> None:
+        """Ensure full_url is same origin as rest_base_url so the auth token is not sent elsewhere."""
+        expected = urlparse(self.rest_base_url)
+        if not expected.scheme or not expected.netloc:
+            raise ValueError(
+                "GitHubAPIClient.rest_base_url must be an absolute URL with host"
+            )
+        target = urlparse(full_url)
+        if not target.netloc:
+            raise ValueError(
+                "Refusing relative or invalid pagination URL (missing host)"
+            )
+        if target.scheme.lower() != "https":
+            raise ValueError(
+                f"Refusing pagination URL with scheme {target.scheme!r}; only https is allowed"
+            )
+        if (target.scheme.lower(), target.netloc.lower()) != (
+            expected.scheme.lower(),
+            expected.netloc.lower(),
+        ):
+            raise ValueError(
+                f"Refusing to follow pagination URL outside {expected.netloc}"
+            )
+
     def _rest_get_url(self, full_url: str) -> requests.Response:
         """GET by full URL (e.g. from Link rel=\"next\"). For pagination only."""
+        self._validate_rest_pagination_url(full_url)
         response = self._do_request(
             "GET",
             full_url,

--- a/github_ops/tests/test_client.py
+++ b/github_ops/tests/test_client.py
@@ -650,7 +650,7 @@ def test_validate_rest_pagination_url_accepts_api_github():
 def test_validate_rest_pagination_url_rejects_foreign_host():
     """Refuse absolute URLs on another host so the token is not sent elsewhere."""
     client = GitHubAPIClient("token")
-    with pytest.raises(ValueError, match="outside api.github.com"):
+    with pytest.raises(ValueError, match=r"outside api\.github\.com"):
         client._validate_rest_pagination_url("https://evil.example/api")
 
 

--- a/github_ops/tests/test_client.py
+++ b/github_ops/tests/test_client.py
@@ -634,3 +634,44 @@ def test_get_submodules_api_404_returns_empty_list():
     client.rest_request = MagicMock(side_effect=err)
     out = client.get_submodules("owner", "repo")
     assert out == []
+
+
+# --- _validate_rest_pagination_url / _rest_get_url ---
+
+
+def test_validate_rest_pagination_url_accepts_api_github():
+    """Pagination URLs on api.github.com are allowed."""
+    client = GitHubAPIClient("token")
+    client._validate_rest_pagination_url(
+        "https://api.github.com/repos/o/r/issues?per_page=1&page=2"
+    )
+
+
+def test_validate_rest_pagination_url_rejects_foreign_host():
+    """Refuse absolute URLs on another host so the token is not sent elsewhere."""
+    client = GitHubAPIClient("token")
+    with pytest.raises(ValueError, match="outside api.github.com"):
+        client._validate_rest_pagination_url("https://evil.example/api")
+
+
+def test_validate_rest_pagination_url_rejects_http():
+    """Refuse non-https pagination URLs."""
+    client = GitHubAPIClient("token")
+    with pytest.raises(ValueError, match="only https is allowed"):
+        client._validate_rest_pagination_url("http://api.github.com/foo")
+
+
+def test_validate_rest_pagination_url_rejects_relative():
+    """Refuse relative URLs (no netloc)."""
+    client = GitHubAPIClient("token")
+    with pytest.raises(ValueError, match="missing host"):
+        client._validate_rest_pagination_url("/repos/o/r/issues?page=2")
+
+
+def test_rest_get_url_calls_do_request_only_after_validation():
+    """_rest_get_url must not call _do_request when URL fails validation."""
+    client = GitHubAPIClient("token")
+    client._do_request = MagicMock()
+    with pytest.raises(ValueError):
+        client._rest_get_url("https://attacker.example/hook")
+    client._do_request.assert_not_called()


### PR DESCRIPTION
## Summary

- **GitHub REST client (`github_ops/client.py`):** Parse the `Link` header for `rel="next"` and add helpers so list endpoints can paginate using full next URLs (including conditional GET variants that return the next link). Adjust rate-limit handling so retries behave reliably when the client backs off and retries.
- **Issue fetcher (`github_activity_tracker/fetcher.py`):** Load issues using GitHub’s recommended cursor-style pagination via the `Link` header instead of relying only on `?page=`, while keeping ETag/conditional requests on the first page when an etag cache is configured.
- **Clang raw sync (`clang_github_tracker/sync_raw.py`):** Resolve issue/PR timestamps from nested `issue_info` / `pr_info` when the fetcher yields `{ issue_info | pr_info, comments, … }`, so date filtering stays correct.
- **Logging (`config/logging_handlers.py`):** Extend `SafeRotatingFileHandler` to retry `os.rename` on Windows when rollover hits **PermissionError / WinError 32** (file briefly still locked), and skip archiving that cycle if the rename still fails so logging keeps working.
- **Tests (`github_activity_tracker/tests/test_fetcher.py`):** Mock `rest_request_with_link` (and the 2-tuple return shape) for `fetch_issues_from_github` tests so they match the new pagination path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable multi-page API fetching with conditional requests; nested payload timestamps (when present) are now preferred for issue/PR dates.

* **Bug Fixes**
  * Safer log-file rollover on Windows with retry handling to avoid interruptions.
  * Increased and more robust API rate-limit retry behavior with extra backoff.

* **Tests**
  * Added/updated tests for pagination, URL validation, and fetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->