### PR TITLE
test(boost_library_usage_dashboard): expand coverage, add .coveragerc, enforce cov gate in CI

### DIFF
--- a/boost_library_usage_dashboard/tests/test_analyzer_integration.py
+++ b/boost_library_usage_dashboard/tests/test_analyzer_integration.py
@@ -98,7 +98,9 @@ def test_load_repository_count_from_db_merges_cpp_rows(tmp_path: Path):
     )
 
     analyzer = BoostUsageDashboardAnalyzer(tmp_path)
-    out = analyzer._load_repository_count_from_db({"2024": 7})  # pylint: disable=protected-access
+    out = analyzer._load_repository_count_from_db(
+        {"2024": 7}
+    )  # pylint: disable=protected-access
 
     row_by_year = {r["year"]: r for r in out["repos_by_year_boost_rate"]}
     assert row_by_year["2024"]["boost_over_10"] == 7
@@ -114,5 +116,7 @@ def test_load_repository_count_from_db_lookup_error_returns_empty(tmp_path: Path
         "boost_library_usage_dashboard.analyzer.apps.get_model",
         side_effect=LookupError("no model"),
     ):
-        out = analyzer._load_repository_count_from_db({"2024": 1})  # pylint: disable=protected-access
+        out = analyzer._load_repository_count_from_db(
+            {"2024": 1}
+        )  # pylint: disable=protected-access
     assert out == {"repos_by_year_boost_rate": [], "language_comparison_data": {}}

