### PR TITLE
feat(deploy): host PostgreSQL, reverse-proxy settings, hardened Compose ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,7 @@ DATABASE_URL=postgres://user:password@localhost:5432/boost_dashboard
 # DEBUG=False
 # ALLOWED_HOSTS=localhost,127.0.0.1,.run.app
 
-# --- Production: Docker on Ubuntu + nginx subpath + PostgreSQL on the host ---
+# --- Production: Docker on Ubuntu + nginx + PostgreSQL on the host ---
 # docker-compose.yml maps host.docker.internal → the host (Linux). Point DATABASE_URL at it.
 # Match pg_hba / listen_addresses on the host (see docs/Deployment.md).
 # DATABASE_URL=postgres://boost_dashboard_user:STRONG_PASSWORD@host.docker.internal:5432/boost_dashboard
@@ -50,7 +50,9 @@ DATABASE_URL=postgres://user:password@localhost:5432/boost_dashboard
 # CSRF_TRUSTED_ORIGINS=https://dev.cppdigest.org
 # USE_X_FORWARDED_HOST=True
 # USE_TLS_PROXY_HEADERS=True
+# Optional URL prefix (see Deployment.md nginx “subpath” example): set both if the app is not at site root.
 # STATIC_URL=/boost-data-collector/static/
+# FORCE_SCRIPT_NAME=/boost-data-collector
 
 # =============================================================================
 # Logging (optional; defaults: logs under project root, 5 MB rotation, 5 backups)

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,16 @@ DATABASE_URL=postgres://user:password@localhost:5432/boost_dashboard
 # DEBUG=False
 # ALLOWED_HOSTS=localhost,127.0.0.1,.run.app
 
+# --- Production: Docker on Ubuntu + nginx subpath + PostgreSQL on the host ---
+# docker-compose.yml maps host.docker.internal → the host (Linux). Point DATABASE_URL at it.
+# Match pg_hba / listen_addresses on the host (see docs/Deployment.md).
+# DATABASE_URL=postgres://boost_dashboard_user:STRONG_PASSWORD@host.docker.internal:5432/boost_dashboard
+# ALLOWED_HOSTS=dev.cppdigest.org,127.0.0.1,web,localhost
+# CSRF_TRUSTED_ORIGINS=https://dev.cppdigest.org
+# USE_X_FORWARDED_HOST=True
+# USE_TLS_PROXY_HEADERS=True
+# STATIC_URL=/boost-data-collector/static/
+
 # =============================================================================
 # Logging (optional; defaults: logs under project root, 5 MB rotation, 5 backups)
 # =============================================================================

--- a/config/settings.py
+++ b/config/settings.py
@@ -33,6 +33,15 @@ if env.bool("USE_TLS_PROXY_HEADERS", default=False):
 
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
 
+_static_url = (env("STATIC_URL", default="static/") or "static/").strip()
+if _static_url and not _static_url.endswith("/"):
+    _static_url += "/"
+STATIC_URL = _static_url
+
+_force_script_name = (env("FORCE_SCRIPT_NAME", default="") or "").strip()
+if _force_script_name:
+    FORCE_SCRIPT_NAME = _force_script_name
+
 # Application definition
 INSTALLED_APPS = [
     "django.contrib.admin",
@@ -130,8 +139,7 @@ TIME_ZONE = "UTC"
 USE_I18N = True
 USE_TZ = True
 
-# Static files
-STATIC_URL = "static/"
+# Static files (STATIC_URL set above from env; STATIC_ROOT is collectstatic output)
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
 # Workspace: one folder for raw/processed files, subfolders per app (see docs/Workspace.md)

--- a/config/settings.py
+++ b/config/settings.py
@@ -26,6 +26,13 @@ DEBUG = env("DEBUG")
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
 
+# Reverse proxy (e.g. nginx terminating TLS). Enable USE_TLS_PROXY_HEADERS only behind a trusted proxy.
+USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST", default=False)
+if env.bool("USE_TLS_PROXY_HEADERS", default=False):
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
+
 # Application definition
 INSTALLED_APPS = [
     "django.contrib.admin",

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,4 @@
-# CI-only overlay: enables Postgres (base compose references @db but db is commented out).
+# CI-only overlay: adds a db service and health deps; base compose requires DATABASE_URL in .env.
 services:
   db:
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     platform: linux/amd64
     shm_size: "2g"
     ports:
-      - "4444:4444"
+      - "127.0.0.1:4444:4444"
     healthcheck:
       test:
         [
@@ -48,18 +48,22 @@ services:
   web:
     build: .
     restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     env_file: .env
     environment:
-      DATABASE_URL: postgres://${POSTGRES_USER:-boost}:${POSTGRES_PASSWORD:-boost}@db:5432/${POSTGRES_DB:-boost_dashboard}
+      # If DATABASE_URL is set in .env, it is used; else default targets a Compose service named db.
+      DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-boost}:${POSTGRES_PASSWORD:-boost}@db:5432/${POSTGRES_DB:-boost_dashboard}}
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
-      ALLOWED_HOSTS: localhost,127.0.0.1,web,0.0.0.0
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1,web,0.0.0.0}
       SELENIUM_HUB_URL: http://selenium:4444/wd/hub
     volumes:
       - workspace_data:/app/workspace
       - logs_data:/app/logs
