### PR TITLE
docs: clarify failure webhooks default-on; expand architecture data flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,9 +67,12 @@ DATABASE_URL=postgres://user:password@localhost:5432/boost_dashboard
 # =============================================================================
 # Error Notifications (Discord/Slack)
 # =============================================================================
-# When DISCORD_WEBHOOK_URL and/or SLACK_WEBHOOK_URL is set, ERROR log notifications
-# are enabled by default. Set ENABLE_ERROR_NOTIFICATIONS=false to turn them off.
-# ENABLE_ERROR_NOTIFICATIONS=false
+# Default-on when at least one webhook URL below is set: ERROR-level logs are sent
+# to Discord and/or Slack (see config/settings.py + config/logging_handlers.py).
+# You do not need to set ENABLE_ERROR_NOTIFICATIONS=true for that behavior.
+#
+# Opt-out (e.g. webhooks used only for deploy/startup messages, or to silence alerts):
+#   ENABLE_ERROR_NOTIFICATIONS=false
 
 # Discord webhook URL (get from Discord: Server Settings > Integrations > Webhooks)
 # DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Each Django app can expose management commands in `management/commands/`. All ap
 ## How it works
 
 - Django project: One Django project with multiple Django apps; all apps share the same settings and database.
+- **Architecture / data flow:** See **[docs/Architecture_data_flow.md](docs/Architecture_data_flow.md)** for Mermaid diagrams (sources → collectors → PostgreSQL / workspace → Pinecone) and a per-app component map. Scheduling diagram: [docs/Development_guideline.md](docs/Development_guideline.md#architecture-high-level).
 - Workflow: **`boost_collector_runner`** runs app commands from **`config/boost_collector_schedule.yaml`** (via **`run_scheduled_collectors`** and Celery). You can also run individual `manage.py` commands by hand.
 - Database: One PostgreSQL database (e.g. `boost_dashboard`); Django ORM and migrations for all apps.
 - Configuration: Django settings (`settings.py`) and environment variables (e.g. via `django-environ` or `python-decouple`).

--- a/docs/Architecture_data_flow.md
+++ b/docs/Architecture_data_flow.md
@@ -1,6 +1,10 @@
 # Collector data flow (architecture)
 
-High-level view of how data moves through Boost Data Collector. For execution order and scheduling, see [Workflow.md](Workflow.md).
+High-level view of how data moves through Boost Data Collector: external sources, Django collector apps, shared storage, and vector search. For execution order, Celery Beat, and YAML groups, see [Workflow.md](Workflow.md). For the schedule → command wiring, see [Development_guideline.md](Development_guideline.md#architecture-high-level).
+
+**Schema vs flow:** [Schema.md](Schema.md) documents tables and relationships per domain. This page complements it by showing **cross-app data movement** (ingest → PostgreSQL / workspace → Pinecone), which is easy to miss when reading ORM diagrams alone.
+
+## 1. External sources → collectors → storage → vectors
 
 ```mermaid
 flowchart LR
@@ -41,3 +45,50 @@ flowchart LR
 - **Workspace** holds clones, exports, and intermediate files under `WORKSPACE_DIR` (see [Workspace.md](Workspace.md)).
 - **PostgreSQL** is the system of record for ORM models across apps.
 - **cppa_pinecone_sync** (and app-specific upsert paths) push embeddings/metadata to **Pinecone** namespaces.
+
+## 2. Orchestration and components (per app)
+
+Scheduled batch work is driven by **`boost_collector_runner`** reading **`config/boost_collector_schedule.yaml`**, which invokes **`run_scheduled_collectors`** → individual **`run_*` management commands** (one command per task line in the YAML).
+
+```mermaid
+flowchart TB
+  subgraph orch [Orchestration]
+    YAML[boost_collector_schedule.yaml]
+    RSC[run_scheduled_collectors]
+  end
+  YAML -.schedule.-> RSC
+  subgraph apps [Collector_commands_project_apps]
+    CMDS[Per_app_run_commands_in_INSTALLED_APPS]
+  end
+  RSC --> CMDS
+  CMDS --> PG[(PostgreSQL)]
+  CMDS --> WS[WORKSPACE_DIR]
+  CMDS --> PC[cppa_pinecone_sync]
+  PG --> PC
+  PC --> PIN[(Pinecone)]
+```
+
+**Typical persistence** (column below): where this app **usually** stores durable data during normal runs. **PostgreSQL** = Django ORM tables in the shared DB. **`WORKSPACE_DIR`** = files under the configured workspace root (`workspace/<app>/…` or `workspace/raw/…`; see [Workspace.md](Workspace.md)). **Pinecone** = remote vector index. Apps may also call external APIs without listing them here (e.g. GitHub for pushes).
+
+**Django apps (project)** — each row is an `INSTALLED_APPS` entry that participates in collection, sync, or shared identity (not an exhaustive command list; see each app’s `management/commands/` and [docs/README.md](README.md)).
+
+| Django app | Role (summary) | Typical persistence |
+|------------|----------------|------------------------|
+| `core` | Shared collector base types (`CollectorBase`, `BaseCollectorCommand`), structured errors, **`core.operations`** (GitHub/Slack I/O helpers — not a separate app) | N/A (library code; `core` has no ORM models) |
+| `boost_collector_runner` | YAML schedule resolution; **`run_scheduled_collectors`** entry point | N/A (no ORM models) |
+| `cppa_user_tracker` | Shared Slack/GitHub user identity used by trackers | PostgreSQL |
+| `github_activity_tracker` | GitHub raw fetch utilities, workspace JSON, models used across GitHub pipelines | PostgreSQL, `WORKSPACE_DIR` |
+| `boost_library_tracker` | Primary Boost org GitHub activity and library metadata | PostgreSQL, `WORKSPACE_DIR` |
+| `boost_library_docs_tracker` | Boost documentation crawl / ingest | PostgreSQL, `WORKSPACE_DIR` |
+| `boost_library_usage_dashboard` | Usage dashboard inputs | PostgreSQL, `WORKSPACE_DIR` (generated/export files) |
+| `boost_usage_tracker` | Stars / content monitoring | PostgreSQL, `WORKSPACE_DIR` (CSV / staging paths) |
+| `boost_mailing_list_tracker` | Mailing list archives | PostgreSQL, `WORKSPACE_DIR` (raw / message JSON) |
+| `clang_github_tracker` | LLVM/Clang GitHub activity | PostgreSQL, `WORKSPACE_DIR` |
+| `cppa_slack_tracker` | Slack messages and channels | PostgreSQL, `WORKSPACE_DIR` (per-channel JSON, raw) |
+| `discord_activity_tracker` | Discord server activity | PostgreSQL, `WORKSPACE_DIR` |
+| `cppa_youtube_script_tracker` | YouTube transcript collection | PostgreSQL, `WORKSPACE_DIR` (metadata, raw VTT) |
+| `wg21_paper_tracker` | WG21 committee papers pipeline | PostgreSQL, `WORKSPACE_DIR` |
+| `cppa_pinecone_sync` | Hybrid vector upserts / namespaces | PostgreSQL (sync status, fail lists), Pinecone |
+| `slack_event_handler` | Slack Bolt (Socket Mode): huddles / PR bot — **long-running process**, not the same as the YAML nightly batch | `WORKSPACE_DIR` (JSON state / queue; no ORM models), GitHub (optional MD uploads) |
+
+**Pinecone paths:** Many collectors write rows first; **`cppa_pinecone_sync`** (and some commands’ built-in sync phases) read from PostgreSQL and/or files and upsert into Pinecone. Namespace and field conventions vary by source; see [Pinecone_preprocess_guideline.md](Pinecone_preprocess_guideline.md) and per-app docs under [service_api/](service_api/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Documentation is organized **by topic**, not by app. Each doc covers one cross-c
 | Topic | Doc | Purpose |
 |-------|-----|---------|
 | **Workflow** | [Workflow.md](Workflow.md) | Main application workflow, execution order, and project details. |
-| **Architecture** | [Architecture_data_flow.md](Architecture_data_flow.md) | Data flow diagram: sources → collectors → DB / workspace → Pinecone. |
+| **Architecture** | [Architecture_data_flow.md](Architecture_data_flow.md) | Data flow (sources → collectors → DB / workspace → Pinecone), orchestration diagram, per-app component map. |
 | **Add a collector** | [How_to_add_a_collector.md](How_to_add_a_collector.md) | Checklist: new command, registration, tests, docs. |
 | **Core API** | [Core_public_API.md](Core_public_API.md) | Stable `core` imports: collectors, error classification. |
 | **Operations** | [operations/](operations/README.md) | **Group:** shared I/O (GitHub, Discord, etc.) used by multiple apps. Index in [operations/README.md](operations/README.md). |


### PR DESCRIPTION
Closes #160 , closes #159 

## Summary

Documentation updates for how failure alerts use Discord/Slack webhooks by default when URLs are set, and for onboarding: architecture diagrams, YAML-driven orchestration, and a per-app **typical persistence** table aligned with the codebase.

## Changes

- **`.env.example` — error notifications:** Clarify default-on `ERROR`-level webhook posts when `DISCORD_WEBHOOK_URL` and/or `SLACK_WEBHOOK_URL` is set; document opt-out with `ENABLE_ERROR_NOTIFICATIONS=false` (no need to set `=true` for default behavior).
- **`docs/Architecture_data_flow.md`:** Schema vs cross-app flow; second Mermaid chart (schedule → collectors → PostgreSQL / workspace → Pinecone); component table with corrected persistence (`cppa_pinecone_sync` ORM + Pinecone, `slack_event_handler` workspace JSON, workspace usage for Slack/YouTube/mailing list/usage trackers, etc.).
- **`README.md` / `docs/README.md`:** Link “How it works” and the docs index to the architecture page (orchestration + component map).

## Notes

Runtime behavior for `ENABLE_ERROR_NOTIFICATIONS` is already implemented in `config/settings.py` (default on when a webhook URL is present). This PR focuses on **docs accuracy and discoverability**, not a settings change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Architecture & data flow docs with orchestration diagrams, per-app component maps, persistence details, and Pinecone integration; updated docs index and README "How it works" to reference the enhanced architecture content.

* **Chores**
  * Clarified error-notifications guidance in environment examples: ERROR-level notifications now described as enabled by default when a webhook is configured, and an explicit opt-out example added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->