--- a/boost_library_usage_dashboard/tests/test_analyzer_integration.py
+++ b/boost_library_usage_dashboard/tests/test_analyzer_integration.py
@@ -1,0 +1,118 @@
+"""Integration tests for BoostUsageDashboardAnalyzer with PostgreSQL/Django ORM."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from model_bakery import baker
+
+from boost_library_tracker import services as bl_services
+from boost_library_usage_dashboard.analyzer import BoostUsageDashboardAnalyzer
+from boost_usage_tracker import services as bu_services
+from github_activity_tracker import services as gh_services
+
+
+@pytest.mark.django_db
+def test_analyzer_run_writes_dashboard_json_and_stats(
+    tmp_path: Path,
+    github_account,
+    github_file,
+    boost_library,
+):
+    """Minimal repo + usage graph exercises analyzer pipeline including DB metrics."""
+    v_old, _ = bl_services.get_or_create_boost_version(
+        "boost-1.80.0",
+        datetime(2020, 1, 1, tzinfo=timezone.utc),
+    )
+    v_new, _ = bl_services.get_or_create_boost_version(
+        "boost-1.81.0",
+        datetime(2021, 6, 1, tzinfo=timezone.utc),
+    )
+    bl_services.get_or_create_boost_library_version(
+        boost_library,
+        v_old,
+        cpp_version="C++14",
+        description="Old snap",
+        key="algorithm-old",
+        documentation="https://example.invalid/old",
+    )
+    bl_services.get_or_create_boost_library_version(
+        boost_library,
+        v_new,
+        cpp_version="C++17",
+        description="Algorithm library",
+        key="algorithm",
+        documentation="https://example.invalid/new",
+    )
+
+    boost_file, _ = bl_services.get_or_create_boost_file(github_file, boost_library)
+
+    ext_repo_parent = baker.make(
+        "github_activity_tracker.GitHubRepository",
+        owner_account=github_account,
+        repo_name="dash-consumer-" + uuid.uuid4().hex[:8],
+        stars=11,
+        repo_created_at=datetime(2024, 3, 15, tzinfo=timezone.utc),
+    )
+    ext_repo, _ = bu_services.get_or_create_boost_external_repo(
+        ext_repo_parent,
+        boost_version="boost-1.81.0",
+        is_boost_used=True,
+    )
+    ext_file = baker.make(
+        "github_activity_tracker.GitHubFile",
+        repo=ext_repo_parent,
+        filename="consumer.cpp",
+    )
+    bu_services.create_or_update_boost_usage(
+        ext_repo,
+        boost_file,
+        ext_file,
+        last_commit_date=datetime(2024, 4, 1, tzinfo=timezone.utc),
+    )
+
+    analyzer = BoostUsageDashboardAnalyzer(tmp_path)
+    stats = analyzer.run()
+
+    assert stats["total_repositories"] >= 1
+    assert "version_related_stats" in stats
+    assert (tmp_path / "dashboard_data.json").is_file()
+    payload = json.loads((tmp_path / "dashboard_data.json").read_text(encoding="utf-8"))
+    assert "metrics_by_library" in payload
+    assert "libraries_page_data" in payload
+
+
+@pytest.mark.django_db
+def test_load_repository_count_from_db_merges_cpp_rows(tmp_path: Path):
+    cpp, _ = gh_services.get_or_create_language("C++")
+    gh_services.create_or_update_created_repos_by_language(
+        language=cpp,
+        year=2024,
+        all_repos=100,
+        significant_repos=40,
+    )
+
+    analyzer = BoostUsageDashboardAnalyzer(tmp_path)
+    out = analyzer._load_repository_count_from_db({"2024": 7})  # pylint: disable=protected-access
+
+    row_by_year = {r["year"]: r for r in out["repos_by_year_boost_rate"]}
+    assert row_by_year["2024"]["boost_over_10"] == 7
+    assert row_by_year["2024"]["over_10"] == 40
+    assert row_by_year["2024"]["cpp_repo_count"] == 100
+    assert "C++" in out["language_comparison_data"]
+
+
+@pytest.mark.django_db
+def test_load_repository_count_from_db_lookup_error_returns_empty(tmp_path: Path):
+    analyzer = BoostUsageDashboardAnalyzer(tmp_path)
+    with patch(
+        "boost_library_usage_dashboard.analyzer.apps.get_model",
+        side_effect=LookupError("no model"),
+    ):
+        out = analyzer._load_repository_count_from_db({"2024": 1})  # pylint: disable=protected-access
+    assert out == {"repos_by_year_boost_rate": [], "language_comparison_data": {}}

--- a/boost_library_usage_dashboard/tests/test_analyzer_libraries_pure.py
+++ b/boost_library_usage_dashboard/tests/test_analyzer_libraries_pure.py
@@ -34,12 +34,8 @@ def test_get_first_version_released_after_no_candidates():
 
 
 def test_get_first_version_released_after_picks_earliest_future_release():
-    v_early = _FakeVersion(
-        "boost-1.82.0", datetime(2023, 6, 1, tzinfo=timezone.utc)
-    )
-    v_later = _FakeVersion(
-        "boost-1.83.0", datetime(2024, 6, 1, tzinfo=timezone.utc)
-    )
+    v_early = _FakeVersion("boost-1.82.0", datetime(2023, 6, 1, tzinfo=timezone.utc))
+    v_later = _FakeVersion("boost-1.83.0", datetime(2024, 6, 1, tzinfo=timezone.utc))
     commit_at = datetime(2023, 1, 1, tzinfo=timezone.utc)
     assert (
         get_first_version_released_after([v_later, v_early], commit_at)
@@ -130,9 +126,7 @@ def test_build_library_overview_data_aggregates_chart():
             },
         },
     }
-    with patch(
-        "boost_library_usage_dashboard.analyzer_libraries.datetime"
-    ) as dt_mock:
+    with patch("boost_library_usage_dashboard.analyzer_libraries.datetime") as dt_mock:
         dt_mock.now.return_value = now_ret
         overview = build_library_overview_data(lib_source, lib_data)
     assert overview["internal_consumers"] == 1

--- a/boost_library_usage_dashboard/tests/test_analyzer_libraries_pure.py
+++ b/boost_library_usage_dashboard/tests/test_analyzer_libraries_pure.py
@@ -1,0 +1,191 @@
+"""Tests for pure helpers in boost_library_usage_dashboard.analyzer_libraries."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from boost_library_usage_dashboard.analyzer_libraries import (
+    collect_commit_info_by_library,
+    collect_libraries_page_data,
+    build_library_overview_data,
+    get_contribution_data,
+    get_external_consumer_data,
+    get_first_version_released_after,
+    get_last_updated_version,
+)
+
+
+class _FakeVersion:
+    def __init__(self, version: str, created_at: datetime | None) -> None:
+        self.version = version
+        self.version_created_at = created_at
+
+
+def test_get_first_version_released_after_none_commit():
+    v = _FakeVersion("boost-1.81.0", datetime(2024, 1, 1, tzinfo=timezone.utc))
+    assert get_first_version_released_after([v], None) is None
+
+
+def test_get_first_version_released_after_no_candidates():
+    v = _FakeVersion("boost-1.81.0", datetime(2024, 1, 1, tzinfo=timezone.utc))
+    commit_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    assert get_first_version_released_after([v], commit_at) is None
+
+
+def test_get_first_version_released_after_picks_earliest_future_release():
+    v_early = _FakeVersion(
+        "boost-1.82.0", datetime(2023, 6, 1, tzinfo=timezone.utc)
+    )
+    v_later = _FakeVersion(
+        "boost-1.83.0", datetime(2024, 6, 1, tzinfo=timezone.utc)
+    )
+    commit_at = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert (
+        get_first_version_released_after([v_later, v_early], commit_at)
+        == "boost-1.82.0"
+    )
+
+
+def test_get_external_consumer_data_builds_table_and_chart():
+    lib = {
+        "top_repo_list": {"org/a": 2, "org/b": 1},
+        "year_data": {
+            "2024": {"created_count": 5, "last_commit_count": 3},
+        },
+    }
+    repo_info_dict = {
+        "org/a": {
+            "stars": 100,
+            "created_at": "2024-01-15T00:00:00",
+            "pushed_at": "2024-06-01T00:00:00",
+        },
+        "org/b": {"stars": 10, "created_at": "", "pushed_at": ""},
+    }
+    out = get_external_consumer_data(lib, repo_info_dict)
+    names = {row["name"] for row in out["table_data"]}
+    assert names == {"org/a", "org/b"}
+    assert out["chart_data"]["2024"]["by_created"] == 5
+    assert out["chart_data"]["2024"]["repos"] == 1
+
+
+def test_get_contribution_data_filters_chart_by_created_version():
+    lib = {
+        "created_version": "1.70.0",
+        "contribute_data": {
+            "1.65.0": {
+                "count": 2,
+                "persons": {"1": {"identity_name": "Old", "commit_count": 2}},
+            },
+            "1.80.0": {
+                "count": 4,
+                "persons": {
+                    "2": {"identity_name": "New", "commit_count": 4},
+                },
+            },
+        },
+    }
+    out = get_contribution_data(lib)
+    assert any(row["version"] == "1.80.0" for row in out["table_data"])
+    assert out["chart_data"] == {"1.80.0": 4}
+    assert "1.65.0" not in out["chart_data"]
+
+
+def test_get_last_updated_version_empty():
+    assert get_last_updated_version({}) == ""
+
+
+def test_get_last_updated_version_max_tuple():
+    data = {
+        "1.80.0": {"count": 2, "persons": {}},
+        "1.84.0": {"count": 1, "persons": {}},
+    }
+    assert get_last_updated_version(data) == "1.84.0"
+
+
+def test_build_library_overview_data_aggregates_chart():
+    now_ret = MagicMock()
+    now_ret.year = 2026
+    lib_source = {
+        "created_version": "1.70.0",
+        "repo_count": 12,
+        "activity_score": 1.2,
+        "average_stars": 40,
+        "description": "d",
+        "used_headers": {"h.hpp": 3},
+        "contribute_data": {
+            "1.84.0": {
+                "count": 2,
+                "persons": {"10": {}, "11": {}},
+            },
+        },
+    }
+    lib_data = {
+        "internal_dependents_data": {"table_data": [{"name": "x"}]},
+        "external_consumers": {
+            "chart_data": {
+                "2024": {"repos": 5},
+                "2025": {"repos": 3},
+                "2026": {"repos": 12},
+            },
+        },
+    }
+    with patch(
+        "boost_library_usage_dashboard.analyzer_libraries.datetime"
+    ) as dt_mock:
+        dt_mock.now.return_value = now_ret
+        overview = build_library_overview_data(lib_source, lib_data)
+    assert overview["internal_consumers"] == 1
+    assert overview["most_used_year"]["year"] == "2026"
+    assert overview["most_used_year"]["count"] == 12
+    assert overview["last_year_used_repo_count"]["year"] == 2025
+    assert overview["last_year_used_repo_count"]["count"] == 3
+
+
+def test_collect_libraries_page_data_wires_sections():
+    analyzer = MagicMock()
+    analyzer.library_info = [
+        {
+            "id": 7,
+            "name": "asio",
+            "top_repo_list": {},
+            "year_data": {},
+            "created_version": "1.72.0",
+            "contribute_data": {},
+        }
+    ]
+    analyzer.repo_info_dict = {}
+    deps = {
+        7: {"table_data": [{"name": "dep"}], "chart_data": {"boost-1.81.0": {}}},
+    }
+    with patch(
+        "boost_library_usage_dashboard.analyzer_libraries.collect_dependents_data",
+        return_value=deps,
+    ):
+        out = collect_libraries_page_data(analyzer)
+    assert "asio" in out
+    assert out["asio"]["internal_dependents_data"]["table_data"][0]["name"] == "dep"
+    assert "over_view" in out["asio"]
+
+
+def test_collect_commit_info_by_library_empty_iterator():
+    analyzer = MagicMock()
+    analyzer.library_info = [{"name": "algo"}]
+    v = MagicMock()
+    v.version = "boost-1.81.0"
+    analyzer.version_info = [v]
+
+    qs = MagicMock()
+    qs.iterator.return_value = []
+    mgr = MagicMock()
+    mgr.select_related.return_value.filter.return_value.exclude.return_value = qs
+
+    with patch(
+        "boost_library_usage_dashboard.analyzer_libraries.GitCommitFileChange.objects",
+        mgr,
+    ):
+        out = collect_commit_info_by_library(analyzer)
+
+    assert "algo" in out
+    assert out["algo"]["boost-1.81.0"]["count"] == 0
+    assert out["algo"]["boost-1.81.0"]["persons"] == {}