+      - ./staticfiles:/app/staticfiles
     depends_on:
       # db: { condition: service_healthy }
       redis: { condition: service_healthy }
@@ -67,9 +71,11 @@ services:
   celery_worker:
     build: .
     restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     env_file: .env
     environment:
-      DATABASE_URL: postgres://${POSTGRES_USER:-boost}:${POSTGRES_PASSWORD:-boost}@db:5432/${POSTGRES_DB:-boost_dashboard}
+      DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-boost}:${POSTGRES_PASSWORD:-boost}@db:5432/${POSTGRES_DB:-boost_dashboard}}
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       SELENIUM_HUB_URL: http://selenium:4444/wd/hub
@@ -84,9 +90,11 @@ services:
   celery_beat:
     build: .
     restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     env_file: .env
     environment:
-      DATABASE_URL: postgres://${POSTGRES_USER:-boost}:${POSTGRES_PASSWORD:-boost}@db:5432/${POSTGRES_DB:-boost_dashboard}
+      DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-boost}:${POSTGRES_PASSWORD:-boost}@db:5432/${POSTGRES_DB:-boost_dashboard}}
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 # Boost Data Collector - Docker Compose
-# Runs: PostgreSQL, Redis, Django (gunicorn), Celery worker, Celery beat
+# Runs: Redis, Django (gunicorn), Celery worker, Celery beat, Selenium.
+# DATABASE_URL must be set in .env (host Postgres, or postgres://...@db:5432/... if you enable db).
 
 services:
   # db:
@@ -54,8 +55,7 @@ services:
       - "127.0.0.1:8000:8000"
     env_file: .env
     environment:
-      # If DATABASE_URL is set in .env, it is used; else default targets a Compose service named db.
-      DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-boost}:${POSTGRES_PASSWORD:-boost}@db:5432/${POSTGRES_DB:-boost_dashboard}}
+      DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL in .env (e.g. host.docker.internal or db:5432 with db service enabled)}
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1,web,0.0.0.0}
@@ -75,7 +75,7 @@ services:
       - "host.docker.internal:host-gateway"
     env_file: .env
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-boost}:${POSTGRES_PASSWORD:-boost}@db:5432/${POSTGRES_DB:-boost_dashboard}}
+      DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL in .env (e.g. host.docker.internal or db:5432 with db service enabled)}
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       SELENIUM_HUB_URL: http://selenium:4444/wd/hub
@@ -94,7 +94,7 @@ services:
       - "host.docker.internal:host-gateway"
     env_file: .env
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-boost}:${POSTGRES_PASSWORD:-boost}@db:5432/${POSTGRES_DB:-boost_dashboard}}
+      DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL in .env (e.g. host.docker.internal or db:5432 with db service enabled)}
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
     volumes:

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -234,6 +234,21 @@ sudo -u postgres pg_restore -h /var/run/postgresql -p 5432 -U postgres \
   /tmp/boost-data-collector-db-2026-03-25.dump
 ```
 
+**After restore — privileges for the app user:** Restore as `postgres` leaves **`public` tables owned by `postgres`**; DB owner `bdc` still has **no table rights** until you `GRANT` (empty `role_table_grants` for `bdc` is expected). Grants to other roles in the dump (e.g. `app_readonly`) do not apply to `bdc`.
+
+1. As superuser: `\c boost_dashboard`, then run (adjust role name if not `bdc`):
+
+```sql
+GRANT USAGE ON SCHEMA public TO bdc;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO bdc;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO bdc;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO bdc;
+```
+
+2. **Check:** `pg_tables` / `information_schema` are **per database**—always `\c boost_dashboard` before querying. After grants, `SELECT COUNT(*) FROM information_schema.role_table_grants WHERE grantee = 'bdc' AND table_schema = 'public'` should be large (on the order of hundreds for a full app schema).
+
+Repeat step 1 after any future restore that leaves table ownership on `postgres`.
+
 ### `.env` for host PostgreSQL
 
 Set **`DATABASE_URL`** (and any `DB_*` overrides) so containers reach the host database, for example:

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -191,6 +191,30 @@ Run these statements as a superuser (e.g. `postgres`). The app role does not nee
 
 If your dump replays `GRANT … TO app_readonly`, the `app_readonly` role must exist before restore (as above).
 
+### `pg_hba.conf`: Docker containers → host PostgreSQL
+
+With `host.docker.internal` in `DATABASE_URL` (see `docker-compose.yml` `extra_hosts`), Postgres still sees the client as the **container’s bridge IP** (e.g. `172.20.0.4`), not `127.0.0.1`, so `host … 127.0.0.1/32` rules do not match that traffic. `pg_hba.conf` lines match **database**, **user**, and **client address**; without a matching line you may see:
+
+```text
+FATAL:  no pg_hba.conf entry for host "172.20.0.4", user "bdc", database "boost_dashboard", ...
+```
+
+Add something like (adjust user/database names and auth to match your install; `scram-sha-256` is typical):
+
+```conf
+host  boost_dashboard  bdc  172.16.0.0/12  scram-sha-256
+```
+
+**`172.16.0.0/12`** covers `172.16.0.0`–`172.31.255.255`, which includes common Docker bridge subnets. To narrow to one subnet (e.g. only `172.20.*`), use **`172.20.0.0/16`** instead.
+
+Reload Postgres after editing:
+
+```bash
+sudo systemctl reload postgresql
+```
+
+If the client negotiates SSL but the server does not use TLS for this path, add **`?sslmode=disable`** or **`prefer`** to **`DATABASE_URL`** (see `.env.example`).
+
 ### Restoring from `pg_dump` (custom format)
 
 Backups produced with `pg_dump -Fc` are **not** plain SQL. Restore with **`pg_restore`**, not `psql -f`. The file may still be named `*.sql` even though it is custom format—use `pg_restore`, not the extension, to decide the tool.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -39,7 +39,7 @@ In each environment (**production** and **staging**), add the following **Enviro
 | Secret | Description |
 |--------|-------------|
 | `SSH_HOST` | IP address or hostname of the server |
-| `SSH_USER` | SSH username |
+| `SSH_USER` | SSH username (e.g. `gcp-cppdigest`) |
 | `SSH_PRIVATE_KEY` | SSH private key (full content, including header/footer) |
 | `SSH_PORT` | SSH port (optional, defaults to `22`) |
 | `SSH_KEY_PASSPHRASE` | Passphrase for the SSH private key (optional; only if the key is passphrase-protected) |
@@ -76,20 +76,24 @@ Docker and Docker Compose are also required. Refer to the [official Docker docs]
 The deploy script does **not** manage secrets. It also requires an empty or non-existent deploy directory for the first clone: `git clone` in [deploy.sh](../.github/workflows/deploy-script/deploy.sh) fails if the target directory already exists and is not a git repo. So create `.env` **after** the first clone, not before.
 
 **Step 1 — Trigger the first deploy**
+
 Push to `main` or `develop` (or re-run the Deploy workflow). The script will clone the repo into `/opt/boost-data-collector` and then exit with an error because `.env` is missing.
 
 **Step 2 — Add `.env` on the server**
-SSH into the server and create the file inside the cloned directory:
+
+SSH into the server as the same user GitHub Actions uses (e.g. `gcp-cppdigest`) and create the file inside the cloned directory. Use `.env.example` as a reference.
+
+If you create or edit `.env` with `sudo` (e.g. `sudo nano`), the file is often owned by **root** with mode `600`. **Docker Compose reads `.env` as the user running `make build` / `make up`** (your deploy user), which causes `permission denied`. Fix ownership after saving:
 
 ```bash
