### PR TITLE
test(boost_mailing_list_tracker): broaden unit/integration coverage

### DIFF
--- a/boost_mailing_list_tracker/tests/test_commands.py
+++ b/boost_mailing_list_tracker/tests/test_commands.py
@@ -1,5 +1,9 @@
 """Tests for boost_mailing_list_tracker management commands."""
 
+import logging
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from boost_mailing_list_tracker.models import MailingListMessage, MailingListName
@@ -121,8 +125,6 @@ def test_persist_email_creates_profile_and_message():
 @pytest.mark.django_db
 def test_command_handle_dry_run_exits_cleanly(capsys):
     """Command with --dry-run runs without writing to DB and exits cleanly."""
-    from unittest.mock import patch
-
     from django.core.management import call_command
 
     with patch(
@@ -131,9 +133,367 @@ def test_command_handle_dry_run_exits_cleanly(capsys):
     ):
         call_command("run_boost_mailing_list_tracker", "--dry-run")
     out, _ = capsys.readouterr()
-    assert (
-        "dry" in out.lower()
-        or "fetch" in out.lower()
-        or "No emails" in out
-        or len(out) >= 0
+    assert "dry run" in out.lower()
+
+
+# --- _clean_text ---
+
+
+def test_clean_text_none_and_nul_bytes():
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _clean_text,
     )