--- a/boost_library_usage_dashboard/tests/test_analyzer_metrics_unit.py
+++ b/boost_library_usage_dashboard/tests/test_analyzer_metrics_unit.py
@@ -1,0 +1,116 @@
+"""Direct unit tests for boost_library_usage_dashboard.analyzer_metrics."""
+
+# Tests intentionally exercise ``_float_from_env`` (module-private helper).
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import datetime as dt_module
+
+import pytest
+
+from boost_library_usage_dashboard import analyzer_metrics as metrics
+
+
+class _FixedNowDatetime:
+    """Stand-in for ``datetime`` class with a controlled ``now()``."""
+
+    fixed_year: int = 2030
+
+    @staticmethod
+    def now(_tz=None):
+        return dt_module.datetime(_FixedNowDatetime.fixed_year, 1, 1)
+
+
+def test_float_from_env_empty_uses_default():
+    key = "BOOST_DASHBOARD_TEST_FLOAT_METRICS_" + str(id(test_float_from_env_empty_uses_default))
+    os.environ.pop(key, None)
+    assert metrics._float_from_env(key, 0.42) == pytest.approx(0.42)
+
+
+def test_float_from_env_valid_number():
+    key = "BOOST_DASHBOARD_TEST_FLOAT_METRICS_" + str(id(test_float_from_env_valid_number))
+    with patch.dict(os.environ, {key: " 2.5 "}):
+        assert metrics._float_from_env(key, 1.0) == pytest.approx(2.5)
+
+
+def test_float_from_env_invalid_falls_back():
+    key = "BOOST_DASHBOARD_TEST_FLOAT_METRICS_" + str(id(test_float_from_env_invalid_falls_back))
+    with patch.dict(os.environ, {key: "not-a-float"}):
+        assert metrics._float_from_env(key, 0.25) == pytest.approx(0.25)
+
+
+def test_calculate_trend_metrics_empty_year_data():
+    out = metrics.calculate_trend_metrics([], recent_year_threshold=2020)
+    assert out["total_usage"] == 0
+    assert out["activity_score"] == -10.0
+
+
+def test_calculate_trend_metrics_zero_total_usage():
+    out = metrics.calculate_trend_metrics(
+        [(2022, {"created_count": 0, "last_commit_count": 0})],
+        recent_year_threshold=2020,
+    )
+    assert out["activity_score"] == -10.0
+
+
+def test_calculate_trend_metrics_uses_fallback_when_only_current_year():
+    fixed_year = 2030
+    year_data = [
+        (fixed_year, {"created_count": 5, "last_commit_count": 0}),
+        (fixed_year, {"created_count": 5, "last_commit_count": 0}),
+    ]
+    _FixedNowDatetime.fixed_year = fixed_year
+    with patch("boost_library_usage_dashboard.analyzer_metrics.datetime", _FixedNowDatetime):
+        out = metrics.calculate_trend_metrics(
+            year_data, recent_year_threshold=fixed_year - 5
+        )
+    assert out["total_usage"] == 10
+    assert isinstance(out["activity_score"], float)
+
+
+def test_calculate_trend_metrics_zero_denom_trend_skipped():
+    """Duplicate calendar years => x_values tied => linear regression denominator zero."""
+    fixed_now_year = 2026
+    _FixedNowDatetime.fixed_year = fixed_now_year
+    year_data = [
+        (2020, {"created_count": 3, "last_commit_count": 0}),
+        (2020, {"created_count": 2, "last_commit_count": 0}),
+    ]
+    with patch("boost_library_usage_dashboard.analyzer_metrics.datetime", _FixedNowDatetime):
+        out = metrics.calculate_trend_metrics(year_data, recent_year_threshold=2019)
+    assert out["total_usage"] == 5
+    assert isinstance(out["activity_score"], float)
+
+
+def test_calculate_trend_metrics_momentum_requires_two_points():
+    fixed_now_year = 2027
+    _FixedNowDatetime.fixed_year = fixed_now_year
+    with patch("boost_library_usage_dashboard.analyzer_metrics.datetime", _FixedNowDatetime):
+        single = metrics.calculate_trend_metrics(
+            [(2024, {"created_count": 10, "last_commit_count": 0})],
+            recent_year_threshold=2020,
+        )
+        multi = metrics.calculate_trend_metrics(
+            [
+                (2023, {"created_count": 2, "last_commit_count": 0}),
+                (2024, {"created_count": 8, "last_commit_count": 0}),
+            ],
+            recent_year_threshold=2020,
+        )
+    assert single["total_usage"] == 10
+    assert multi["total_usage"] == 10
+    assert isinstance(multi["activity_score"], float)
+
+
+@pytest.mark.django_db
+def test_calculate_library_metrics_by_repository_empty_db():
+    """No BoostUsage rows => empty metrics dict."""
+
+    class FakeAnalyzer:
+        stars_min_threshold = 10
+
+    assert metrics.calculate_library_metrics_by_repository(FakeAnalyzer()) == {}

