### PR TITLE
fix(dashboard): reliable publish and CLI cleanup - #132

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,16 +170,17 @@ DATABASE_URL=postgres://user:password@localhost:5432/boost_dashboard
 # REPO_COUNT_LANGUAGES=C++,Python,Rust
 
 # =============================================================================
-# Boost Library Usage Dashboard (optional; for --publish)
+# Boost Library Usage Dashboard
 # =============================================================================
-# When set, run_boost_library_usage_dashboard --publish uses a persistent clone
-# at raw/boost_library_usage_dashboard/<owner>/<repo> (clone if missing, pull, copy, push).
+# Target repo for publishing (run_boost_library_usage_dashboard without --skip-publish).
+# Clone/pull/push uses GITHUB_TOKEN_WRITE (see GitHub tokens above).
 # BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER=your-org
 # BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_REPO=your-dashboard-repo
-# Token for clone/pull/push (defaults to GITHUB_TOKEN_WRITE if unset)
-# BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_TOKEN=ghp_xxxx
-# Branch to publish to
 # BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_BRANCH=main
+
+# Git commit author identity used when publishing (defaults shown)
+# GIT_AUTHOR_NAME=unknown
+# GIT_AUTHOR_EMAIL=unknown@noreply.github.com
 
 # =============================================================================
 # Workspace (optional; default: project_root/workspace)

--- a/boost_library_tracker/management/commands/run_boost_github_activity_tracker.py
+++ b/boost_library_tracker/management/commands/run_boost_github_activity_tracker.py
@@ -121,8 +121,6 @@ def _push_markdown_to_github(
     all_new_files: dict[str, str],
 ) -> None:
     """Upload generated Markdown to BOOST_LIBRARY_TRACKER_REPO_*; unlink locals on success."""