+
+    assert _clean_text(None) == ""
+    assert _clean_text("ab\x00cd") == "abcd"
+
+
+# --- _persist_email branches ---
+
+
+@pytest.mark.django_db
+def test_persist_email_missing_sender_address_logs_incomplete(
+    caplog,
+):
+    """Missing sender_address still persists when list_name is valid; logs Incomplete email."""
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _persist_email,
+    )
+
+    caplog.set_level(logging.WARNING)
+    email_data = _valid_email_data(msg_id="<no-addr@example.com>")
+    email_data["sender_address"] = ""
+    was_created, skipped = _persist_email(email_data)
+    assert was_created is True
+    assert skipped is False
+    assert MailingListMessage.objects.filter(msg_id="<no-addr@example.com>").exists()
+    assert any("Incomplete email" in r.message for r in caplog.records)
+    assert any("missing sender_address" in r.message for r in caplog.records)
+
+
+@pytest.mark.django_db
+def test_persist_email_invalid_list_name_returns_skipped():
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _persist_email,
+    )
+
+    email_data = _valid_email_data(msg_id="<bad-list@example.com>")
+    email_data["list_name"] = ""
+    was_created, skipped = _persist_email(email_data)
+    assert was_created is False
+    assert skipped is True
+    assert not MailingListMessage.objects.filter(
+        msg_id="<bad-list@example.com>"
+    ).exists()
+
+
+# --- _process_existing_workspace_json ---
+
+
+@pytest.mark.django_db
+def test_process_existing_workspace_json_valid_unlinks_file(tmp_path):
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _process_existing_workspace_json,
+    )
+
+    list_name = MailingListName.BOOST_USERS.value
+    msg_path = (
+        tmp_path / "boost_mailing_list_tracker" / list_name / "messages" / "one.json"
+    )
+    msg_path.parent.mkdir(parents=True)
+    msg_path.write_text(
+        '[{"msg_id": "<ws-one@example.com>", "list_name": "'
+        + MailingListName.BOOST_USERS.value
+        + '", "sent_at": "2025-01-15T10:00:00Z", "sender_address": "p@w.com", '
+        '"sender_name": "P", "subject": "S", "content": "C"}]',
+        encoding="utf-8",
+    )
+    with patch(
+        "boost_mailing_list_tracker.workspace.get_workspace_path",
+        side_effect=lambda slug: tmp_path / slug,
+    ):
+        processed, skipped = _process_existing_workspace_json(list_name)
+    assert processed == 1
+    assert skipped == 0
+    assert not msg_path.exists()
+    assert MailingListMessage.objects.filter(msg_id="<ws-one@example.com>").exists()
+
+
+@pytest.mark.django_db
+def test_process_existing_workspace_json_malformed_leaves_file(tmp_path):
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _process_existing_workspace_json,
+    )
+
+    list_name = MailingListName.BOOST.value
+    msg_path = (
+        tmp_path / "boost_mailing_list_tracker" / list_name / "messages" / "bad.json"
+    )
+    msg_path.parent.mkdir(parents=True)
+    msg_path.write_text("{ not json", encoding="utf-8")
+    with patch(
+        "boost_mailing_list_tracker.workspace.get_workspace_path",
+        side_effect=lambda slug: tmp_path / slug,
+    ):
+        processed, _skipped = _process_existing_workspace_json(list_name)
+    assert processed == 0
+    assert msg_path.is_file()
+
+
+# --- _run_pinecone_sync ---
+
+
+def test_run_pinecone_sync_skips_empty_app_type(caplog):
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _run_pinecone_sync,
+    )
+
+    caplog.set_level(logging.WARNING)
+    _run_pinecone_sync(app_type="", namespace="ns")
+    assert "pinecone sync skipped" in caplog.text.lower()
+    assert "--pinecone-app-type" in caplog.text.lower()
+
+
+def test_run_pinecone_sync_skips_empty_namespace(caplog):
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _run_pinecone_sync,
+    )
+
+    caplog.set_level(logging.WARNING)
+    _run_pinecone_sync(app_type="t", namespace="")
+    assert "namespace" in caplog.text.lower()
+
+
+def test_run_pinecone_sync_calls_run_cppa_pinecone_sync():
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _run_pinecone_sync,
+    )
+
+    with patch(
+        "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker.call_command"
+    ) as cc:
+        _run_pinecone_sync(app_type="mailing", namespace="my-ns")
+    assert cc.call_args is not None
+    assert cc.call_args.args[0] == "run_cppa_pinecone_sync"
+
+
+def test_run_pinecone_sync_logs_warning_when_call_command_raises(caplog):
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _run_pinecone_sync,
+    )
+
+    caplog.set_level(logging.WARNING)
+    with patch(
+        "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker.call_command",
+        side_effect=RuntimeError("no sync"),
+    ):
+        _run_pinecone_sync(app_type="mailing", namespace="ns")
+    assert any("pinecone" in r.message.lower() for r in caplog.records)
+
+
+# --- BoostMailingListTrackerCollector.run ---
+
+
+@pytest.mark.django_db
+def test_collector_run_writes_raw_and_removes_message_json(tmp_path):
+    from django.core.management import call_command
+
+    email_row = {
+        "msg_id": "<collector-run@example.com>",
+        "sender_name": "User",
+        "sender_address": "user@example.com",
+        "sent_at": "2025-01-15T10:00:00Z",
+        "parent_id": "",
+        "thread_id": "",
+        "subject": "Sub",
+        "content": "Body",
+        "list_name": MailingListName.BOOST_USERS.value,
+    }
+    msg_json = tmp_path / "msg.json"
+    raw_json = tmp_path / "raw.json"
+
+    with patch(
+        "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker.fetch_all_emails",
+        return_value=[email_row],
+    ):
+        with patch(
+            "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker.get_message_json_path",
+            return_value=msg_json,
+        ):
+            with patch(
+                "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker.get_raw_json_path",
+                return_value=raw_json,
+            ):
+                with patch(
+                    "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker._run_pinecone_sync"
+                ):
+                    call_command("run_boost_mailing_list_tracker")
+
+    assert raw_json.is_file()
+    assert not msg_json.exists()
+    assert MailingListMessage.objects.filter(
+        msg_id="<collector-run@example.com>"
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_collector_run_skips_empty_msg_id_and_duplicate(tmp_path):
+    from django.core.management import call_command
+
+    existing = _valid_email_data(msg_id="<dup-collector@example.com>")
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _persist_email,
+    )
+
+    _persist_email(existing)
+
+    rows = [
+        {
+            "msg_id": "",
+            "list_name": MailingListName.BOOST.value,
+            "sender_address": "a@b.com",
+            "sender_name": "A",
+            "sent_at": "2025-01-15T10:00:00Z",
+            "subject": "",
+            "content": "",
+        },
+        _valid_email_data(msg_id="<dup-collector@example.com>"),
+    ]
+    msg_json = tmp_path / "m.json"
+    raw_json = tmp_path / "r.json"
+    with patch(
+        "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker.fetch_all_emails",
+        return_value=rows,
+    ):
+        with patch(
+            "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker.get_message_json_path",
+            return_value=msg_json,
+        ):
+            with patch(
+                "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker.get_raw_json_path",
+                return_value=raw_json,
+            ):
+                with patch(
+                    "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker._run_pinecone_sync"
+                ):
+                    call_command("run_boost_mailing_list_tracker")
+
+    assert (
+        MailingListMessage.objects.filter(msg_id="<dup-collector@example.com>").count()
+        == 1
+    )
+
+
+@pytest.mark.django_db
+def test_process_existing_workspace_json_keeps_file_when_persist_raises(tmp_path):
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _process_existing_workspace_json,
+    )
+
+    list_name = MailingListName.BOOST_USERS.value
+    msg_path = (
+        tmp_path / "boost_mailing_list_tracker" / list_name / "messages" / "raise.json"
+    )
+    msg_path.parent.mkdir(parents=True)
+    msg_path.write_text('[{"msg_id": "<x@y>"}]', encoding="utf-8")
+    with patch(
+        "boost_mailing_list_tracker.workspace.get_workspace_path",
+        side_effect=lambda slug: tmp_path / slug,
+    ):
+        with patch(
+            "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker._persist_email",
+            side_effect=RuntimeError("persist boom"),
+        ):
+            processed, skipped = _process_existing_workspace_json(list_name)
+    assert processed == 1
+    assert skipped == 1
+    assert msg_path.is_file()
+
+
+@pytest.mark.django_db
+def test_collector_run_skips_malformed_email_write():
+    from django.core.management import call_command
+
+    email_row = {
+        "msg_id": "<bad-write@example.com>",
+        "sender_name": "U",
+        "sender_address": "u@example.com",
+        "sent_at": "2025-01-15T10:00:00Z",
+        "parent_id": "",
+        "thread_id": "",
+        "subject": "S",
+        "content": "C",
+        "list_name": MailingListName.BOOST_USERS.value,
+    }
+    msg_json = MagicMock()
+    msg_json.parent.mkdir = MagicMock()
+    raw_json = MagicMock()
+    raw_json.parent.mkdir = MagicMock()
+
+    def _raise_bad_write(*a, **kw):
+        raise ValueError("cannot serialize")
+
+    msg_json.write_text.side_effect = _raise_bad_write
+
+    with patch(
+        "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker.fetch_all_emails",
+        return_value=[email_row],
+    ):
+        with patch(
+            "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker.get_message_json_path",
+            return_value=msg_json,
+        ):
+            with patch(
+                "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker.get_raw_json_path",
+                return_value=raw_json,
+            ):
+                with patch(
+                    "boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker._run_pinecone_sync"
+                ):
+                    call_command("run_boost_mailing_list_tracker")
+
+    assert not MailingListMessage.objects.filter(
+        msg_id="<bad-write@example.com>"
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_persist_email_unknown_sender_display_from_email_local_part():
+    """Unknown Sender + valid address uses local-part as display when creating profile."""
+    from cppa_user_tracker.models import MailingListProfile
+
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        _persist_email,
+    )
+
+    email_data = _valid_email_data(msg_id="<localpart@example.com>")
+    email_data["sender_name"] = ""
+    email_data["sender_address"] = "someone@example.org"
+    was_created, skipped = _persist_email(email_data)
+    assert was_created is True
+    assert skipped is False
+    profile = MailingListProfile.objects.filter(
+        emails__email="someone@example.org",
+        display_name="someone",
+    ).first()
+    assert profile is not None
+
+
+@pytest.mark.django_db
+def test_get_collector_uses_settings_for_empty_pinecone_args(settings):
+    from boost_mailing_list_tracker.management.commands.run_boost_mailing_list_tracker import (
+        Command,
+    )
+
+    settings.BOOST_MAILING_LIST_PINECONE_APP_TYPE = "from-settings-type"
+    settings.BOOST_MAILING_LIST_PINECONE_NAMESPACE = "from-settings-ns"
+    cmd = Command(stdout=StringIO(), stderr=StringIO())
+    collector = cmd.get_collector(
+        start_date="",
+        end_date="",
+        dry_run=True,
+        pinecone_app_type="",
+        pinecone_namespace="",
+    )
+    assert collector.pinecone_app_type == "from-settings-type"
+    assert collector.pinecone_namespace == "from-settings-ns"