--- a/boost_library_usage_dashboard/tests/test_analyzer_metrics_unit.py
+++ b/boost_library_usage_dashboard/tests/test_analyzer_metrics_unit.py
@@ -26,19 +26,25 @@ class _FixedNowDatetime:
 
 
 def test_float_from_env_empty_uses_default():
-    key = "BOOST_DASHBOARD_TEST_FLOAT_METRICS_" + str(id(test_float_from_env_empty_uses_default))
+    key = "BOOST_DASHBOARD_TEST_FLOAT_METRICS_" + str(
+        id(test_float_from_env_empty_uses_default)
+    )
     os.environ.pop(key, None)
     assert metrics._float_from_env(key, 0.42) == pytest.approx(0.42)
 
 
 def test_float_from_env_valid_number():
-    key = "BOOST_DASHBOARD_TEST_FLOAT_METRICS_" + str(id(test_float_from_env_valid_number))
+    key = "BOOST_DASHBOARD_TEST_FLOAT_METRICS_" + str(
+        id(test_float_from_env_valid_number)
+    )
     with patch.dict(os.environ, {key: " 2.5 "}):
         assert metrics._float_from_env(key, 1.0) == pytest.approx(2.5)
 
 
 def test_float_from_env_invalid_falls_back():
-    key = "BOOST_DASHBOARD_TEST_FLOAT_METRICS_" + str(id(test_float_from_env_invalid_falls_back))
+    key = "BOOST_DASHBOARD_TEST_FLOAT_METRICS_" + str(
+        id(test_float_from_env_invalid_falls_back)
+    )
     with patch.dict(os.environ, {key: "not-a-float"}):
         assert metrics._float_from_env(key, 0.25) == pytest.approx(0.25)
 