-    if not all_new_files:
-        return
     cfg = _markdown_export_repo_config()
     if not cfg:
         logger.error(
@@ -504,17 +502,7 @@ class Command(BaseCommand):
 
             if not skip_remote_push:
                 logger.info("push Markdown to configured GitHub repo")
-                if not all_new_files:
-                    if skip_markdown_export and not skip_github_sync:
-                        logger.warning(
-                            "nothing new to push (--skip-markdown-export); skipping remote push"
-                        )
-                    elif skip_github_sync:
-                        logger.warning(
-                            "nothing to push from this run (sync was skipped)"
-                        )
-                else:
-                    _push_markdown_to_github(md_output_dir, all_new_files)
+                _push_markdown_to_github(md_output_dir, all_new_files)
             else:
                 logger.info("skipping remote push (--skip-remote-push)")
 

--- a/boost_library_usage_dashboard/analyzer.py
+++ b/boost_library_usage_dashboard/analyzer.py
@@ -40,8 +40,7 @@ STARS_MIN_THRESHOLD = 10
 
 
 class BoostUsageDashboardAnalyzer:
-    def __init__(self, base_dir: Path, output_dir: Path):
-        self.base_dir = base_dir
+    def __init__(self, output_dir: Path):
         self.output_dir = output_dir
         self.dashboard_data_file = output_dir / "dashboard_data.json"
         self.report_file = output_dir / "Boost_Usage_Report_total.md"

--- a/boost_library_usage_dashboard/management/__init__.py
+++ b/boost_library_usage_dashboard/management/__init__.py
@@ -1,0 +1,1 @@
+"""Django management package for boost_library_usage_dashboard."""

--- a/boost_library_usage_dashboard/management/commands/__init__.py
+++ b/boost_library_usage_dashboard/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for the boost_library_usage_dashboard app."""

--- a/boost_library_usage_dashboard/management/commands/run_boost_library_usage_dashboard.py
+++ b/boost_library_usage_dashboard/management/commands/run_boost_library_usage_dashboard.py
@@ -1,3 +1,5 @@
+"""Build the Boost library usage dashboard from DB data and optionally publish to GitHub."""
+
 import logging
 
 from django.conf import settings
@@ -13,12 +15,15 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
+    """Django management command: collect metrics, render HTML, optionally push to GitHub."""
+
     help = (
         "Generate Boost library usage report/dashboard from PostgreSQL data, "
         "then publish generated files to a target GitHub repository unless skipped."
     )
 
     def add_arguments(self, parser):
+        """Register skip flags and publish target overrides."""
         parser.add_argument(
             "--skip-collect",
             action="store_true",
@@ -54,6 +59,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        """Run collect/render steps, then publish when configured and artifacts exist."""
         output_dir = get_workspace_path("boost_library_usage_dashboard").resolve()
         output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/boost_library_usage_dashboard/management/commands/run_boost_library_usage_dashboard.py
+++ b/boost_library_usage_dashboard/management/commands/run_boost_library_usage_dashboard.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from boost_library_usage_dashboard.analyzer import BoostUsageDashboardAnalyzer
 from boost_library_usage_dashboard.publisher import publish_dashboard
@@ -109,6 +109,11 @@ class Command(BaseCommand):
                     "--owner and --repo."
                 )
             else:
+                if not any(output_dir.rglob("*.html")):
+                    raise CommandError(
+                        "Refusing to publish: no HTML artifacts were found in "
+                        f"{output_dir}. Run without --skip-render first."
+                    )
                 publish_dashboard(
                     output_dir=output_dir,
                     owner=owner,

--- a/boost_library_usage_dashboard/management/commands/run_boost_library_usage_dashboard.py
+++ b/boost_library_usage_dashboard/management/commands/run_boost_library_usage_dashboard.py
@@ -1,17 +1,13 @@
 import logging
-import shutil
-from datetime import datetime
-from pathlib import Path
-from zoneinfo import ZoneInfo
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from boost_library_usage_dashboard.analyzer import BoostUsageDashboardAnalyzer
+from boost_library_usage_dashboard.publisher import publish_dashboard
 from boost_library_usage_dashboard.renderer import render_dashboard_html
 from boost_library_usage_dashboard.report import write_summary_report
 from config.workspace import get_workspace_path
-from github_ops.git_ops import clone_repo, pull, push
 
 logger = logging.getLogger(__name__)
 
@@ -19,154 +15,103 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = (
         "Generate Boost library usage report/dashboard from PostgreSQL data, "
-        "then optionally publish generated files to a target GitHub repository."
+        "then publish generated files to a target GitHub repository unless skipped."
     )
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--publish",
+            "--skip-collect",
             action="store_true",
-            help="Publish generated files to the repository configured in settings.",
+            help="Skip PostgreSQL collection and Markdown report generation.",
         )
         parser.add_argument(
-            "--target-branch",
-            type=str,
-            default="main",
-            help="Branch for pushing generated dashboard files.",
+            "--skip-render",
+            action="store_true",
+            help="Skip HTML rendering.",
         )
         parser.add_argument(
-            "--output-dir",
+            "--skip-publish",
+            action="store_true",
+            help="Skip publishing to the configured GitHub repository.",
+        )
+        parser.add_argument(
+            "--owner",
             type=str,
             default="",
-            help="Custom output directory. Defaults to workspace/boost_library_usage_dashboard.",
+            help="Publish repo owner (overrides BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER).",
+        )
+        parser.add_argument(
+            "--repo",
+            type=str,
+            default="",
+            help="Publish repo name (overrides BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_REPO).",
+        )
+        parser.add_argument(
+            "--branch",
+            type=str,
+            default="",
+            help="Branch to publish to (overrides BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_BRANCH; default main).",
         )
 
     def handle(self, *args, **options):
-        output_dir = (
-            Path(options["output_dir"]).resolve()
-            if options["output_dir"]
-            else get_workspace_path("boost_library_usage_dashboard")
-        )
+        output_dir = get_workspace_path("boost_library_usage_dashboard").resolve()
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        self.stdout.write("Step 1: Collecting dashboard data from PostgreSQL...")
-        analyzer = BoostUsageDashboardAnalyzer(
-            base_dir=settings.BASE_DIR, output_dir=output_dir
-        )
-        stats = analyzer.run()
+        skip_collect = options["skip_collect"]
+        skip_render = options["skip_render"]
+        skip_publish = options["skip_publish"]
 
-        self.stdout.write("Step 2: Writing Markdown report...")
-        write_summary_report(
-            analyzer.report_file,
-            stats,
-            stars_min_threshold=analyzer.stars_min_threshold,
-        )
+        if not skip_collect:
+            logger.info("Step 1: Collecting dashboard data from PostgreSQL...")
+            analyzer = BoostUsageDashboardAnalyzer(output_dir=output_dir)
+            stats = analyzer.run()
 
-        self.stdout.write("Step 3: Rendering HTML files...")
-        render_dashboard_html(base_dir=settings.BASE_DIR, output_dir=output_dir)
+            logger.info("Step 2: Writing Markdown report...")
+            write_summary_report(
+                analyzer.report_file,
+                stats,
+                stars_min_threshold=analyzer.stars_min_threshold,
+            )
 
-        self.stdout.write(
-            self.style.SUCCESS(f"Dashboard artifacts generated at: {output_dir}")
-        )
+        if not skip_render:
+            logger.info("Step 3: Rendering HTML files...")
+            render_dashboard_html(base_dir=settings.BASE_DIR, output_dir=output_dir)
 
-        if options["publish"]:
-            owner = (
+        if not skip_collect or not skip_render:
+            logger.info("Dashboard artifacts at: %s", output_dir)
+
+        if not skip_publish:
+            owner = (options["owner"] or "").strip() or (
                 getattr(settings, "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER", "")
                 or ""
             ).strip()
-            repo = (
+            repo = (options["repo"] or "").strip() or (
                 getattr(settings, "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_REPO", "")
                 or ""
             ).strip()
             branch = (
-                getattr(
-                    settings,
-                    "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_BRANCH",
-                    "",
+                (options["branch"] or "").strip()
+                or (
+                    getattr(
+                        settings,
+                        "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_BRANCH",
+                        "",
+                    )
+                    or ""
+                ).strip()
+                or "main"
+            )
+
+            if not owner or not repo:
+                logger.warning(
+                    "Skipping publish: set BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER "
+                    "and BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_REPO in settings, or pass "
+                    "--owner and --repo."
                 )
-                or ""
-            ).strip() or options["target_branch"]
-            if owner and repo:
-                self._publish_via_raw_clone(
+            else:
+                publish_dashboard(
                     output_dir=output_dir,
                     owner=owner,
                     repo=repo,
                     branch=branch,
                 )
-            else:
-                raise CommandError(
-                    "Cannot publish: BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER "
-                    "and BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_REPO must be set in settings."
-                )
-
-    def _publish_via_raw_clone(
-        self,
-        output_dir: Path,
-        owner: str,
-        repo: str,
-        branch: str,
-    ) -> None:
-        """
-        Publish using persistent clone at raw/boost_library_usage_dashboard/owner/repo.
-        Clone if missing, pull, remove contents, copy output_dir, add/commit/push.
-        """
-        clone_dir = (
-            Path(settings.RAW_DIR) / "boost_library_usage_dashboard" / owner / repo
-        )
-        clone_dir = clone_dir.resolve()
-        output_dir = output_dir.resolve()
-        if (
-            clone_dir == output_dir
-            or clone_dir in output_dir.parents
-            or output_dir in clone_dir.parents
-        ):
-            raise CommandError(
-                "--output-dir must not overlap with the publish clone path: "
-                f"{clone_dir}"
-            )
-        clone_dir.parent.mkdir(parents=True, exist_ok=True)
-        token = (
-            getattr(settings, "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_TOKEN", None)
-            or None
-        )
-        repo_slug = f"{owner}/{repo}"
-        self.stdout.write(
-            f"Publishing dashboard artifacts to {repo_slug} ({branch})..."
-        )
-        if not clone_dir.exists() or not (clone_dir / ".git").is_dir():
-            if clone_dir.exists():
-                shutil.rmtree(clone_dir)
-            self.stdout.write(f"Cloning {repo_slug} to {clone_dir}...")
-            clone_repo(repo_slug, clone_dir, token=token)
-        self.stdout.write("Pulling latest...")
-        pull(clone_dir, branch=branch, token=token)
-        for child in clone_dir.iterdir():
-            if child.name == ".git":
-                continue
-            if child.is_dir() and child.name == "develop":
-                shutil.rmtree(child)
-        publish_subdir = clone_dir / "develop"
-        publish_subdir.mkdir(parents=True, exist_ok=True)
-        for child in output_dir.iterdir():
-            dest = publish_subdir / child.name
-            if child.is_dir():
-                shutil.copytree(child, dest)
-            else:
-                if child.suffix != ".html":
-                    continue
-                shutil.copy2(child, dest)
-        tz_name = getattr(settings, "CELERY_TIMEZONE", None) or settings.TIME_ZONE
-        commit_time = datetime.now(ZoneInfo(tz_name)).strftime("%Y-%m-%d %H:%M:%S")
-        commit_message = (
-            f"Update Boost library usage dashboard artifacts ({commit_time})"
-        )
-        push(
-            clone_dir,
-            remote="origin",
-            branch=branch,
-            commit_message=commit_message,
-            token=token,
-        )
-        self.stdout.write(
-            self.style.SUCCESS("Dashboard artifacts published successfully.")
-        )

--- a/boost_library_usage_dashboard/publisher.py
+++ b/boost_library_usage_dashboard/publisher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,6 +14,25 @@ from django.core.management.base import CommandError
 from github_ops.git_ops import clone_repo, prepare_repo_for_pull, pull, push
 
 logger = logging.getLogger(__name__)
+
+# GitHub owner/login and repository name: single path segment, no traversal.
+_GITHUB_OWNER_REPO_SLUG = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+
+
+def _validate_github_slug(label: str, value: str) -> str:
+    """Return stripped owner or repo name, or raise CommandError if unsafe or invalid."""
+    v = (value or "").strip()
+    if not v:
+        raise CommandError(f"Invalid GitHub {label}: empty")
+    if v in (".", ".."):
+        raise CommandError(f"Invalid GitHub {label}: {v!r}")
+    if "/" in v or "\\" in v:
+        raise CommandError(f"Invalid GitHub {label}: {v!r}")
+    if Path(v).is_absolute():
+        raise CommandError(f"Invalid GitHub {label}: {v!r}")
+    if not _GITHUB_OWNER_REPO_SLUG.fullmatch(v):
+        raise CommandError(f"Invalid GitHub {label}: {v!r}")
+    return v
 
 
 def publish_dashboard(
@@ -30,8 +50,18 @@ def publish_dashboard(
     ``settings.GIT_AUTHOR_NAME`` / ``settings.GIT_AUTHOR_EMAIL`` for the commit
     identity (via env vars on ``git commit`` only).
     """
-    clone_dir = Path(settings.RAW_DIR) / "boost_library_usage_dashboard" / owner / repo
-    clone_dir = clone_dir.resolve()
+    owner = _validate_github_slug("owner", owner)
+    repo = _validate_github_slug("repo", repo)
+
+    publish_root = (Path(settings.RAW_DIR) / "boost_library_usage_dashboard").resolve()
+    clone_dir = (publish_root / owner / repo).resolve()
+    try:
+        clone_dir.relative_to(publish_root)
+    except ValueError:
+        raise CommandError(
+            f"Publish clone path escapes dashboard publish root: {clone_dir}"
+        ) from None
+
     output_dir = output_dir.resolve()
     if (
         clone_dir == output_dir

--- a/boost_library_usage_dashboard/publisher.py
+++ b/boost_library_usage_dashboard/publisher.py
@@ -1,0 +1,97 @@
+"""Publish Boost library usage dashboard artifacts to a GitHub repository."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import CommandError
+
+from github_ops.git_ops import clone_repo, pull, push
+
+logger = logging.getLogger(__name__)
+
+
+def publish_dashboard(
+    output_dir: Path,
+    owner: str,
+    repo: str,
+    branch: str,
+) -> None:
+    """
+    Publish using a persistent clone at raw/boost_library_usage_dashboard/<owner>/<repo>.
+    Clone if missing, pull, sync ``develop/`` from output_dir, commit, push.
+
+    Uses ``settings.GITHUB_TOKEN_WRITE`` for clone/pull/push and
+    ``settings.GIT_AUTHOR_NAME`` / ``settings.GIT_AUTHOR_EMAIL`` for the commit
+    identity (via env vars on ``git commit`` only).
+    """
+    clone_dir = (
+        Path(settings.RAW_DIR) / "boost_library_usage_dashboard" / owner / repo
+    )
+    clone_dir = clone_dir.resolve()
+    output_dir = output_dir.resolve()
+    if (
+        clone_dir == output_dir
+        or clone_dir in output_dir.parents
+        or output_dir in clone_dir.parents
+    ):
+        raise CommandError(
+            "Workspace output directory must not overlap with the publish clone path: "
+            f"{clone_dir}"
+        )
+
+    clone_dir.parent.mkdir(parents=True, exist_ok=True)
+    token = (getattr(settings, "GITHUB_TOKEN_WRITE", None) or "").strip() or None
+    git_user_name = (getattr(settings, "GIT_AUTHOR_NAME", None) or "unknown").strip()
+    git_user_email = (
+        getattr(settings, "GIT_AUTHOR_EMAIL", None) or "unknown@noreply.github.com"
+    ).strip()
+
+    repo_slug = f"{owner}/{repo}"
+    logger.info("Publishing dashboard artifacts to %s (%s)...", repo_slug, branch)
+
+    if not clone_dir.exists() or not (clone_dir / ".git").is_dir():
+        if clone_dir.exists():
+            shutil.rmtree(clone_dir)
+        logger.info("Cloning %s to %s", repo_slug, clone_dir)
+        clone_repo(repo_slug, clone_dir, token=token)
+
+    logger.info("Pulling latest for %s", clone_dir)
+    pull(clone_dir, branch=branch, token=token)
+
+    for child in clone_dir.iterdir():
+        if child.name == ".git":
+            continue
+        if child.is_dir() and child.name == "develop":
+            shutil.rmtree(child)
+
+    publish_subdir = clone_dir / "develop"
+    publish_subdir.mkdir(parents=True, exist_ok=True)
+
+    for child in output_dir.iterdir():
+        dest = publish_subdir / child.name
+        if child.is_dir():
+            shutil.copytree(child, dest)
+        else:
+            if child.suffix != ".html":
+                continue
+            shutil.copy2(child, dest)
+
+    commit_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    commit_message = (
+        f"Update Boost library usage dashboard artifacts ({commit_time})"
+    )
+    push(
+        clone_dir,
+        remote="origin",
+        branch=branch,
+        commit_message=commit_message,
+        token=token,
+        git_user_name=git_user_name,
+        git_user_email=git_user_email,
+    )
+    logger.info("Dashboard artifacts published successfully to %s.", repo_slug)

--- a/boost_library_usage_dashboard/publisher.py
+++ b/boost_library_usage_dashboard/publisher.py
@@ -29,9 +29,7 @@ def publish_dashboard(
     ``settings.GIT_AUTHOR_NAME`` / ``settings.GIT_AUTHOR_EMAIL`` for the commit
     identity (via env vars on ``git commit`` only).
     """
-    clone_dir = (
-        Path(settings.RAW_DIR) / "boost_library_usage_dashboard" / owner / repo
-    )
+    clone_dir = Path(settings.RAW_DIR) / "boost_library_usage_dashboard" / owner / repo
     clone_dir = clone_dir.resolve()
     output_dir = output_dir.resolve()
     if (
@@ -82,9 +80,7 @@ def publish_dashboard(
             shutil.copy2(child, dest)
 
     commit_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-    commit_message = (
-        f"Update Boost library usage dashboard artifacts ({commit_time})"
-    )
+    commit_message = f"Update Boost library usage dashboard artifacts ({commit_time})"
     push(
         clone_dir,
         remote="origin",

--- a/boost_library_usage_dashboard/publisher.py
+++ b/boost_library_usage_dashboard/publisher.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from django.conf import settings
 from django.core.management.base import CommandError
 
-from github_ops.git_ops import clone_repo, pull, push
+from github_ops.git_ops import clone_repo, prepare_repo_for_pull, pull, push
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,8 @@ def publish_dashboard(
 ) -> None:
     """
     Publish using a persistent clone at raw/boost_library_usage_dashboard/<owner>/<repo>.
-    Clone if missing, pull, sync ``develop/`` from output_dir, commit, push.
+    Clone if missing, then fetch/clean/reset the clone, pull, sync ``develop/`` from
+    output_dir, commit, push.
 
     Uses ``settings.GITHUB_TOKEN_WRITE`` for clone/pull/push and
     ``settings.GIT_AUTHOR_NAME`` / ``settings.GIT_AUTHOR_EMAIL`` for the commit
@@ -57,6 +58,9 @@ def publish_dashboard(
             shutil.rmtree(clone_dir)
         logger.info("Cloning %s to %s", repo_slug, clone_dir)
         clone_repo(repo_slug, clone_dir, token=token)
+
+    logger.info("Bootstrapping clone before pull: fetch, clean, reset (%s)", clone_dir)
+    prepare_repo_for_pull(clone_dir, remote="origin", token=token)
 
     logger.info("Pulling latest for %s", clone_dir)
     pull(clone_dir, branch=branch, token=token)

--- a/boost_library_usage_dashboard/tests/fixtures.py
+++ b/boost_library_usage_dashboard/tests/fixtures.py
@@ -5,4 +5,5 @@ import pytest
 
 @pytest.fixture
 def dashboard_cmd_name():
+    """Name of the ``run_boost_library_usage_dashboard`` management command."""
     return "run_boost_library_usage_dashboard"

--- a/boost_library_usage_dashboard/tests/test_analyzer.py
+++ b/boost_library_usage_dashboard/tests/test_analyzer.py
@@ -9,7 +9,6 @@ from boost_library_usage_dashboard.analyzer import BoostUsageDashboardAnalyzer
 
 def _make_analyzer() -> BoostUsageDashboardAnalyzer:
     analyzer = BoostUsageDashboardAnalyzer.__new__(BoostUsageDashboardAnalyzer)
-    analyzer.base_dir = Path(tempfile.gettempdir()) / "boost-dashboard-test-base"
     analyzer.output_dir = Path(tempfile.gettempdir()) / "boost-dashboard-test-output"
     analyzer.version_name_list = ["1.50.0", "1.51.0", "1.52.0", "1.53.0", "1.54.0"]
     analyzer.repo_info = []

--- a/boost_library_usage_dashboard/tests/test_command.py
+++ b/boost_library_usage_dashboard/tests/test_command.py
@@ -11,12 +11,14 @@ from django.core.management.base import CommandError
 
 @pytest.mark.django_db
 def test_dashboard_command_exists(dashboard_cmd_name):
+    """The dashboard management command is registered with Django."""
     commands = get_commands()
     assert dashboard_cmd_name in commands
 
 
 @pytest.mark.django_db
 def test_dashboard_command_runs_generation_only(dashboard_cmd_name, tmp_path):
+    """Default collect+render runs; publish is skipped when ``--skip-publish`` is passed."""
     fake_analyzer = MagicMock()
     fake_analyzer.run.return_value = {"total_repositories": 0}
     fake_analyzer.report_file = tmp_path / "Boost_Usage_Report_total.md"

--- a/boost_library_usage_dashboard/tests/test_command.py
+++ b/boost_library_usage_dashboard/tests/test_command.py
@@ -1,13 +1,11 @@
 """Tests for run_boost_library_usage_dashboard command."""
 
-from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from django.conf import settings
 from django.core.management import call_command, get_commands
-from django.core.management.base import CommandError
 
 
 @pytest.mark.django_db
@@ -23,24 +21,20 @@ def test_dashboard_command_runs_generation_only(dashboard_cmd_name, tmp_path):
     fake_analyzer.report_file = tmp_path / "Boost_Usage_Report_total.md"
     fake_analyzer.stars_min_threshold = 10
 
-    out = StringIO()
-    err = StringIO()
-
     with patch(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.get_workspace_path",
+        return_value=tmp_path,
+    ), patch(
         "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.BoostUsageDashboardAnalyzer",
         return_value=fake_analyzer,
     ) as analyzer_cls, patch(
         "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.write_summary_report"
     ) as write_report, patch(
         "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.render_dashboard_html"
-    ) as render_html:
-        call_command(
-            dashboard_cmd_name,
-            "--output-dir",
-            str(tmp_path),
-            stdout=out,
-            stderr=err,
-        )
+    ) as render_html, patch(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.publish_dashboard"
+    ) as publish_mock:
+        call_command(dashboard_cmd_name, "--skip-publish")
 
     analyzer_cls.assert_called_once()
     fake_analyzer.run.assert_called_once()
@@ -54,13 +48,14 @@ def test_dashboard_command_runs_generation_only(dashboard_cmd_name, tmp_path):
         base_dir=settings.BASE_DIR,
         output_dir=expected_output_dir,
     )
+    publish_mock.assert_not_called()
 
 
 @pytest.mark.django_db
-def test_dashboard_command_publish_with_owner_repo_calls_publish_via_raw_clone(
+def test_dashboard_command_publish_with_owner_repo_calls_publish_dashboard(
     dashboard_cmd_name, tmp_path
 ):
-    """When --publish and settings have owner/repo, _publish_via_raw_clone is called."""
+    """When owner/repo are set (settings or CLI), publish_dashboard is called."""
     fake_analyzer = MagicMock()
     fake_analyzer.run.return_value = {}
     fake_analyzer.report_file = tmp_path / "Boost_Usage_Report_total.md"
@@ -68,6 +63,9 @@ def test_dashboard_command_publish_with_owner_repo_calls_publish_via_raw_clone(
     (tmp_path / "index.html").write_text("<html/>")
 
     with patch(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.get_workspace_path",
+        return_value=tmp_path,
+    ), patch(
         "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.BoostUsageDashboardAnalyzer",
         return_value=fake_analyzer,
     ), patch(
@@ -75,8 +73,8 @@ def test_dashboard_command_publish_with_owner_repo_calls_publish_via_raw_clone(
     ), patch(
         "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.render_dashboard_html"
     ), patch(
-        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.Command._publish_via_raw_clone"
-    ) as publish_raw_mock, patch.object(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.publish_dashboard"
+    ) as publish_mock, patch.object(
         settings,
         "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER",
         "myorg",
@@ -91,15 +89,12 @@ def test_dashboard_command_publish_with_owner_repo_calls_publish_via_raw_clone(
     ):
         call_command(
             dashboard_cmd_name,
-            "--publish",
-            "--target-branch",
+            "--branch",
             "gh-pages",
-            "--output-dir",
-            str(tmp_path),
         )
 
-    publish_raw_mock.assert_called_once()
-    call_kw = publish_raw_mock.call_args[1]
+    publish_mock.assert_called_once()
+    call_kw = publish_mock.call_args[1]
     assert call_kw["owner"] == "myorg"
     assert call_kw["repo"] == "my-repo"
     assert call_kw["branch"] == "gh-pages"
@@ -110,13 +105,16 @@ def test_dashboard_command_publish_with_owner_repo_calls_publish_via_raw_clone(
 def test_dashboard_command_publish_uses_branch_from_settings_when_set(
     dashboard_cmd_name, tmp_path
 ):
-    """When BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_BRANCH is set, it is passed to _publish_via_raw_clone."""
+    """When BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_BRANCH is set, it is used if --branch omitted."""
     fake_analyzer = MagicMock()
     fake_analyzer.run.return_value = {}
     fake_analyzer.report_file = tmp_path / "report.md"
     fake_analyzer.stars_min_threshold = 10
 
     with patch(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.get_workspace_path",
+        return_value=tmp_path,
+    ), patch(
         "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.BoostUsageDashboardAnalyzer",
         return_value=fake_analyzer,
     ), patch(
@@ -124,8 +122,8 @@ def test_dashboard_command_publish_uses_branch_from_settings_when_set(
     ), patch(
         "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.render_dashboard_html"
     ), patch(
-        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.Command._publish_via_raw_clone"
-    ) as publish_raw_mock, patch.object(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.publish_dashboard"
+    ) as publish_mock, patch.object(
         settings,
         "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER",
         "org",
@@ -138,29 +136,25 @@ def test_dashboard_command_publish_uses_branch_from_settings_when_set(
         "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_BRANCH",
         "publish-branch",
     ):
-        call_command(
-            dashboard_cmd_name,
-            "--publish",
-            "--target-branch",
-            "main",
-            "--output-dir",
-            str(tmp_path),
-        )
+        call_command(dashboard_cmd_name)
 
-    assert publish_raw_mock.call_args[1]["branch"] == "publish-branch"
+    assert publish_mock.call_args[1]["branch"] == "publish-branch"
 
 
 @pytest.mark.django_db
-def test_dashboard_command_publish_no_owner_repo_raises_command_error(
+def test_dashboard_command_publish_no_owner_repo_skips_publish(
     dashboard_cmd_name, tmp_path
 ):
-    """When --publish but owner or repo missing in settings, CommandError is raised."""
+    """When owner and repo are missing, publish is skipped (no CommandError)."""
     fake_analyzer = MagicMock()
     fake_analyzer.run.return_value = {}
     fake_analyzer.report_file = tmp_path / "report.md"
     fake_analyzer.stars_min_threshold = 10
 
     with patch(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.get_workspace_path",
+        return_value=tmp_path,
+    ), patch(
         "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.BoostUsageDashboardAnalyzer",
         return_value=fake_analyzer,
     ), patch(
@@ -168,8 +162,8 @@ def test_dashboard_command_publish_no_owner_repo_raises_command_error(
     ), patch(
         "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.render_dashboard_html"
     ), patch(
-        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.Command._publish_via_raw_clone"
-    ) as publish_raw_mock, patch.object(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.publish_dashboard"
+    ) as publish_mock, patch.object(
         settings,
         "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER",
         "",
@@ -178,12 +172,6 @@ def test_dashboard_command_publish_no_owner_repo_raises_command_error(
         "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_REPO",
         "",
     ):
-        with pytest.raises(CommandError) as exc_info:
-            call_command(
-                dashboard_cmd_name,
-                "--publish",
-                "--output-dir",
-                str(tmp_path),
-            )
-        assert "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH" in str(exc_info.value)
-        publish_raw_mock.assert_not_called()
+        call_command(dashboard_cmd_name)
+
+    publish_mock.assert_not_called()

--- a/boost_library_usage_dashboard/tests/test_command.py
+++ b/boost_library_usage_dashboard/tests/test_command.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.conf import settings
 from django.core.management import call_command, get_commands
+from django.core.management.base import CommandError
 
 
 @pytest.mark.django_db
@@ -110,6 +111,7 @@ def test_dashboard_command_publish_uses_branch_from_settings_when_set(
     fake_analyzer.run.return_value = {}
     fake_analyzer.report_file = tmp_path / "report.md"
     fake_analyzer.stars_min_threshold = 10
+    (tmp_path / "index.html").write_text("<html/>")
 
     with patch(
         "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.get_workspace_path",
@@ -175,3 +177,40 @@ def test_dashboard_command_publish_no_owner_repo_skips_publish(
         call_command(dashboard_cmd_name)
 
     publish_mock.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_dashboard_command_publish_refuses_without_html_artifacts(
+    dashboard_cmd_name, tmp_path
+):
+    """Publish with owner/repo but no *.html under output_dir raises CommandError."""
+    with patch(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.get_workspace_path",
+        return_value=tmp_path,
+    ), patch(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.BoostUsageDashboardAnalyzer",
+    ), patch(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.write_summary_report"
+    ), patch(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.render_dashboard_html"
+    ), patch(
+        "boost_library_usage_dashboard.management.commands.run_boost_library_usage_dashboard.publish_dashboard"
+    ) as publish_mock, patch.object(
+        settings,
+        "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER",
+        "org",
+    ), patch.object(
+        settings,
+        "BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_REPO",
+        "repo",
+    ):
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "dashboard_data.json").write_text("{}")
+        with pytest.raises(CommandError) as exc_info:
+            call_command(
+                dashboard_cmd_name,
+                "--skip-collect",
+                "--skip-render",
+            )
+        assert "no HTML artifacts" in str(exc_info.value)
+        publish_mock.assert_not_called()

--- a/boost_library_usage_dashboard/tests/test_publisher.py
+++ b/boost_library_usage_dashboard/tests/test_publisher.py
@@ -1,0 +1,54 @@
+"""Tests for boost_library_usage_dashboard.publisher validation."""
+
+from unittest.mock import patch
+
+import pytest
+from django.conf import settings
+from django.core.management.base import CommandError
+
+from boost_library_usage_dashboard.publisher import publish_dashboard
+
+
+@pytest.mark.django_db
+def test_publish_dashboard_rejects_owner_with_path_separator(tmp_path):
+    """Owner must be a single slug; path separators are rejected."""
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    with patch.object(settings, "RAW_DIR", str(raw)):
+        with pytest.raises(CommandError, match="Invalid GitHub owner"):
+            publish_dashboard(
+                tmp_path / "out",
+                owner="foo/bar",
+                repo="repo",
+                branch="main",
+            )
+
+
+@pytest.mark.django_db
+def test_publish_dashboard_rejects_dotdot_repo(tmp_path):
+    """Repo must not be path-like."""
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    with patch.object(settings, "RAW_DIR", str(raw)):
+        with pytest.raises(CommandError, match="Invalid GitHub repo"):
+            publish_dashboard(
+                tmp_path / "out",
+                owner="org",
+                repo="..",
+                branch="main",
+            )
+
+
+@pytest.mark.django_db
+def test_publish_dashboard_rejects_invalid_slug_chars(tmp_path):
+    """Spaces and other disallowed characters are rejected."""
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    with patch.object(settings, "RAW_DIR", str(raw)):
+        with pytest.raises(CommandError, match="Invalid GitHub owner"):
+            publish_dashboard(
+                tmp_path / "out",
+                owner="bad name",
+                repo="repo",
+                branch="main",
+            )

--- a/config/settings.py
+++ b/config/settings.py
@@ -289,18 +289,27 @@ BOOST_LIBRARY_TRACKER_REPO_BRANCH = (
     env("BOOST_LIBRARY_TRACKER_REPO_BRANCH", default="master") or "master"
 ).strip()
 
-# Settings for publishing boost_library_usage_dashboard
+# =============================================================================
+# Boost Library Usage Dashboard
+# run_boost_library_usage_dashboard writes artifacts under the workspace, then
+# optionally publishes to the GitHub repo below (unless --skip-publish). Clone,
+# pull, and push use GITHUB_TOKEN_WRITE. If PUBLISH_OWNER / PUBLISH_REPO are
+# unset, publish is skipped (CLI --owner / --repo can override). GIT_AUTHOR_*
+# set commit author for that push only (via git env vars, not git config).
+# =============================================================================
 BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER = (
     env("BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER", default="") or ""
 ).strip()
 BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_REPO = (
     env("BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_REPO", default="") or ""
 ).strip()
-BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_TOKEN = (
-    env("BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_TOKEN", default="") or ""
-).strip() or GITHUB_TOKEN_WRITE
 BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_BRANCH = (
     env("BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_BRANCH", default="") or ""
+).strip()
+GIT_AUTHOR_NAME = (env("GIT_AUTHOR_NAME", default="unknown") or "unknown").strip()
+GIT_AUTHOR_EMAIL = (
+    env("GIT_AUTHOR_EMAIL", default="unknown@noreply.github.com")
+    or "unknown@noreply.github.com"
 ).strip()
 
 

--- a/github_ops/git_ops.py
+++ b/github_ops/git_ops.py
@@ -105,12 +105,17 @@ GIT_CMD_TIMEOUT_SECONDS = 300
 
 
 def _url_with_token(url: str, token: str) -> str:
-    """Inject token into GitHub HTTPS URL for auth."""
+    """Inject credentials into a GitHub HTTPS URL for Git over HTTPS.
+
+    Uses ``x-access-token:<token>`` as the userinfo segment. Required for
+    fine-grained PATs (``github_pat_...``); classic PATs work with this form too.
+    """
     if not token:
         return url
+    auth = f"x-access-token:{token}"
     return re.sub(
         r"^(https://)(github\.com/)",
-        r"\1" + token + r"@\2",
+        r"\1" + auth + r"@\2",
         url,
         count=1,
     )
@@ -162,11 +167,13 @@ def clone_repo(
         )
         raise
     except subprocess.CalledProcessError as e:
+        err_tail = ((e.stderr or "") + (e.stdout or ""))[-500:]
         logger.warning(
-            "git clone failed (%s -> %s), returncode=%s",
+            "git clone failed (%s -> %s), returncode=%s, stderr/stdout_tail=%r",
             url_or_slug,
             dest_dir,
             e.returncode,
+            err_tail,
         )
         raise
 
@@ -190,6 +197,8 @@ def push(
 
     git_user_name / git_user_email: if set, passed only to the ``git commit`` subprocess
     via GIT_AUTHOR_* / GIT_COMMITTER_* env vars (does not modify repo ``git config``).
+    Any existing GIT_AUTHOR_* / GIT_COMMITTER_* entries are removed from the commit
+    environment first so ambient or Django-set values are not inherited when unset.
     """
     repo_dir = Path(repo_dir)
     if token is None:
@@ -209,6 +218,13 @@ def push(
         text=True,
     )
     commit_env = dict(os.environ)
+    for _key in (
+        "GIT_AUTHOR_NAME",
+        "GIT_AUTHOR_EMAIL",
+        "GIT_COMMITTER_NAME",
+        "GIT_COMMITTER_EMAIL",
+    ):
+        commit_env.pop(_key, None)
     if git_user_name:
         commit_env["GIT_AUTHOR_NAME"] = git_user_name
         commit_env["GIT_COMMITTER_NAME"] = git_user_name

--- a/github_ops/git_ops.py
+++ b/github_ops/git_ops.py
@@ -179,12 +179,17 @@ def push(
     commit_message: Optional[str] = None,
     add_paths: Optional[list[str | Path]] = None,
     token: Optional[str] = None,
+    git_user_name: Optional[str] = None,
+    git_user_email: Optional[str] = None,
 ) -> None:
     """
     Push to remote. Uses push token by default.
     Always runs git add, git commit, then push. Uses commit_message if provided,
     otherwise "Auto commit in <YYYY-MM-DD HH:MM:SS UTC>". add_paths: paths to add
     (relative to repo_dir); if None, adds all (git add .).
+
+    git_user_name / git_user_email: if set, passed only to the ``git commit`` subprocess
+    via GIT_AUTHOR_* / GIT_COMMITTER_* env vars (does not modify repo ``git config``).
     """
     repo_dir = Path(repo_dir)
     if token is None:
@@ -203,10 +208,20 @@ def push(
         capture_output=True,
         text=True,
     )
+    commit_env = dict(os.environ)
+    if git_user_name:
+        commit_env["GIT_AUTHOR_NAME"] = git_user_name
+        commit_env["GIT_COMMITTER_NAME"] = git_user_name
+    if git_user_email:
+        commit_env["GIT_AUTHOR_EMAIL"] = git_user_email
+        commit_env["GIT_COMMITTER_EMAIL"] = git_user_email
     commit_result = subprocess.run(
         ["git", "-C", str(repo_dir), "commit", "-m", message],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=commit_env,
     )
     if commit_result.returncode != 0:
         out = (commit_result.stderr or "") + (commit_result.stdout or "")

--- a/github_ops/git_ops.py
+++ b/github_ops/git_ops.py
@@ -304,6 +304,68 @@ def pull(
     subprocess.run(cmd, check=True, capture_output=True, text=True)
 
 
+def prepare_repo_for_pull(
+    repo_dir: str | Path,
+    *,
+    remote: str = "origin",
+    token: Optional[str] = None,
+) -> None:
+    """
+    Fetch remote branch refs (prune), remove untracked files, and reset the working tree.
+
+    Use before checkout/pull on a reused clone that may have local changes or lack
+    remote-tracking refs for branches that exist only on the remote.
+    """
+    repo_dir = Path(repo_dir)
+    if token is None:
+        token = get_github_token(use="push")
+    result = subprocess.run(
+        ["git", "-C", str(repo_dir), "remote", "get-url", remote],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    remote_url = result.stdout.strip()
+    auth_url = _url_with_token(remote_url, token or "")
+
+    logger.info("Fetching %s refs (prune) in %s", remote, repo_dir)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_dir),
+            "fetch",
+            auth_url,
+            f"+refs/heads/*:refs/remotes/{remote}/*",
+            "--prune",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=GIT_CMD_TIMEOUT_SECONDS,
+    )
+    logger.info("Running git clean -fd in %s", repo_dir)
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "clean", "-fd"],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    logger.info("Running git reset --hard in %s", repo_dir)
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "reset", "--hard"],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
 def fetch_file_content(
     owner: str,
     repo: str,

--- a/github_ops/tests/test_git_ops.py
+++ b/github_ops/tests/test_git_ops.py
@@ -26,10 +26,10 @@ def test_url_with_token_empty_token_returns_unchanged():
 
 
 def test_url_with_token_injects_token_before_github_com():
-    """_url_with_token injects token into HTTPS GitHub URL."""
+    """_url_with_token uses x-access-token form for GitHub HTTPS Git auth."""
     url = "https://github.com/owner/repo.git"
     out = _url_with_token(url, "secret")
-    assert out == "https://secret@github.com/owner/repo.git"
+    assert out == "https://x-access-token:secret@github.com/owner/repo.git"
 
 
 def test_url_with_token_none_like_token_returns_unchanged():
@@ -42,7 +42,7 @@ def test_url_with_token_only_replaces_first_occurrence():
     """_url_with_token uses count=1 so only first https://github.com/ is modified."""
     url = "https://github.com/boostorg/boost.git"
     out = _url_with_token(url, "tok")
-    assert out == "https://tok@github.com/boostorg/boost.git"
+    assert out == "https://x-access-token:tok@github.com/boostorg/boost.git"
 
 
 # --- clone_repo ---
@@ -69,9 +69,9 @@ def test_clone_repo_slug_converted_to_https_url(tmp_path):
     with patch("github_ops.git_ops.subprocess.run", MagicMock()) as run_mock:
         clone_repo("owner/repo", tmp_path, token="t")
     call_args = run_mock.call_args[0][0]
-    assert (
-        "https://github.com/owner/repo.git" in call_args[2]
-        or "t@github.com" in call_args[2]
+    clone_url = call_args[2]
+    assert "https://github.com/owner/repo.git" in clone_url or (
+        "x-access-token:t@" in clone_url and "github.com/owner/repo.git" in clone_url
     )
 
 


### PR DESCRIPTION
- Set `GIT_AUTHOR_/GIT_COMMITTER_` env vars on git commit only (`git_ops.push`)
- Add publisher module; use `GITHUB_TOKEN_WRITE; GIT_AUTHOR_* settings + .env.example`
- Replace `--publish` with `--skip-collect/--skip-render/--skip-publish`; add `--owner/--repo/--branch`
- Fix publish skipped when owner/repo missing (do not call `publish_dashboard`)
- Drop unused `BoostUsageDashboardAnalyzer base_dir`; UTC timestamp in publish commit message
- Clarify Boost Library Usage Dashboard block in settings comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --skip-collect, --skip-render, --skip-publish flags and --owner/--repo/--branch publishing overrides; command now uses a fixed workspace for artifacts.

* **Configuration**
  * Introduced GIT_AUTHOR_NAME and GIT_AUTHOR_EMAIL env vars; removed the explicit publish-token override; updated example env docs and publish guidance.

* **Refactor**
  * Publishing flow moved to a centralized publisher component with improved validation and safer Git handling.

* **Tests**
  * Updated and added tests for CLI changes, publishing validations, and missing-HTML artifact behavior.

* **Documentation**
  * Added package/commands docstrings and clarified publish documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->