--- a/boost_mailing_list_tracker/tests/test_email_formatter_unit.py
+++ b/boost_mailing_list_tracker/tests/test_email_formatter_unit.py
@@ -7,6 +7,8 @@ from boost_mailing_list_tracker.email_formatter import (
     _extract_sender,
     _extract_url_tail_id,
     _normalize_sent_at,
+    _normalize_one,
+    _to_text,
 )
 
 
@@ -57,3 +59,89 @@ def test_format_email_shapes():
         }
     )
     assert threaded[0]["thread_id"] == "tid"
+
+
+def test_to_text_non_string_and_none():
+    assert _to_text(None) == ""
+    assert _to_text(42) == "42"
+
+
+def test_extract_list_name_from_to_header():
+    assert (
+        _extract_list_name("Discussion <boost-users@lists.boost.org>")
+        == "boost-users@lists.boost.org"
+    )
+
+
+def test_deobfuscate_address_patterns():
+    assert _deobfuscate_address("user [at] lists.boost.org") == "user@lists.boost.org"
+    assert _deobfuscate_address("person AT example.com") == "person@example.com"
+    assert (
+        _deobfuscate_address("somebody at lists.boost.org")
+        == "somebody@lists.boost.org"
+    )
+    assert _deobfuscate_address("u(at)v.org") == "u@v.org"
+
+
+def test_extract_sender_nested_dict_email_and_display_name():
+    addr, name = _extract_sender(
+        {
+            "sender": {"email": "nested@example.com", "display_name": "Nested"},
+            "sender_address": "",
+            "sender_name": "",
+        }
+    )
+    assert addr == "nested@example.com"
+    assert name == "Nested"
+
+
+def test_extract_sender_early_return_when_address_and_name_present():
+    addr, name = _extract_sender(
+        {"sender": {"address": "a@b.com", "name": "Quick"}, "from": "ignored <z@z.com>"}
+    )
+    assert addr == "a@b.com"
+    assert name == "Quick"
+
+
+def test_normalize_sent_at_prefers_sent_at_over_date():
+    out = _normalize_sent_at(
+        {"sent_at": "iso-only", "date": "Sat, 03 Apr 2010 18:32:00 +0200"}
+    )
+    assert out == "iso-only"
+
+
+def test_normalize_sent_at_invalid_rfc2822_returns_raw():
+    out = _normalize_sent_at({"date": "not-valid-for-parse"})
+    assert out == "not-valid-for-parse"
+
+
+def test_normalize_sent_at_naive_rfc2822_returns_isoformat():
+    raw = {"date": "Sat, 03 Apr 2010 18:32:00"}
+    out = _normalize_sent_at(raw)
+    assert out is not None
+    assert "2010-04-03" in out
+
+
+def test_format_email_single_message_dict_fallback():
+    out = format_email({"msg_id": "<single@example.com>", "subject": "S"})
+    assert len(out) == 1
+    assert out[0]["msg_id"] == "<single@example.com>"
+
+
+def test_format_email_non_dict_thread_info_coerced_to_empty():
+    out = format_email(
+        {
+            "thread_info": "not-a-dict",
+            "messages": [{"message_id": "mid", "subject": "Hi"}],
+        }
+    )
+    assert len(out) == 1
+
+
+def test_normalize_one_accepts_thread_info_url_for_list():
+    thread = {
+        "url": "https://lists.boost.org/archives/api/list/boost@lists.boost.org/thread/x/"
+    }
+    row = {"message_id": "m1", "subject": "S"}
+    normalized = _normalize_one(row, thread_info=thread)
+    assert normalized["list_name"] == "boost@lists.boost.org"