@@ -64,7 +70,9 @@ def test_calculate_trend_metrics_uses_fallback_when_only_current_year():
         (fixed_year, {"created_count": 5, "last_commit_count": 0}),
     ]
     _FixedNowDatetime.fixed_year = fixed_year
-    with patch("boost_library_usage_dashboard.analyzer_metrics.datetime", _FixedNowDatetime):
+    with patch(
+        "boost_library_usage_dashboard.analyzer_metrics.datetime", _FixedNowDatetime
+    ):
         out = metrics.calculate_trend_metrics(
             year_data, recent_year_threshold=fixed_year - 5
         )
@@ -80,7 +88,9 @@ def test_calculate_trend_metrics_zero_denom_trend_skipped():
         (2020, {"created_count": 3, "last_commit_count": 0}),
         (2020, {"created_count": 2, "last_commit_count": 0}),
     ]
-    with patch("boost_library_usage_dashboard.analyzer_metrics.datetime", _FixedNowDatetime):
+    with patch(
+        "boost_library_usage_dashboard.analyzer_metrics.datetime", _FixedNowDatetime
+    ):
         out = metrics.calculate_trend_metrics(year_data, recent_year_threshold=2019)
     assert out["total_usage"] == 5
     assert isinstance(out["activity_score"], float)