-sudo nano /opt/boost-data-collector/.env
-# paste your environment variables, save and exit
+sudo chown gcp-cppdigest:gcp-cppdigest /opt/boost-data-collector/.env
 sudo chmod 600 /opt/boost-data-collector/.env
 ```
 
-Use `.env.example` in the repository as a reference for the required variables. The script expects `.env` at `$DEPLOY_DIR/.env` (default: `/opt/boost-data-collector/.env`).
+(Replace `gcp-cppdigest` with your actual `SSH_USER` if different.)
 
 **Step 3 — Run deploy again**
+
 Re-run the Deploy workflow (or push again). The script will see the existing repo and `.env`, and complete successfully.
 
 ### 2. Add the deploy SSH key
@@ -110,6 +114,174 @@ Add the private key content (`~/.ssh/deploy_key`) as the **`SSH_PRIVATE_KEY`** s
 
 ---
 
+## Remote server layout: Docker Compose + host PostgreSQL + nginx
+
+This matches a common production/staging layout for this repo:
+
+- **On the host:** PostgreSQL (package install), **nginx** (TLS + reverse proxy).
+- **In Docker Compose:** `web` (Gunicorn), `celery_worker`, `celery_beat`, `redis`, `selenium`. The bundled **`db` service is commented out** in `docker-compose.yml`; the app uses **`DATABASE_URL`** to reach PostgreSQL on the host.
+
+Compose already sets `extra_hosts: host.docker.internal:host-gateway` on app containers so `DATABASE_URL` can use host `host.docker.internal` (see `.env.example`).
+
+### Google Cloud Storage (optional seed and backups)
+
+Example bucket name: `bdc-backups` (choose your own).
+
+- Upload artifacts manually at first (e.g. workspace zip + DB dump).
+- Prefer **`gcloud storage`** over legacy `gsutil` for copies; it is typically much faster on large objects.
+
+Example: copy from bucket to the VM, then unpack (paths are illustrative):
+
+```bash
+gcloud storage cp "gs://bdc-backups/workspace-2026-03-24.zip" .
+gcloud storage cp "gs://bdc-backups/boost-data-collector-db-2026-03-25.dump" .
+unzip workspace-2026-03-24.zip -d /path/to/workspace-parent
+```
+
+Sync workspace back to the bucket (first full sync can take a long time; later syncs are incremental):
+
+```bash
+gcloud storage rsync /opt/boost-data-collector/workspace gs://bdc-backups/workspace --recursive
+```
+
+### Repository checkout and permissions
+
+The deploy user (e.g. `gcp-cppdigest`) should own the app tree under `/opt/boost-data-collector` so `git`, `make`, and Docker Compose can run without sudo.
+
+If the tree was created as root, normalize ownership:
+
+```bash
+sudo chown -R gcp-cppdigest:gcp-cppdigest /opt/boost-data-collector
+```
+
+Docker bind mounts for `staticfiles` (and optionally a host `workspace` directory if you use one) must be readable/writable by the **UID used inside the image** for the app process (commonly `1000`). Example:
+
+```bash
+mkdir -p /opt/boost-data-collector/staticfiles
+sudo chown -R 1000:1000 /opt/boost-data-collector/staticfiles
+# If using a host workspace directory mounted into the container:
+sudo chown -R 1000:1000 /opt/boost-data-collector/workspace
+sudo chmod -R u+rwX /opt/boost-data-collector/workspace
+```
+
+### PostgreSQL on the host (role `bdc`, database `boost_dashboard`)
+
+Install PostgreSQL on the server (version should be compatible with your dumps and Django; this project is tested with recent PostgreSQL releases).
+
+Create the application role and database **once** (use a strong password; the example below uses a placeholder):
+
+```bash
+sudo -u postgres psql
+```
+
+In the `psql` session:
+
+```sql
+CREATE ROLE bdc WITH LOGIN PASSWORD 'REPLACE_WITH_STRONG_PASSWORD' CREATEDB;
+DROP DATABASE IF EXISTS boost_dashboard;
+CREATE DATABASE boost_dashboard OWNER bdc;
+GRANT ALL PRIVILEGES ON DATABASE boost_dashboard TO bdc;
+GRANT CREATE, USAGE ON SCHEMA public TO bdc;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO bdc;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO bdc;
+CREATE ROLE app_readonly NOLOGIN;
+```
+
+If your dump replays `GRANT … TO app_readonly`, the `app_readonly` role must exist before restore (as above).
+
+### Restoring from `pg_dump` (custom format)
+
+Backups produced with `pg_dump -Fc` are **not** plain SQL. Restore with **`pg_restore`**, not `psql -f`. The file may still be named `*.sql` even though it is custom format—use `pg_restore`, not the extension, to decide the tool.
+
+**Where to put the dump file**
+
+- The **`postgres`** OS user must be able to read the file. Placing it under **`/tmp/`** with world-readable permissions (e.g. `644`) during restore is typical.
+
+**Prefer Unix socket for superuser restore**
+
+`sudo -u postgres pg_restore -h localhost …` often fails because **TCP** to `localhost` uses `pg_hba.conf` **password** rules, not **peer** auth. Connect via the **socket** instead (omit `-h` or use `-h /var/run/postgresql`):
+
+```bash
+sudo -u postgres pg_restore -h /var/run/postgresql -p 5432 -U postgres \
+  --verbose --clean --if-exists \
+  -d boost_dashboard \
+  /tmp/boost-data-collector-db-2026-03-25.dump
+```
+
+### `.env` for host PostgreSQL
+
+Set **`DATABASE_URL`** (and any `DB_*` overrides) so containers reach the host database, for example:
+
+```bash
+DATABASE_URL=postgres://bdc:REPLACE_WITH_STRONG_PASSWORD@host.docker.internal:5432/boost_dashboard
+```
+
+Also set production-safe values for:
+
+- **`ALLOWED_HOSTS`** — your public hostname(s).
+- **`CSRF_TRUSTED_ORIGINS`** — `https://your.hostname` entries for HTTPS sites.
+- **`USE_X_FORWARDED_HOST=True`** and **`USE_TLS_PROXY_HEADERS=True`** when Django sits behind nginx terminating TLS (see comments in `config/settings.py`).
+
+### Docker stack
+
+From `/opt/boost-data-collector` as the deploy user:
+
+```bash
+make build   # first build is slower; later builds are incremental
+make up
+make health  # optional smoke checks (see Makefile)
+```
+
+The deploy script runs `make down`, `make build`, `make up`, then polls `make health`.
+
+### nginx reverse proxy
+
+`docker-compose.yml` publishes Gunicorn on **`127.0.0.1:8000`** only. Terminate TLS on the host with nginx and proxy to that port.
+
+Example site snippet (adjust `server_name`, certificate paths, and `client_max_body_size` as needed):
+
+```nginx
+upstream boost_collector_app {
+    server 127.0.0.1:8000;
+    keepalive 32;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name collector.example.org;
+
+    ssl_certificate     /etc/letsencrypt/live/collector.example.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/collector.example.org/privkey.pem;
+
+    client_max_body_size 100M;
+
+    location / {
+        proxy_pass         http://boost_collector_app;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_redirect     off;
+        proxy_read_timeout 300s;
+    }
+
+    location /static/ {
+        alias /opt/boost-data-collector/staticfiles/;
+    }
+}
+```
+
+Reload nginx after testing config (`sudo nginx -t && sudo systemctl reload nginx`).
+
+**Selenium (port 4444)** is bound to **`127.0.0.1:4444`** in Compose so it is not exposed on the public interface. Access from your laptop via **SSH port forwarding** if you need the hub from outside the VM:
+
+```bash
+ssh -L 4444:127.0.0.1:4444 gcp-cppdigest@YOUR_VM_IP
+```
+
+---
+
 ## Deploy Script Behavior
 
 The deploy script (`.github/workflows/deploy-script/deploy.sh`) runs on the remote server and does the following:
@@ -121,6 +293,7 @@ The deploy script (`.github/workflows/deploy-script/deploy.sh`) runs on the remo
 5. Checks for `.env` in the deploy directory (`$DEPLOY_DIR/.env`). If it is missing, the script exits with an error. Create `.env` after the first clone using the [two-step process](#1-create-the-env-file-two-step-process).
 6. Stops existing containers (`make down`).
 7. Builds and starts the stack (`make build && make up`).
+8. Waits for `make health` to succeed (see `Makefile`).
 
 ### Overriding the deploy directory
 
@@ -136,8 +309,23 @@ When secrets or config values change, SSH into the server and edit the file dire
 nano /opt/boost-data-collector/.env
 ```
 
+Ensure the deploy user still owns the file if you used `sudo` to edit:
+
+```bash
+sudo chown gcp-cppdigest:gcp-cppdigest /opt/boost-data-collector/.env
+sudo chmod 600 /opt/boost-data-collector/.env
+```
+
 Then restart the containers to pick up the new values:
 
 ```bash
 cd /opt/boost-data-collector && make down && make up
 ```
+
+---
+
+## Health checks (`make health`)
+
+`make health` runs a small set of checks from the `Makefile` (Django `check --database default` inside **`web`**, `redis-cli PING`, Selenium `/status` from inside the selenium container, and `docker compose ps` for Celery services). It does **not** fully prove Celery broker connectivity or every cross-service path. Treat it as a quick smoke test after deploy.
+
+For more detail see [Docker.md](./Docker.md) and the `health` target in the `Makefile`.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -121,7 +121,7 @@ This matches a common production/staging layout for this repo:
 - **On the host:** PostgreSQL (package install), **nginx** (TLS + reverse proxy).
 - **In Docker Compose:** `web` (Gunicorn), `celery_worker`, `celery_beat`, `redis`, `selenium`. The bundled **`db` service is commented out** in `docker-compose.yml`; the app uses **`DATABASE_URL`** to reach PostgreSQL on the host.
 
-Compose already sets `extra_hosts: host.docker.internal:host-gateway` on app containers so `DATABASE_URL` can use host `host.docker.internal` (see `.env.example`).
+Compose already sets `extra_hosts: host.docker.internal:host-gateway` on app containers so `DATABASE_URL` can use host `host.docker.internal` (see `.env.example`). **`DATABASE_URL` is required** in `.env` for `docker compose` (there is no default to a bundled `db` service while that service stays commented out).
 
 ### Google Cloud Storage (optional seed and backups)
 
@@ -177,7 +177,7 @@ sudo -u postgres psql
 In the `psql` session:
 
 ```sql
-CREATE ROLE bdc WITH LOGIN PASSWORD 'REPLACE_WITH_STRONG_PASSWORD' CREATEDB;
+CREATE ROLE bdc WITH LOGIN PASSWORD 'REPLACE_WITH_STRONG_PASSWORD';
 DROP DATABASE IF EXISTS boost_dashboard;
 CREATE DATABASE boost_dashboard OWNER bdc;
 GRANT ALL PRIVILEGES ON DATABASE boost_dashboard TO bdc;
@@ -186,6 +186,8 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO bdc;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO bdc;
 CREATE ROLE app_readonly NOLOGIN;
 ```
+
+Run these statements as a superuser (e.g. `postgres`). The app role does not need `CREATEDB`; the database is created explicitly above. If you need a separate migration-only user with broader rights, create that role separately.
 
 If your dump replays `GRANT … TO app_readonly`, the `app_readonly` role must exist before restore (as above).
 
@@ -221,6 +223,7 @@ Also set production-safe values for:
 - **`ALLOWED_HOSTS`** — your public hostname(s).
 - **`CSRF_TRUSTED_ORIGINS`** — `https://your.hostname` entries for HTTPS sites.
 - **`USE_X_FORWARDED_HOST=True`** and **`USE_TLS_PROXY_HEADERS=True`** when Django sits behind nginx terminating TLS (see comments in `config/settings.py`).
+- **`STATIC_URL`** / **`FORCE_SCRIPT_NAME`** — only if you serve the app under a URL prefix; see the optional nginx subsection below.
 
 ### Docker stack
 
@@ -238,7 +241,9 @@ The deploy script runs `make down`, `make build`, `make up`, then polls `make he
 
 `docker-compose.yml` publishes Gunicorn on **`127.0.0.1:8000`** only. Terminate TLS on the host with nginx and proxy to that port.
 
-Example site snippet (adjust `server_name`, certificate paths, and `client_max_body_size` as needed):
+#### At site root (`/`)
+
+The following example assumes the app is served at the **domain root** (`https://collector.example.org/`) and static files at **`/static/`**.
 
 ```nginx
 upstream boost_collector_app {
@@ -268,6 +273,47 @@ server {
 
     location /static/ {
         alias /opt/boost-data-collector/staticfiles/;
+    }
+}
+```
+
+#### Optional: URL prefix (subpath)
+
+If the app must live under a prefix (e.g. `https://example.org/boost-data-collector/`), set in `.env`:
+
+- `FORCE_SCRIPT_NAME=/boost-data-collector` (no trailing slash)
+- `STATIC_URL=/boost-data-collector/static/` (must end with `/`)
+
+Example nginx (adjust the prefix string to match your `FORCE_SCRIPT_NAME`):
+
+```nginx
+upstream boost_collector_app {
+    server 127.0.0.1:8000;
+    keepalive 32;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name example.org;
+
+    ssl_certificate     /etc/letsencrypt/live/example.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.org/privkey.pem;
+
+    client_max_body_size 100M;
+
+    location /boost-data-collector/static/ {
+        alias /opt/boost-data-collector/staticfiles/;
+    }
+
+    location /boost-data-collector/ {
+        proxy_pass         http://boost_collector_app/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_redirect     off;
+        proxy_read_timeout 300s;
     }
 }
 ```


### PR DESCRIPTION
## Summary

This PR implements production-oriented deployment support: Django behind a reverse proxy (forwarded host/HTTPS and CSRF origins), Docker Compose that can use **PostgreSQL on the host** via `host.docker.internal`, **loopback-only** published ports for web and Selenium, a **`staticfiles` bind mount** for nginx, and expanded **Deployment** documentation (host Postgres, `pg_restore`, nginx example, GCS notes, permissions, `make health`, `.env` ownership).

## Changes

| Area | What changed |
|------|----------------|
| `config/settings.py` | `USE_X_FORWARDED_HOST`, `USE_TLS_PROXY_HEADERS` → `SECURE_PROXY_SSL_HEADER`, `CSRF_TRUSTED_ORIGINS` |
| `docker-compose.yml` | `host.docker.internal`; `${DATABASE_URL}` / `${ALLOWED_HOSTS}` overrides; `127.0.0.1` port binds; `./staticfiles` volume |
| `.env.example` | Commented block for Docker + nginx subpath + host Postgres |
| `docs/Deployment.md` | Full guide for Compose + host PG + nginx; operational fixes (e.g. `.env` ownership) |

## Verification

- [x] Stack comes up with `DATABASE_URL` pointing at host Postgres via `host.docker.internal`.
- [x] App works behind nginx with TLS and correct CSRF behavior.

Closes #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for reverse-proxy and TLS header handling, optional URL subpath/static URL support, and improved local-only service port bindings and host gateway access for containerized setups.
  * Configurable database and allowed-hosts handling and an added bind mount for static files.

* **Documentation**
  * Expanded deployment guide with production examples, .env creation/ownership guidance, remote server layout, health-check details, and restore/seeding instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->