--- a/boost_mailing_list_tracker/tests/test_email_formatter_unit.py
+++ b/boost_mailing_list_tracker/tests/test_email_formatter_unit.py
@@ -68,7 +68,7 @@ def test_to_text_non_string_and_none():
 
 def test_extract_list_name_from_to_header():
     assert (
-        _extract_list_name("Discussion <boost-users@lists.boost.org>")
+        _extract_list_name("", "Discussion <boost-users@lists.boost.org>")
         == "boost-users@lists.boost.org"
     )
 

--- a/boost_mailing_list_tracker/tests/test_fetcher.py
+++ b/boost_mailing_list_tracker/tests/test_fetcher.py
@@ -4,10 +4,14 @@ Covers edge cases and boundaries: empty inputs, date filtering,
 format_email with missing/None/invalid data, _get_start_date_from_db format.
 """
 
+import json
+import logging
 from datetime import datetime, timezone
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
+from requests.exceptions import HTTPError
 
 from boost_mailing_list_tracker import fetcher
 
@@ -341,3 +345,335 @@ def test_fetch_email_list_returns_filtered_results():
     assert result is not None
     assert len(result) == 1
     assert result[0]["date"] == "2024-06-15T12:00:00Z"
+
+
+# --- _parse_datetime / _parse_end_bound ---
+
+
+def test_parse_datetime_empty_and_invalid():
+    assert fetcher._parse_datetime("") is None
+    assert fetcher._parse_datetime("   ") is None
+    assert fetcher._parse_datetime("not-a-date") is None
+
+
+def test_parse_datetime_z_suffix_and_naive_gets_utc():
+    dt = fetcher._parse_datetime("2024-06-15T12:00:00Z")
+    assert dt is not None
+    assert dt.tzinfo == timezone.utc
+    naive = fetcher._parse_datetime("2024-06-15T12:00:00")
+    assert naive is not None
+    assert naive.tzinfo == timezone.utc
+
+
+def test_parse_end_bound_date_only_extends_to_end_of_day():
+    end_dt = fetcher._parse_end_bound("2024-06-15")
+    assert end_dt is not None
+    assert end_dt.hour == 23 and end_dt.minute == 59 and end_dt.second == 59
+
+
+def test_parse_end_bound_datetime_unchanged():
+    end_dt = fetcher._parse_end_bound("2024-06-15T12:00:00Z")
+    assert end_dt is not None
+    assert end_dt.hour == 12
+
+
+# --- _filter_by_date invalid date ---
+
+
+def test_filter_by_date_skips_invalid_date_string():
+    results = [
+        {"date": "not-parseable", "message_id_hash": "x"},
+        {"date": "2024-06-15T12:00:00Z"},
+    ]
+    filtered, stop = fetcher._filter_by_date(results, "", "")
+    assert len(filtered) == 1
+    assert filtered[0]["date"] == "2024-06-15T12:00:00Z"
+    assert stop is False
+
+
+# --- _path_tail ---
+
+
+def test_path_tail_empty_and_url():
+    assert fetcher._path_tail("") == ""
+    assert fetcher._path_tail(None) == ""
+    assert fetcher._path_tail("https://ex/a/b/") == "b"
+    assert fetcher._path_tail("plain-id") == "plain-id"
+
+
+# --- _fetch_page ---
+
+
+def test_fetch_page_appends_limit_offset_when_no_query():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"results": []}
+    mock_resp.raise_for_status = MagicMock()
+    with patch.object(fetcher.requests, "get", return_value=mock_resp) as get:
+        fetcher._fetch_page("https://lists.boost.org/api/list/x/emails/", page=2)
+    url = get.call_args[0][0]
+    assert "limit=" in url and "offset=100" in url
+
+
+def test_fetch_page_preserves_url_when_query_present():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {}
+    mock_resp.raise_for_status = MagicMock()
+    with patch.object(fetcher.requests, "get", return_value=mock_resp) as get:
+        fetcher._fetch_page("https://next?page=cursor", page=3)
+    get.assert_called_once_with(
+        "https://next?page=cursor", timeout=fetcher.REQUEST_TIMEOUT
+    )
+
+
+def test_fetch_page_429_retry_after_header_then_success():
+    rate_limited = MagicMock(status_code=429)
+    rate_limited.headers = {"Retry-After": "0"}
+    ok = MagicMock(status_code=200)
+    ok.json.return_value = {"ok": True}
+    ok.raise_for_status = MagicMock()
+    with patch.object(fetcher.requests, "get", side_effect=[rate_limited, ok]):
+        with patch.object(fetcher.time, "sleep"):
+            out = fetcher._fetch_page("https://example.com/a/", page=1)
+    assert out == {"ok": True}
+
+
+def test_fetch_page_429_retry_after_json_body():
+    rate_limited = MagicMock(status_code=429)
+    rate_limited.headers = {}
+    rate_limited.json.return_value = {"retry_after": 0}
+    ok = MagicMock(status_code=200)
+    ok.json.return_value = {"x": 1}
+    ok.raise_for_status = MagicMock()
+    with patch.object(fetcher.requests, "get", side_effect=[rate_limited, ok]):
+        with patch.object(fetcher.time, "sleep"):
+            out = fetcher._fetch_page("https://example.com/a/", page=1)
+    assert out == {"x": 1}
+
+
+def test_fetch_page_429_exhausted_returns_none():
+    rate_limited = MagicMock(status_code=429)
+    rate_limited.headers = {}
+    rate_limited.json.return_value = {}
+    with patch.object(fetcher.requests, "get", return_value=rate_limited):
+        with patch.object(fetcher.time, "sleep"):
+            out = fetcher._fetch_page("https://example.com/a/", page=1)
+    assert out is None
+
+
+def test_fetch_page_http_error_non_429_returns_none():
+    resp404 = MagicMock()
+    resp404.status_code = 404
+    err = HTTPError(response=resp404)
+    resp404.raise_for_status.side_effect = err
+    with patch.object(fetcher.requests, "get", return_value=resp404):
+        assert fetcher._fetch_page("https://example.com/", page=1) is None
+
+
+def test_fetch_page_request_exception_returns_none():
+    with patch.object(
+        fetcher.requests,
+        "get",
+        side_effect=requests.exceptions.ConnectionError("refused"),
+    ):
+        assert fetcher._fetch_page("https://example.com/", page=1) is None
+
+
+def test_fetch_page_json_decode_error_returns_none():
+    mock_resp = MagicMock(status_code=200)
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.side_effect = json.JSONDecodeError("msg", "doc", 0)
+    with patch.object(fetcher.requests, "get", return_value=mock_resp):
+        assert fetcher._fetch_page("https://example.com/", page=1) is None
+
+
+# --- fetch_email_list pagination / empty ---
+
+
+def test_fetch_email_list_two_pages_merges_results():
+    page1 = {
+        "results": [{"date": "2024-06-15T12:00:00Z", "id": 1}],
+        "next": "https://api/next?cursor=2",
+    }
+    page2 = {
+        "results": [{"date": "2024-06-14T12:00:00Z", "id": 2}],
+        "next": None,
+    }
+    with patch.object(fetcher, "_fetch_page", side_effect=[page1, page2]):
+        result = fetcher.fetch_email_list(
+            "https://lists.boost.org/archives/api/list/boost@lists.boost.org/emails/",
+            "",
+            "",
+        )
+    assert result is not None
+    assert len(result) == 2
+
+
+def test_fetch_email_list_returns_none_when_all_filtered_out():
+    """Empty aggregate list yields None (not only when _fetch_page fails)."""
+    with patch.object(
+        fetcher,
+        "_fetch_page",
+        return_value={
+            "results": [{"date": "2020-01-01T00:00:00Z"}],
+            "next": None,
+        },
+    ):
+        result = fetcher.fetch_email_list(
+            "https://lists.boost.org/archives/api/list/boost@lists.boost.org/emails/",
+            start_date="2024-01-01T00:00:00Z",
+            end_date="",
+        )
+    assert result is None
+
+
+def test_fetch_email_list_page_increment_on_next():
+    with patch.object(fetcher, "_fetch_page") as fp:
+        fp.side_effect = [
+            {"results": [], "next": "http://x?y=1"},
+            {"results": [{"date": "2024-06-01T00:00:00Z"}], "next": None},
+        ]
+        fetcher.fetch_email_list(
+            "https://lists.boost.org/archives/api/list/boost@lists.boost.org/emails/",
+            "",
+            "",
+        )
+    assert fp.call_args_list[1][0][1] == 2
+
+
+# --- fetch_all_emails ---
+
+
+def test_fetch_all_emails_formats_and_saves_raw(tmp_path):
+    api_url = "https://lists.boost.org/archives/api/list/boost@lists.boost.org/emails/"
+    content = {
+        "message_id_hash": "<raw-test@lists.boost.org>",
+        "subject": "Subj",
+        "content": "Body",
+        "date": "2024-06-01T00:00:00Z",
+        "sender": {"address": "u (a) example.com"},
+    }
+
+    with patch(
+        "boost_mailing_list_tracker.workspace.get_workspace_path",
+        side_effect=lambda slug: tmp_path / slug,
+    ):
+        with patch.object(
+            fetcher,
+            "fetch_email_list",
+            return_value=[
+                {
+                    "url": "https://lists.boost.org/archives/api/email/foo/",
+                    "date": "2024-06-01T00:00:00Z",
+                }
+            ],
+        ):
+            with patch.object(fetcher, "_fetch_page", return_value=content):
+                out = fetcher.fetch_all_emails(
+                    start_date="2024-01-01",
+                    end_date="",
+                    list_urls=[api_url],
+                )
+    assert len(out) == 1
+    assert out[0]["msg_id"] == "<raw-test@lists.boost.org>"
+    raw_dir = tmp_path / "raw" / "boost_mailing_list_tracker" / "boost@lists.boost.org"
+    assert raw_dir.is_dir()
+    json_files = list(raw_dir.glob("*.json"))
+    assert len(json_files) == 1
+
+
+def test_fetch_all_emails_skips_row_without_url():
+    api_url = "https://lists.boost.org/archives/api/list/boost@lists.boost.org/emails/"
+    with patch.object(
+        fetcher,
+        "fetch_email_list",
+        return_value=[{"date": "2024-06-01T00:00:00Z"}],
+    ):
+        out = fetcher.fetch_all_emails(
+            start_date="2024-01-01",
+            list_urls=[api_url],
+        )
+    assert out == []
+
+
+def test_fetch_all_emails_skips_when_content_fetch_returns_none():
+    api_url = "https://lists.boost.org/archives/api/list/boost@lists.boost.org/emails/"
+    with patch.object(
+        fetcher,
+        "fetch_email_list",
+        return_value=[
+            {
+                "url": "https://lists.boost.org/archives/api/email/x/",
+                "date": "2024-06-01",
+            }
+        ],
+    ):
+        with patch.object(fetcher, "_fetch_page", return_value=None):
+            out = fetcher.fetch_all_emails(
+                start_date="2024-01-01",
+                list_urls=[api_url],
+            )
+    assert out == []
+
+
+def test_fetch_all_emails_skips_when_msg_id_empty_after_format():
+    api_url = "https://lists.boost.org/archives/api/list/boost@lists.boost.org/emails/"
+    with patch.object(
+        fetcher,
+        "fetch_email_list",
+        return_value=[
+            {
+                "url": "https://lists.boost.org/archives/api/email/x/",
+                "date": "2024-06-01",
+            }
+        ],
+    ):
+        with patch.object(
+            fetcher,
+            "_fetch_page",
+            return_value={
+                "message_id_hash": "",
+                "subject": "",
+                "content": "",
+                "date": None,
+            },
+        ):
+            out = fetcher.fetch_all_emails(
+                start_date="2024-01-01",
+                list_urls=[api_url],
+            )
+    assert out == []
+
+
+@pytest.mark.django_db
+def test_fetch_all_emails_inserts_start_date_from_database_when_blank(
+    mailing_list_profile,
+    default_list_name,
+    caplog,
+):
+    """When start_date is omitted, fetch_email_list receives latest sent_at from DB."""
+    from boost_mailing_list_tracker import services
+
+    dt = datetime(2024, 3, 1, 12, 0, 0, tzinfo=timezone.utc)
+    services.get_or_create_mailing_list_message(
+        mailing_list_profile,
+        msg_id="<db-start@example.com>",
+        sent_at=dt,
+        list_name=default_list_name,
+    )
+    api_url = "https://lists.boost.org/archives/api/list/boost@lists.boost.org/emails/"
+    with patch.object(fetcher, "fetch_email_list", return_value=[]) as fel:
+        with caplog.at_level(logging.INFO):
+            fetcher.fetch_all_emails(start_date="", end_date="", list_urls=[api_url])
+    fel.assert_called_once()
+    assert fel.call_args[0][1] == "2024-03-01T12:00:00Z"
+    assert "Using start_date from DB" in caplog.text
+
+
+def test_fetch_all_emails_logs_warning_when_no_index_rows(caplog):
+    api_url = "https://lists.boost.org/archives/api/list/boost@lists.boost.org/emails/"
+    with patch.object(fetcher, "fetch_email_list", return_value=[]):
+        with caplog.at_level(logging.WARNING):
+            fetcher.fetch_all_emails(start_date="2024-01-01", list_urls=[api_url])
+    assert "No email index data" in caplog.text

--- a/boost_mailing_list_tracker/tests/test_preprocessor.py
+++ b/boost_mailing_list_tracker/tests/test_preprocessor.py
@@ -221,3 +221,65 @@ def test_preprocessor_handles_empty_body_with_metadata_fallback_content(
     )
     assert "List: " in target["content"]
     assert "Sent At: " in target["content"]
+
+
+@pytest.mark.django_db
+def test_preprocessor_author_falls_back_to_identity_display_name(
+    mailing_list_profile,
+    default_list_name,
+    sample_sent_at,
+):
+    """When MailingListProfile.display_name is blank, use Identity.display_name."""
+    from boost_mailing_list_tracker import services
+
+    identity = mailing_list_profile.identity
+    identity.display_name = "Identity Display"
+    identity.save()
+    mailing_list_profile.display_name = ""
+    mailing_list_profile.save()
+
+    services.get_or_create_mailing_list_message(
+        mailing_list_profile,
+        msg_id="<identity-author@example.com>",
+        sent_at=sample_sent_at,
+        subject="Sub",
+        content="Body",
+        list_name=default_list_name,
+    )
+
+    docs, _ = preprocess_mailing_list_for_pinecone([], None)
+    target = next(
+        d for d in docs if d["metadata"]["doc_id"] == "<identity-author@example.com>"
+    )
+    assert target["metadata"]["author"] == "Identity Display"
+
+
+@pytest.mark.django_db
+def test_preprocess_failed_ids_normalizes_whitespace_and_duplicates(
+    mailing_list_profile,
+    default_list_name,
+    sample_sent_at,
+):
+    """failed_ids strips blanks, de-duplicates; same doc appears once."""
+    from boost_mailing_list_tracker import services
+    from boost_mailing_list_tracker.models import MailingListMessage
+
+    msg, _ = services.get_or_create_mailing_list_message(
+        mailing_list_profile,
+        msg_id="<norm-fail@example.com>",
+        sent_at=sample_sent_at,
+        subject="S",
+        content="C",
+        list_name=default_list_name,
+    )
+    now = timezone.now()
+    MailingListMessage.objects.filter(pk=msg.pk).update(
+        created_at=now - timedelta(days=30)
+    )
+
+    docs, _ = preprocess_mailing_list_for_pinecone(
+        ["", "  ", "<norm-fail@example.com>", " <norm-fail@example.com> "],
+        final_sync_at=now - timedelta(days=1),
+    )
+    matching = [d for d in docs if d["metadata"]["doc_id"] == "<norm-fail@example.com>"]
+    assert len(matching) == 1

--- a/boost_mailing_list_tracker/tests/test_workspace.py
+++ b/boost_mailing_list_tracker/tests/test_workspace.py
@@ -240,6 +240,19 @@ def test_iter_existing_message_jsons_ignores_non_json(mock_workspace_path):
     assert paths[0].name == "x.json"
 
 
+def test_iter_existing_message_jsons_skips_dot_prefixed_files(mock_workspace_path):
+    """Hidden-style JSON names starting with '.' are skipped."""
+    messages_dir = (
+        mock_workspace_path / "boost_mailing_list_tracker" / "dotlist" / "messages"
+    )
+    messages_dir.mkdir(parents=True)
+    (messages_dir / ".hidden.json").write_text("{}")
+    (messages_dir / "visible.json").write_text("{}")
+    paths = list(iter_existing_message_jsons("dotlist"))
+    assert len(paths) == 1
+    assert paths[0].name == "visible.json"
+
+
 # --- iter_all_list_dirs ---
 
 
@@ -248,6 +261,16 @@ def test_iter_all_list_dirs_empty_when_no_root(mock_workspace_path):
     # Root exists but no list_name/messages/
     listed = list(iter_all_list_dirs())
     assert listed == []
+
+
+def test_iter_all_list_dirs_when_workspace_root_missing(tmp_path):
+    """If workspace root path does not exist, yield nothing."""
+    missing = tmp_path / "nonexistent_boost_ml_workspace"
+    with patch(
+        "boost_mailing_list_tracker.workspace.get_workspace_root",
+        return_value=missing,
+    ):
+        assert list(iter_all_list_dirs()) == []
 
 
 def test_iter_all_list_dirs_yields_lists_with_messages(mock_workspace_path):


### PR DESCRIPTION
Expands tests for the Boost mailing list tracker: fetcher (parsing, _fetch_page, fetch_email_list, fetch_all_emails + raw JSON), run_boost_mailing_list_tracker (persist paths, workspace JSON, Pinecone sync, non–dry-run collector), email_formatter, preprocessor, and workspace helpers. Mocks requests and workspace paths to keep tests deterministic. No production behavior changes.

How to verify: pytest boost_mailing_list_tracker/tests --cov=boost_mailing_list_tracker --cov-report=term-missing (use project venv / config.test_settings).

close https://github.com/cppalliance/boost-data-collector/issues/168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Significantly expanded test coverage across email formatting, message persistence, data fetching, and workspace management. Added validation for edge cases and error scenarios to improve overall system reliability and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->