@@ -89,7 +99,9 @@ def test_calculate_trend_metrics_zero_denom_trend_skipped():
 def test_calculate_trend_metrics_momentum_requires_two_points():
     fixed_now_year = 2027
     _FixedNowDatetime.fixed_year = fixed_now_year
-    with patch("boost_library_usage_dashboard.analyzer_metrics.datetime", _FixedNowDatetime):
+    with patch(
+        "boost_library_usage_dashboard.analyzer_metrics.datetime", _FixedNowDatetime
+    ):
         single = metrics.calculate_trend_metrics(
             [(2024, {"created_count": 10, "last_commit_count": 0})],
             recent_year_threshold=2020,

--- a/boost_library_usage_dashboard/tests/test_collectors_direct.py
+++ b/boost_library_usage_dashboard/tests/test_collectors_direct.py
@@ -1,0 +1,50 @@
+"""Direct tests for BoostLibraryUsageDashboardCollector orchestration."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.conf import settings
+
+from boost_library_usage_dashboard.collectors import BoostLibraryUsageDashboardCollector
+
+
+@pytest.mark.django_db
+def test_collector_run_with_collect_and_render_skips_publish(tmp_path):
+    fake_analyzer = MagicMock()
+    fake_analyzer.run.return_value = {"total_repositories": 0}
+    fake_analyzer.report_file = tmp_path / "Boost_Usage_Report_total.md"
+    fake_analyzer.stars_min_threshold = 10
+
+    with patch(
+        "boost_library_usage_dashboard.collectors.get_workspace_path",
+        return_value=tmp_path,
+    ), patch(
+        "boost_library_usage_dashboard.collectors.BoostUsageDashboardAnalyzer",
+        return_value=fake_analyzer,
+    ) as analyzer_cls, patch(
+        "boost_library_usage_dashboard.collectors.write_summary_report"
+    ) as write_report, patch(
+        "boost_library_usage_dashboard.collectors.render_dashboard_html"
+    ) as render_html, patch(
+        "boost_library_usage_dashboard.collectors.publish_dashboard"
+    ) as publish_mock:
+        col = BoostLibraryUsageDashboardCollector(
+            skip_collect=False,
+            skip_render=False,
+            skip_publish=True,
+            owner="",
+            repo="",
+            branch="",
+        )
+        col.run()
+
+    analyzer_cls.assert_called_once()
+    fake_analyzer.run.assert_called_once()
+    write_report.assert_called_once()
+    expected = Path(str(tmp_path)).resolve()
+    render_html.assert_called_once_with(
+        base_dir=settings.BASE_DIR,
+        output_dir=expected,
+    )
+    publish_mock.assert_not_called()

--- a/boost_library_usage_dashboard/tests/test_dashboard_html_branches.py
+++ b/boost_library_usage_dashboard/tests/test_dashboard_html_branches.py
@@ -1,0 +1,99 @@
+"""Branch coverage for dashboard HTML builders beyond test_renderer happy path."""
+
+from __future__ import annotations
+
+import json
+
+from boost_library_usage_dashboard.dashboard_html import generate_dashboard_html
+
+def _base_payload():
+    return {
+        "repos_by_year": {"2023": 2},
+        "repos_by_version": [{"version": "1.83.0", "count": 7}],
+        "repos_by_year_boost_rate": [
+            {
+                "year": "2024",
+                "cpp_repo_count": 50,
+                "over_10": 10,
+                "boost_over_10": 3,
+                "boost_over_10_percentage": "not-a-number",
+            },
+        ],
+        "language_comparison_data": {
+            "C++": {"2023": {"all": 100, "stars_10_plus": 40}},
+            "Rust": {"2023": {"all": 200, "stars_10_plus": 80}},
+        },
+        "metrics_by_library": [
+            {
+                "name": "filesystem",
+                "repo_count": 1,
+                "total_usage": 1,
+                "activity_score": 0.0,
+            },
+        ],
+        "top_repositories": {
+            "top20_by_stars": [],
+            "top20_by_usage": [],
+            "top20_by_created": [],
+        },
+        "libraries_page_data": {
+            "filesystem": {
+                "over_view": {"used_headers": {}},
+                "external_consumers": {"table_data": [], "chart_data": {}},
+                "contribute_data": {"table_data": [], "chart_data": {}},
+                "internal_dependents_data": {
+                    "table_data": [],
+                    "chart_data": {
+                        "1.83.0": "not-a-dict",
+                        "1.84.0": {"first_level": 2, "all_deeper": 5},
+                    },
+                },
+            },
+            "emptylib": {},
+        },
+        "all_versions_for_chart": ["1.83.0"],
+    }
+
+
+def test_generate_dashboard_html_covers_index_and_library_branches(tmp_path):
+    data_file = tmp_path / "dashboard_data.json"
+    data_file.write_text(json.dumps(_base_payload()), encoding="utf-8")
+
+    lib_dir = tmp_path / "libraries"
+    generate_dashboard_html(
+        dashboard_data_file=data_file,
+        output_dir=tmp_path,
+        libraries_dir=lib_dir,
+    )
+
+    index_html = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert "Language Comparison by Year" in index_html
+    assert "C++" in index_html and "Rust" in index_html
+
+    fs_html = (lib_dir / "filesystem.html").read_text(encoding="utf-8")
+    assert "filesystem" in fs_html
+
+    assert not (lib_dir / "emptylib.html").exists()
+
+
+def test_build_library_page_ext_chart_int_year_keys(tmp_path):
+    """Exercise ext_chart.get(y) vs get(int(y)) branch."""
+    payload = _base_payload()
+    payload["libraries_page_data"] = {
+        "filesystem": {
+            "over_view": {"used_headers": {}},
+            "external_consumers": {
+                "table_data": [],
+                "chart_data": {
+                    2024: {"repos": 1, "by_created": 2, "by_last_commit": 3},
+                },
+            },
+            "contribute_data": {"table_data": [], "chart_data": []},
+            "internal_dependents_data": {"table_data": [], "chart_data": {}},
+        },
+    }
+    data_file = tmp_path / "dashboard_data.json"
+    data_file.write_text(json.dumps(payload), encoding="utf-8")
+    generate_dashboard_html(data_file, tmp_path, tmp_path / "libraries")
+    html = (tmp_path / "libraries" / "filesystem.html").read_text(encoding="utf-8")
+    assert "filesystem" in html

--- a/boost_library_usage_dashboard/tests/test_dashboard_html_branches.py
+++ b/boost_library_usage_dashboard/tests/test_dashboard_html_branches.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 from boost_library_usage_dashboard.dashboard_html import generate_dashboard_html
 
@@ -78,7 +79,12 @@ def test_generate_dashboard_html_covers_index_and_library_branches(tmp_path):
 
 
 def test_build_library_page_ext_chart_int_year_keys(tmp_path):
-    """Exercise ext_chart.get(y) vs get(int(y)) branch."""
+    """Integer keys in chart_data are lost through JSON; patch loads to preserve them.
+
+    ``build_library_page`` uses ``ext_chart.get(y, ext_chart.get(int(y), {}))`` where
+    ``y`` is the string year. Keys stored as int (e.g. 2024) miss ``.get(y)`` and hit
+    the ``int(y)`` fallback — only possible if data is not round-tripped through JSON.
+    """
     payload = _base_payload()
     payload["libraries_page_data"] = {
         "filesystem": {
@@ -89,12 +95,16 @@ def test_build_library_page_ext_chart_int_year_keys(tmp_path):
                     2024: {"repos": 1, "by_created": 2, "by_last_commit": 3},
                 },
             },
-            "contribute_data": {"table_data": [], "chart_data": []},
+            "contribute_data": {"table_data": [], "chart_data": {}},
             "internal_dependents_data": {"table_data": [], "chart_data": {}},
         },
     }
     data_file = tmp_path / "dashboard_data.json"
-    data_file.write_text(json.dumps(payload), encoding="utf-8")
-    generate_dashboard_html(data_file, tmp_path, tmp_path / "libraries")
+    data_file.write_text("{}", encoding="utf-8")
+    with patch(
+        "boost_library_usage_dashboard.dashboard_html.json.loads",
+        return_value=payload,
+    ):
+        generate_dashboard_html(data_file, tmp_path, tmp_path / "libraries")
     html = (tmp_path / "libraries" / "filesystem.html").read_text(encoding="utf-8")
     assert "filesystem" in html

--- a/boost_library_usage_dashboard/tests/test_dashboard_html_branches.py
+++ b/boost_library_usage_dashboard/tests/test_dashboard_html_branches.py
@@ -6,6 +6,7 @@ import json
 
 from boost_library_usage_dashboard.dashboard_html import generate_dashboard_html
 
+
 def _base_payload():
     return {
         "repos_by_year": {"2023": 2},

--- a/boost_library_usage_dashboard/tests/test_utils.py
+++ b/boost_library_usage_dashboard/tests/test_utils.py
@@ -22,3 +22,7 @@ def test_format_percent():
 
 def test_sanitize_library_name_replaces_irregular_chars():
     assert sanitize_library_name("asio/io") == "asio_io"
+
+
+def test_sanitize_library_name_empty_returns_unknown():
+    assert sanitize_library_name("") == "unknown"


### PR DESCRIPTION
## Summary
This change improves automated test coverage for the boost_library_usage_dashboard Django app and introduces shared coverage configuration plus a minimum coverage threshold in the GitHub Actions test job.


## What changed

### New tests
- test_analyzer_metrics_unit.py — _float_from_env, calculate_trend_metrics branches (including controlled “current year” / regression edge cases), empty DB path for calculate_library_metrics_by_repository.
- test_analyzer_libraries_pure.py — get_first_version_released_after, get_external_consumer_data, get_contribution_data, get_last_updated_version, build_library_overview_data, collect_libraries_page_data, and collect_commit_info_by_library with a mocked empty ORM iterator.
- test_dashboard_html_branches.py — index/library HTML paths beyond the existing renderer smoke test (language comparison, invalid boost rate percentage, non-dict dependent chart entries, empty library payload skipped, integer year keys in external consumer charts).
- test_analyzer_integration.py — end-to-end BoostUsageDashboardAnalyzer.run() with a minimal Boost version string (boost-*.*.0), library versions, starred external repo, and usage row; _load_repository_count_from_db with C++ CreatedReposByLanguage data and with LookupError when resolving the model.
- test_collectors_direct.py — BoostLibraryUsageDashboardCollector with collect+render enabled and publish skipped (asserts analyzer, report, and render hooks).

### Small extension to test_utils.py for sanitize_library_name("") → "unknown".
### .coveragerc — omit patterns for migrations, tests, conftest.py, and virtualenv paths; relative_files for portable reports.
### CI — pytest invocation updated to pass --cov-config=.coveragerc and --cov-fail-under=85.


## Testing
- pytest boost_library_usage_dashboard/tests --cov=boost_library_usage_dashboard --cov-config=.coveragerc
- Confirmed 71 dashboard tests passing; package line coverage ~92% in this environment (vs ~75% prior for the same scope).


## Related
- Closes #[issue-number] (replace after you open the issue)

## Notes for reviewers
- The 85% threshold applies to full-suite coverage as measured by CI (--cov), not only this app; it matches the conservative “round down” approach discussed for the repo-wide coverage gate.
- Remaining uncovered hotspots are mostly collect_commit_info_by_library real DB iteration and some publisher branches under non-mocked git operations; follow-up work can target those if we want to push past ~92% for this package.

close https://github.com/cppalliance/boost-data-collector/issues/165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded comprehensive test coverage for the Boost Library Usage Dashboard, including integration tests for the analyzer pipeline with database validation.
  * Added unit tests for metrics calculation, library data collection workflows, and HTML dashboard generation logic.
  * Enhanced validation for edge cases and error handling scenarios to ensure system reliability and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->