### PR TITLE
test(boost_usage_tracker): raise coverage with integration and edge-case tests

### DIFF
--- a/boost_usage_tracker/tests/test_boost_searcher_more.py
+++ b/boost_usage_tracker/tests/test_boost_searcher_more.py
@@ -188,7 +188,7 @@ def test_search_boost_include_files_batch_splits_on_large_total(mock_search, _sl
     mock_search.return_value = []
     state = {"probe_calls": 0}
 
-    def rest_side_effect(path, params=None):
+    def rest_side_effect(_path, params=None):
         if params and params.get("per_page") == 1:
             state["probe_calls"] += 1
             # Parent probe: huge → split; child probes: small → single query path
@@ -247,3 +247,155 @@ def test_extract_boost_version_more_patterns():
         'GIT_TAG "boost-1.70.0"', "CMakeLists.txt"
     )
     assert extract_boost_version_from_content("boost/1.2.3", "conanfile.txt")
+
+
+def test_extract_boost_version_from_empty_content():
+    assert extract_boost_version_from_content("", "boost/version.hpp") is None
+
+
+def test_graphql_file_info_missing_repository():
+    client = MagicMock()
+    client.graphql_request.return_value = {"data": {"repository": None}}
+    assert _get_file_info_graphql(client, "o", "r", "p.txt") is None
+
+
+def test_graphql_file_info_blob_without_text():
+    client = MagicMock()
+    client.graphql_request.return_value = {
+        "data": {
+            "repository": {
+                "object": {"oid": "x"},
+                "defaultBranchRef": {"target": {"history": {"edges": []}}},
+            }
+        }
+    }
+    assert _get_file_info_graphql(client, "o", "r", "p.txt") is None
+
+
+def test_batch_graphql_missing_repository():
+    client = MagicMock()
+    client.graphql_request.return_value = {"data": {"repository": None}}
+    assert _get_files_info_graphql_batch(client, "o", "r", ["a.cpp"]) == {}
+
+
+def test_batch_graphql_request_failure_returns_empty():
+    client = MagicMock()
+    client.graphql_request.side_effect = RuntimeError("gql")
+    assert _get_files_info_graphql_batch(client, "o", "r", ["a.cpp"]) == {}
+
+
+def test_batch_graphql_skips_blob_without_text():
+    client = MagicMock()
+    client.graphql_request.return_value = {
+        "data": {
+            "repository": {
+                "f0": {"oid": "only"},
+                "h0": {"target": {"history": {"edges": []}}},
+            }
+        }
+    }
+    assert _get_files_info_graphql_batch(client, "o", "r", ["z.hpp"]) == {}
+
+
+@patch("boost_usage_tracker.boost_searcher.time.sleep", return_value=None)
+def test_search_boost_include_files_batch_empty(_sleep):
+    client = MagicMock()
+    assert search_boost_include_files_batch(client, []) == []
+
+
+@patch("boost_usage_tracker.boost_searcher.time.sleep", return_value=None)
+@patch("boost_usage_tracker.boost_searcher.search_boost_include_files")
+def test_search_boost_include_files_batch_single_repo(mock_single, _sleep):
+    client = MagicMock()
+    mock_single.return_value = ["x"]
+    assert search_boost_include_files_batch(client, ["only/repo"]) == ["x"]
+    mock_single.assert_called_once_with(client, "only/repo")
+
+
+@patch("boost_usage_tracker.boost_searcher.time.sleep", return_value=None)
+def test_search_boost_include_files_batch_probe_failure_returns_empty(_sleep):
+    client = MagicMock()
+    client.rest_request.side_effect = RuntimeError("probe failed")
+    assert search_boost_include_files_batch(client, ["a/z", "b/y"]) == []
+
+
+@patch("boost_usage_tracker.boost_searcher.time.sleep", return_value=None)
+def test_search_boost_include_files_batch_zero_total(_sleep):
+    client = MagicMock()
+    client.rest_request.return_value = {"total_count": 0}
+    assert search_boost_include_files_batch(client, ["a/z", "b/y"]) == []
+
+
+@patch("boost_usage_tracker.boost_searcher.time.sleep", return_value=None)
+@patch("boost_usage_tracker.boost_searcher.ThreadPoolExecutor")
+def test_search_boost_include_by_query_code_search_error(mock_exec, _sleep):
+    mock_exec.return_value.__enter__.return_value.submit.side_effect = RuntimeError(
+        "no worker"
+    )
+    client = MagicMock()
+    client.rest_request.side_effect = RuntimeError("search down")
+    assert _search_boost_include_by_query(client, "q") == []
+
+
+@patch("boost_usage_tracker.boost_searcher.time.sleep", return_value=None)
+@patch(
+    "boost_usage_tracker.boost_searcher.as_completed",
+    lambda futures: iter(futures),
+)
+@patch("boost_usage_tracker.boost_searcher.wait", return_value=(set(), set()))
+@patch("boost_usage_tracker.boost_searcher.ThreadPoolExecutor")
+def test_search_boost_include_by_query_skips_boost_paths_and_boostorg(
+    mock_exec, _mock_wait, _sleep
+):
+    bad_fut = MagicMock()
+    bad_fut.result.side_effect = RuntimeError("task")
+    good_fut = MagicMock()
+    good_fut.result.return_value = []
+    mock_exec.return_value.__enter__.return_value.submit.side_effect = [
+        good_fut,
+        bad_fut,
+    ]
+    client = MagicMock()
+    client.rest_request.return_value = {
+        "items": [
+            {"path": "third_party/boost/foo.hpp", "repository": {"full_name": "u/r"}},
+            {"path": "src/x.cpp", "repository": {"full_name": "boostorg/boost"}},
+            {
+                "path": "app.cpp",
+                "repository": {"full_name": "me/proj"},
+            },
+        ]
+    }
+    _search_boost_include_by_query(client, "q")
+    assert mock_exec.return_value.__enter__.return_value.submit.call_count == 1
+
+
+@patch("boost_usage_tracker.boost_searcher.time.sleep", return_value=None)
+@patch("boost_usage_tracker.boost_searcher.get_file_content_with_commit_date")
+def test_check_repo_has_vendored_boost_search_fails(mock_gfc, _sleep):
+    client = MagicMock()
+    client.rest_request.side_effect = RuntimeError("code search")
+    assert check_repo_has_vendored_boost(client, "u/r") == (False, None)
+
+
+@patch("boost_usage_tracker.boost_searcher.time.sleep", return_value=None)
+@patch("boost_usage_tracker.boost_searcher.get_file_content_with_commit_date")
+def test_check_repo_has_vendored_boost_zero_hits(_mock_gfc, _sleep):
+    client = MagicMock()
+    client.rest_request.return_value = {"total_count": 0, "items": []}
+    assert check_repo_has_vendored_boost(client, "u/r") == (False, None)
+    _mock_gfc.assert_not_called()
+
+
+@patch("boost_usage_tracker.boost_searcher.time.sleep", return_value=None)
+@patch("boost_usage_tracker.boost_searcher.get_file_content_with_commit_date")
+def test_detect_boost_version_no_build_file_version(mock_gfc, _sleep):
+    mock_gfc.return_value = None
+    client = MagicMock()
+    with patch(
+        "boost_usage_tracker.boost_searcher.check_repo_has_vendored_boost",
+        return_value=(False, None),
+    ):
+        embed, ver = detect_boost_version_in_repo(client, "u/r")
+    assert embed is False
+    assert ver is None

--- a/boost_usage_tracker/tests/test_db_from_file.py
+++ b/boost_usage_tracker/tests/test_db_from_file.py
@@ -198,3 +198,36 @@ def test_update_db_from_file_recursive_subdir(tmp_path):
     result = update_db_from_file(source=tmp_path, table="github_account")
     assert result["created"] == 1
     assert GitHubAccount.objects.filter(github_account_id=6001).exists()
+
+
+@pytest.mark.django_db
+def test_update_db_from_file_defaults_to_github_account_dir(tmp_path):
+    (tmp_path / "acc.json").write_text(
+        json.dumps({"github_account_id": 92009999, "username": "from-default-dir"}),
+        encoding="utf-8",
+    )
+    with patch(
+        "boost_usage_tracker.db_from_file.get_github_account_dir", return_value=tmp_path
+    ):
+        result = update_db_from_file(source=None, table="github_account")
+    assert result["created"] == 1
+    assert GitHubAccount.objects.filter(github_account_id=92009999).exists()
+
+
+def test_load_all_json_records_skips_rglob_entry_that_is_not_file(tmp_path):
+    """Coverage for ``if not path.is_file(): continue`` in _load_all_json_records."""
+    good = tmp_path / "keep.json"
+    good.write_text(json.dumps({"github_account_id": 7001}), encoding="utf-8")
+    ghost = tmp_path / "ghost.json"
+    ghost.write_text("{}", encoding="utf-8")
+    orig_is_file = Path.is_file
+
+    def selective_is_file(self):
+        if self.resolve() == ghost.resolve():
+            return False
+        return orig_is_file(self)
+
+    with patch.object(Path, "is_file", selective_is_file):
+        recs = _load_all_json_records(tmp_path)
+    assert len(recs) == 1
+    assert recs[0]["github_account_id"] == 7001

--- a/boost_usage_tracker/tests/test_post_process.py
+++ b/boost_usage_tracker/tests/test_post_process.py
@@ -1,12 +1,18 @@
 """Tests for boost_usage_tracker.post_process header resolution."""
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+from model_bakery import baker
 
-from core.operations.github_ops.client import ConnectionException
+from core.operations.github_ops.client import (
+    ConnectionException,
+    RateLimitException,
+)
 from boost_library_tracker import services as boost_library_services
+from boost_usage_tracker.boost_searcher import FileSearchResult
+from boost_usage_tracker.models import BoostUsage
 from boost_usage_tracker.post_process import (
     _resolve_boost_header,
     _resolve_boost_headers_bulk,
@@ -77,3 +83,248 @@ def test_process_single_repo_logs_generic_errors(caplog):
     )
     assert stats["usages_created"] == 0
     assert any("Failed post-processing" in r.message for r in caplog.records)
+
+
+@pytest.mark.django_db
+def test_process_single_repo_propagates_rate_limit_exception():
+    rr = RepoSearchResult(full_name="owner/repo-rl")
+
+    def ensure(*_a, **_k):
+        raise RateLimitException("slow down")
+
+    with pytest.raises(RateLimitException):
+        process_single_repo(
+            MagicMock(),
+            rr,
+            [],
+            datetime.now(timezone.utc),
+            ensure,
+        )
+
+
+@pytest.mark.django_db
+def test_process_single_repo_no_file_results_skips_version_detection(
+    external_github_repository,
+):
+    rr = RepoSearchResult(full_name=_repo_full_name(external_github_repository))
+
+    def ensure(_c, _r):
+        return external_github_repository
+
+    with patch(
+        "boost_usage_tracker.post_process.detect_boost_version_in_repo"
+    ) as m_det:
+        stats = process_single_repo(
+            MagicMock(),
+            rr,
+            [],
+            datetime.now(timezone.utc),
+            ensure,
+        )
+    m_det.assert_not_called()
+    assert stats["boost_used"] is False
+
+
+def _repo_full_name(github_repository):
+    return f"{github_repository.owner_account.username}/{github_repository.repo_name}"
+
+
+@pytest.mark.django_db
+def test_process_single_repo_bulk_usage_and_boost_used(
+    external_github_repository, ext_repo, github_file, boost_library
+):
+    """Non-empty file results: detect version, resolve header, bulk create usage."""
+    github_file.filename = "boost/asio.hpp"
+    github_file.save(update_fields=["filename"])
+    boost_hdr, _ = boost_library_services.get_or_create_boost_file(
+        github_file, boost_library
+    )
+    rr = RepoSearchResult(full_name=_repo_full_name(external_github_repository))
+    src_file = baker.make(
+        "github_activity_tracker.GitHubFile",
+        repo=external_github_repository,
+        filename="app/main.cpp",
+    )
+    fr = FileSearchResult(
+        repo_full_name=rr.full_name,
+        file_path=src_file.filename,
+        content="#include <boost/asio.hpp>\n",
+        commit_date=datetime(2025, 7, 1, tzinfo=timezone.utc),
+    )
+
+    def ensure(_c, _r):
+        return external_github_repository
+
+    with patch(
+        "boost_usage_tracker.post_process.detect_boost_version_in_repo",
+        return_value=(True, "1.85.0"),
+    ):
+        stats = process_single_repo(
+            MagicMock(),
+            rr,
+            [fr],
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            ensure,
+        )
+
+    assert stats["boost_used"] is True
+    assert stats["usages_created"] >= 1
+    usage = BoostUsage.objects.filter(
+        repo=ext_repo, boost_header=boost_hdr, file_path=src_file
+    ).first()
+    assert usage is not None
+
+
+@pytest.mark.django_db
+def test_process_single_repo_skips_stale_file_and_uses_boost_headers_fallback(
+    external_github_repository, ext_repo, github_file, boost_library
+):
+    """Skip already-processed files; empty extract uses file_result.boost_headers."""
+    github_file.filename = "boost/thread.hpp"
+    github_file.save(update_fields=["filename"])
+    boost_hdr, _ = boost_library_services.get_or_create_boost_file(
+        github_file, boost_library
+    )
+    rr = RepoSearchResult(full_name=_repo_full_name(external_github_repository))
+    stale = baker.make(
+        "github_activity_tracker.GitHubFile",
+        repo=external_github_repository,
+        filename="old.cpp",
+    )
+    fresh = baker.make(
+        "github_activity_tracker.GitHubFile",
+        repo=external_github_repository,
+        filename="new.cpp",
+    )
+    cutoff = datetime(2025, 6, 15, tzinfo=timezone.utc)
+    stale_fr = FileSearchResult(
+        repo_full_name=rr.full_name,
+        file_path=stale.filename,
+        content="",
+        commit_date=datetime(2025, 6, 1, tzinfo=timezone.utc),
+        boost_headers=[],
+    )
+    fresh_fr = FileSearchResult(
+        repo_full_name=rr.full_name,
+        file_path=fresh.filename,
+        content="",
+        commit_date=datetime(2025, 7, 1, tzinfo=timezone.utc),
+        boost_headers=["boost/thread.hpp"],
+    )
+
+    def ensure(_c, _r):
+        return external_github_repository
+
+    with patch(
+        "boost_usage_tracker.post_process.detect_boost_version_in_repo",
+        return_value=(False, ""),
+    ):
+        with patch(
+            "boost_usage_tracker.post_process.create_or_update_github_file"
+        ) as m_file:
+            m_file.side_effect = [
+                (stale, False),
+                (fresh, True),
+            ]
+            stats = process_single_repo(
+                MagicMock(),
+                rr,
+                [stale_fr, fresh_fr],
+                cutoff,
+                ensure,
+            )
+
+    assert stats["usages_created"] >= 1
+    assert BoostUsage.objects.filter(
+        repo=ext_repo, boost_header=boost_hdr, file_path=fresh
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_process_single_repo_missing_header_records_tmp(
+    ext_repo, external_github_repository
+):
+    rr = RepoSearchResult(full_name=_repo_full_name(external_github_repository))
+    gf = baker.make(
+        "github_activity_tracker.GitHubFile",
+        repo=external_github_repository,
+        filename="x.cpp",
+    )
+    fr = FileSearchResult(
+        repo_full_name=rr.full_name,
+        file_path=gf.filename,
+        content="#include <boost/does/not/exist_ever.hpp>\n",
+        commit_date=datetime(2025, 8, 1, tzinfo=timezone.utc),
+    )
+
+    def ensure(_c, _r):
+        return external_github_repository
+
+    with patch(
+        "boost_usage_tracker.post_process.detect_boost_version_in_repo",
+        return_value=(False, ""),
+    ):
+        stats = process_single_repo(
+            MagicMock(),
+            rr,
+            [fr],
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            ensure,
+        )
+
+    assert stats["missing_header_recorded"] >= 1
+    assert BoostUsage.objects.filter(repo=ext_repo, boost_header__isnull=True).exists()
+
+
+@pytest.mark.django_db
+def test_process_single_repo_marks_stale_usages_excepted(
+    external_github_repository, ext_repo, github_file, boost_library
+):
+    github_file.filename = "boost/lambda.hpp"
+    github_file.save(update_fields=["filename"])
+    boost_hdr, _ = boost_library_services.get_or_create_boost_file(
+        github_file, boost_library
+    )
+    old_src = baker.make(
+        "github_activity_tracker.GitHubFile",
+        repo=external_github_repository,
+        filename="legacy.cpp",
+    )
+    baker.make(
+        BoostUsage,
+        repo=ext_repo,
+        boost_header=boost_hdr,
+        file_path=old_src,
+        last_commit_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    rr = RepoSearchResult(full_name=_repo_full_name(external_github_repository))
+    new_src = baker.make(
+        "github_activity_tracker.GitHubFile",
+        repo=external_github_repository,
+        filename="current.cpp",
+    )
+    fr = FileSearchResult(
+        repo_full_name=rr.full_name,
+        file_path=new_src.filename,
+        content="#include <boost/lambda.hpp>\n",
+        commit_date=datetime(2025, 9, 1, tzinfo=timezone.utc),
+    )
+
+    def ensure(_c, _r):
+        return external_github_repository
+
+    with patch(
+        "boost_usage_tracker.post_process.detect_boost_version_in_repo",
+        return_value=(False, ""),
+    ):
+        stats = process_single_repo(
+            MagicMock(),
+            rr,
+            [fr],
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            ensure,
+        )
+
+    assert stats["usages_excepted"] >= 1
+    old_usage = BoostUsage.objects.get(repo=ext_repo, file_path=old_src)
+    assert old_usage.excepted_at is not None

--- a/boost_usage_tracker/tests/test_repo_searcher.py
+++ b/boost_usage_tracker/tests/test_repo_searcher.py
@@ -134,3 +134,93 @@ def test_search_repos_with_date_splitting_dedupes():
     end = datetime(2024, 1, 1, tzinfo=timezone.utc)
     out = search_repos_with_date_splitting(client, start, end, date_field="pushed")
     assert len(out) == 1
+
+
+def _repo_item(name: str) -> dict:
+    return {
+        "full_name": name,
+        "stargazers_count": 1,
+        "description": "",
+        "license": None,
+        "created_at": "",
+        "updated_at": "",
+        "pushed_at": "",
+        "forks_count": 0,
+    }
+
+
+def test_process_date_range_splits_over_1000_merges_deduped_names():
+    """Probe returns >1000 once, children return small counts; merge drops dup full_name."""
+    client = MagicMock()
+    responses = iter(
+        [
+            {"total_count": 1500, "items": []},
+            {"total_count": 10, "items": []},
+            {"items": [_repo_item("u/a")]},
+            {"total_count": 10, "items": []},
+            {
+                "items": [
+                    _repo_item("u/a"),
+                    _repo_item("u/b"),
+                ]
+            },
+        ]
+    )
+
+    def rest_side_effect(_path, params=None):
+        return next(responses)
+
+    client.rest_request.side_effect = rest_side_effect
+    start = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 6, 10, tzinfo=timezone.utc)
+    repos = _process_date_range(client, (start, end), date_field="pushed")
+    names = sorted(r.full_name for r in repos)
+    assert names == ["u/a", "u/b"]
+
+
+def test_process_date_range_cannot_split_returns_first_1000_query():
+    """Same-day primary + same-day secondary => no split; falls back to search."""
+    client = MagicMock()
+    same_day = datetime(2024, 3, 1, tzinfo=timezone.utc)
+
+    def rest_side_effect(_path, params=None):
+        if params.get("per_page") == 1:
+            return {"total_count": 2000, "items": []}
+        return {"items": [_repo_item("only/one")]}
+
+    client.rest_request.side_effect = rest_side_effect
+    repos = _process_date_range(
+        client,
+        (same_day, same_day),
+        second_range=(same_day, same_day),
+        date_field="pushed",
+    )
+    assert [r.full_name for r in repos] == ["only/one"]
+
+
+def test_process_date_range_splits_second_created_range_when_primary_single_day():
+    """When primary span is one day, split uses *second_range* if wide enough."""
+    client = MagicMock()
+    day = datetime(2024, 4, 1, tzinfo=timezone.utc)
+    sec_lo = datetime(2024, 5, 1, tzinfo=timezone.utc)
+    sec_hi = datetime(2024, 5, 20, tzinfo=timezone.utc)
+
+    responses = iter(
+        [
+            {"total_count": 1200, "items": []},
+            {"total_count": 5, "items": []},
+            {"items": [_repo_item("left/repo")]},
+            {"total_count": 5, "items": []},
+            {"items": [_repo_item("right/repo")]},
+        ]
+    )
+
+    client.rest_request.side_effect = lambda _p, params=None: next(responses)
+    repos = _process_date_range(
+        client,
+        (day, day),
+        second_range=(sec_lo, sec_hi),
+        date_field="pushed",
+    )
+    names = {r.full_name for r in repos}
+    assert names == {"left/repo", "right/repo"}

--- a/boost_usage_tracker/tests/test_services.py
+++ b/boost_usage_tracker/tests/test_services.py
@@ -6,6 +6,7 @@ Covers service layer in detail including edge cases and boundaries:
 """
 
 from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -694,6 +695,45 @@ def test_bulk_create_or_update_boost_usage_updates_existing(
     usage.refresh_from_db()
     assert usage.last_commit_date == new_dt
     assert usage.excepted_at is None
+
+
+@pytest.mark.django_db
+def test_get_or_create_boost_external_repo_integrity_error_returns_existing(
+    external_github_repository,
+):
+    """INSERT races another writer; IntegrityError handler loads existing row."""
+    from django.db import IntegrityError
+
+    ext_existing, _ = services.get_or_create_boost_external_repo(
+        external_github_repository,
+        boost_version="1.0",
+        is_boost_used=False,
+    )
+
+    cursor = MagicMock()
+    cursor.execute.side_effect = IntegrityError("duplicate key value")
+
+    conn_cm = MagicMock()
+    conn_cm.__enter__.return_value = cursor
+    conn_cm.__exit__.return_value = False
+
+    mock_objects = MagicMock()
+    mock_objects.filter.return_value.first.return_value = None
+    mock_objects.get.return_value = ext_existing
+
+    with patch("django.db.connection.cursor", return_value=conn_cm):
+        with patch(
+            "boost_usage_tracker.services.BoostExternalRepository.objects", mock_objects
+        ):
+            repo, created = services.get_or_create_boost_external_repo(
+                external_github_repository,
+                boost_version="2.0",
+                is_boost_used=True,
+            )
+
+    assert created is False
+    assert repo.pk == ext_existing.pk
+    mock_objects.get.assert_called_once_with(pk=external_github_repository.pk)
 
 
 # --- mark_usages_excepted_bulk ---

--- a/boost_usage_tracker/tests/test_update_created_repos_by_language.py
+++ b/boost_usage_tracker/tests/test_update_created_repos_by_language.py
@@ -1,5 +1,6 @@
 """Tests for boost_usage_tracker.update_created_repos_by_language."""
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -84,3 +85,120 @@ def test_update_created_repos_by_language_upserts_rows():
     )
     assert all(r.all_repos == 130 for r in rows)
     assert all(r.significant_repos == 13 for r in rows)
+
+
+@pytest.mark.django_db
+def test_update_created_repos_invalid_year_range():
+    r = update_created_repos_by_language(
+        languages_csv="C++",
+        start_year=2025,
+        end_year=2020,
+    )
+    assert r["rows_processed"] == 0
+    assert any("Invalid year range" in e for e in r["errors"])
+
+
+@pytest.mark.django_db
+def test_update_created_repos_fail_on_missing_language():
+    r = update_created_repos_by_language(
+        languages_csv="AbsolutelyFakeLangXYZ",
+        start_year=2024,
+        end_year=2024,
+        fail_on_missing_language=True,
+    )
+    assert r["rows_processed"] == 0
+    assert any("not found" in e.lower() for e in r["errors"])
+
+
+@pytest.mark.django_db
+def test_update_created_repos_missing_language_warns_and_skips(caplog):
+    caplog.set_level(logging.WARNING)
+    r = update_created_repos_by_language(
+        languages_csv="GhostLang",
+        start_year=2024,
+        end_year=2024,
+        fail_on_missing_language=False,
+    )
+    assert r["rows_processed"] == 0
+    assert any("Skipping languages" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.django_db
+def test_update_created_repos_dedupes_language_list():
+    cpp = baker.make("github_activity_tracker.Language", name="C++")
+
+    with patch(
+        "boost_usage_tracker.update_created_repos_by_language.get_github_client"
+    ), patch(
+        "boost_usage_tracker.update_created_repos_by_language._count_items_from_git",
+        return_value=5,
+    ):
+        result = update_created_repos_by_language(
+            languages_csv="C++, C++ , C++",
+            start_year=2024,
+            end_year=2024,
+            stars_min=10,
+        )
+
+    assert result["errors"] == []
+    assert result["languages_requested"] == ["C++"]
+    assert result["rows_processed"] == 1
+    assert CreatedReposByLanguage.objects.filter(  # pylint: disable=no-member
+        language=cpp, year=2024
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_update_created_repos_per_year_exception_recorded():
+    rust_lang = baker.make("github_activity_tracker.Language", name="Rust")
+
+    def boom(_client, _query):
+        raise RuntimeError("api")
+
+    with patch(
+        "boost_usage_tracker.update_created_repos_by_language.get_github_client"
+    ), patch(
+        "boost_usage_tracker.update_created_repos_by_language._count_items_from_git",
+        side_effect=boom,
+    ):
+        result = update_created_repos_by_language(
+            languages_csv="Rust",
+            start_year=2023,
+            end_year=2024,
+            stars_min=10,
+        )
+
+    assert result["rows_processed"] == 0
+    assert len(result["errors"]) == 2
+    assert all("Rust" in e for e in result["errors"])
+    assert (
+        CreatedReposByLanguage.objects.filter(  # pylint: disable=no-member
+            language=rust_lang
+        ).count()
+        == 0
+    )
+
+
+@pytest.mark.django_db
+def test_update_created_repos_optional_sleep_called():
+    go_lang = baker.make("github_activity_tracker.Language", name="Go")
+
+    with patch(
+        "boost_usage_tracker.update_created_repos_by_language.get_github_client"
+    ), patch(
+        "boost_usage_tracker.update_created_repos_by_language._count_items_from_git",
+        return_value=1,
+    ), patch(
+        "boost_usage_tracker.update_created_repos_by_language.time.sleep"
+    ) as m_sleep:
+        update_created_repos_by_language(
+            languages_csv="Go",
+            start_year=2022,
+            end_year=2022,
+            sleep_seconds=0.01,
+        )
+
+    assert m_sleep.called
+    assert CreatedReposByLanguage.objects.filter(  # pylint: disable=no-member
+        language=go_lang, year=2022
+    ).exists()

--- a/boost_usage_tracker/tests/test_update_csv_and_git_account.py
+++ b/boost_usage_tracker/tests/test_update_csv_and_git_account.py
@@ -1,8 +1,12 @@
 """Tests for CSV/git-account update helpers."""
 
 import json
+import logging
+from unittest.mock import patch
 
 import pytest
+
+from cppa_user_tracker.models import GitHubAccount, GitHubAccountType
 
 from boost_usage_tracker.update_boostusage_from_csv import (
     update_boostusage_table_from_csv,
@@ -118,3 +122,393 @@ def test_update_git_account_with_owner_wrapped_json(tmp_path):
 def test_update_git_account_unsupported_table():
     result = update_git_account(table="other")
     assert any("Unsupported" in e for e in result["errors"])
+
+
+@pytest.mark.django_db
+def test_update_git_account_rejects_non_json_source(tmp_path):
+    p = tmp_path / "data.txt"
+    p.write_text("nope", encoding="utf-8")
+    r = update_git_account(source=p, table="github_account")
+    assert "not a directory or .json file" in r["errors"][0].lower()
+
+
+@pytest.mark.django_db
+def test_update_git_account_single_file_json_error(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{", encoding="utf-8")
+    r = update_git_account(source=bad, table="github_account")
+    assert r["created"] == 0
+    assert any("skipping" in e.lower() for e in r["errors"])
+
+
+@pytest.mark.django_db
+def test_update_git_account_nonexistent_path_is_not_dir_nor_file(tmp_path):
+    missing = tmp_path / "nope" / "dir"
+    r = update_git_account(source=missing, table="github_account")
+    assert "not a directory or .json file" in r["errors"][0].lower()
+
+
+@pytest.mark.django_db
+def test_update_git_account_dir_loads_org_and_enterprise_types(tmp_path):
+    (tmp_path / "accounts.json").write_text(
+        json.dumps(
+            [
+                {
+                    "owner": {
+                        "id": 91001102,
+                        "login": "org-acct",
+                        "type": "Organization",
+                    }
+                },
+                {
+                    "owner": {
+                        "id": 91001103,
+                        "login": "ent-acct",
+                        "type": "enterprise",
+                    }
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    r = update_git_account(source=tmp_path, table="github_account")
+    assert r["created"] + r["updated"] == 2
+    assert (
+        GitHubAccount.objects.get(github_account_id=91001102).account_type
+        == GitHubAccountType.ORGANIZATION
+    )
+    assert (
+        GitHubAccount.objects.get(github_account_id=91001103).account_type
+        == GitHubAccountType.ENTERPRISE
+    )
+
+
+@pytest.mark.django_db
+def test_update_git_account_skips_bad_records(caplog, tmp_path):
+    caplog.set_level(logging.WARNING)
+    (tmp_path / "mix.json").write_text(
+        json.dumps(
+            [
+                "not-a-dict",
+                {"owner": "bad"},
+                {"owner": {"login": "x"}},
+                {"owner": {"id": "nan", "login": "y"}},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    r = update_git_account(source=tmp_path, table="github_account")
+    assert r["created"] == 0
+    assert sum(1 for rec in caplog.records if "Skipping" in rec.message) >= 3
+
+
+@pytest.mark.django_db
+def test_update_git_account_empty_username_warns(caplog, tmp_path):
+    caplog.set_level(logging.WARNING)
+    (tmp_path / "e.json").write_text(
+        json.dumps({"owner": {"id": 92002002, "login": ""}}),
+        encoding="utf-8",
+    )
+    r = update_git_account(source=tmp_path, table="github_account")
+    assert r["created"] + r["updated"] >= 1
+    assert any("empty username" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.django_db
+def test_update_git_account_directory_skips_bad_json(tmp_path, caplog):
+    caplog.set_level(logging.WARNING)
+    (tmp_path / "bad.json").write_text("{", encoding="utf-8")
+    (tmp_path / "ok.json").write_text(
+        json.dumps({"owner": {"id": 92002003, "login": "goodjson"}}),
+        encoding="utf-8",
+    )
+    r = update_git_account(source=tmp_path, table="github_account")
+    assert r["created"] + r["updated"] >= 1
+    assert any("Skipping" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.django_db
+def test_update_boostusage_csv_not_found(tmp_path):
+    r = update_boostusage_table_from_csv(tmp_path / "nope.csv")
+    assert "not found" in r["errors"][0].lower()
+
+
+@pytest.mark.django_db
+def test_update_boostusage_csv_bad_columns(tmp_path):
+    p = tmp_path / "bu.csv"
+    p.write_text("a,b\n1,2\n", encoding="utf-8")
+    r = update_boostusage_table_from_csv(p)
+    assert any("csv must have columns" in e.lower() for e in r["errors"])
+
+
+@pytest.mark.django_db
+def test_update_boostusage_skipped_counters(tmp_path, github_account, ext_repo):
+    """skipped_no_repo / skipped_no_file / skipped_no_boost_header."""
+    owner = github_account.username
+    p = tmp_path / "bu.csv"
+    p.write_text(
+        "owner,repo_name,file_path,boost_header_name\n"
+        f"{owner},nonexistent-repo,x.cpp,h.hpp\n"
+        f"{owner},{ext_repo.repo_name},missing.cpp,h.hpp\n"
+        f"{owner},{ext_repo.repo_name},src/main.cpp,missing_header.hpp\n",
+        encoding="utf-8",
+    )
+    from model_bakery import baker
+
+    baker.make(
+        "github_activity_tracker.GitHubFile",
+        repo=ext_repo,
+        filename="src/main.cpp",
+    )
+    r = update_boostusage_table_from_csv(p)
+    assert r["skipped_no_repo"] >= 1
+    assert r["skipped_no_file"] >= 1
+    assert r["skipped_no_boost_header"] >= 1
+
+
+@pytest.mark.django_db
+def test_update_boostusage_open_os_error(tmp_path):
+    p = tmp_path / "bu.csv"
+    p.write_text(
+        "owner,repo_name,file_path,boost_header_name\nx,y,z,h\n", encoding="utf-8"
+    )
+    with patch(
+        "boost_usage_tracker.update_boostusage_from_csv.Path.open",
+        side_effect=OSError("disk"),
+    ):
+        r = update_boostusage_table_from_csv(p)
+    assert any("disk" in e.lower() for e in r["errors"])
+
+
+@pytest.mark.django_db
+def test_update_repository_csv_not_found(tmp_path):
+    r = update_repository_table_from_csv(tmp_path / "missing.csv")
+    assert "not found" in r["errors"][0].lower()
+
+
+@pytest.mark.django_db
+def test_update_repository_csv_bad_columns(tmp_path):
+    p = tmp_path / "r.csv"
+    p.write_text("only_one_col\nx\n", encoding="utf-8")
+    r = update_repository_table_from_csv(p)
+    assert any("owner" in e.lower() for e in r["errors"])
+
+
+@pytest.mark.django_db
+def test_update_repository_skips_blank_identifiers(tmp_path, github_account):
+    p = tmp_path / "r.csv"
+    p.write_text(
+        "owner,repo_name\n"
+        f",{github_account.username}\n"
+        f"{github_account.username},\n",
+        encoding="utf-8",
+    )
+    r = update_repository_table_from_csv(p)
+    assert r["created_repos"] == 0
+
+
+@pytest.mark.django_db
+def test_update_repository_invalid_int_stars_defaults(tmp_path, github_account):
+    import uuid
+
+    slug = "stars-parse-" + uuid.uuid4().hex[:8]
+    p = tmp_path / "r.csv"
+    p.write_text(
+        "owner,repo_name,stars,forks\n"
+        f'{github_account.username},{slug},"not-a-number","bogus"\n',
+        encoding="utf-8",
+    )
+    r = update_repository_table_from_csv(p)
+    assert r["created_repos"] == 1
+    from github_activity_tracker.models import GitHubRepository
+
+    repo = GitHubRepository.objects.get(owner_account=github_account, repo_name=slug)
+    assert repo.stars == 0
+    assert repo.forks == 0
+
+
+@pytest.mark.django_db
+def test_update_repository_open_os_error(tmp_path):
+    p = tmp_path / "r.csv"
+    p.write_text("owner,repo_name\na,b\n", encoding="utf-8")
+    with patch(
+        "boost_usage_tracker.update_repository_from_csv.Path.open",
+        side_effect=OSError("read"),
+    ):
+        r = update_repository_table_from_csv(p)
+    assert any("read" in e.lower() for e in r["errors"])
+
+
+@pytest.mark.django_db
+def test_update_githubfile_csv_not_found(tmp_path):
+    r = update_githubfile_table_from_csv(tmp_path / "gf.csv")
+    assert "not found" in r["errors"][0].lower()
+
+
+@pytest.mark.django_db
+def test_update_githubfile_bad_columns(tmp_path):
+    p = tmp_path / "gf.csv"
+    p.write_text("owner,repo_name\nx,y\n", encoding="utf-8")
+    r = update_githubfile_table_from_csv(p)
+    assert any("file_path" in e.lower() for e in r["errors"])
+
+
+@pytest.mark.django_db
+def test_update_githubfile_skipped_no_repo(tmp_path, github_account):
+    p = tmp_path / "gf.csv"
+    p.write_text(
+        "owner,repo_name,file_path\n"
+        f"{github_account.username},ghost-repo,main.cpp\n",
+        encoding="utf-8",
+    )
+    r = update_githubfile_table_from_csv(p)
+    assert r["skipped_no_repo"] == 1
+
+
+@pytest.mark.django_db
+def test_update_githubfile_deleted_flag_and_update(tmp_path, github_account):
+    from model_bakery import baker
+
+    repo = baker.make(
+        "github_activity_tracker.GitHubRepository",
+        owner_account=github_account,
+        repo_name="gf-flag-repo",
+    )
+    p = tmp_path / "gf.csv"
+    p.write_text(
+        "owner,repo_name,file_path,is_deleted\n"
+        f"{github_account.username},{repo.repo_name},a.cpp,false\n",
+        encoding="utf-8",
+    )
+    r1 = update_githubfile_table_from_csv(p)
+    assert r1["created"] == 1
+    p.write_text(
+        "owner,repo_name,file_path,is_deleted\n"
+        f"{github_account.username},{repo.repo_name},a.cpp,true\n",
+        encoding="utf-8",
+    )
+    r2 = update_githubfile_table_from_csv(p)
+    assert r2["updated"] == 1
+    from github_activity_tracker.models import GitHubFile
+
+    gf = GitHubFile.objects.get(repo=repo, filename="a.cpp")
+    assert gf.is_deleted is True
+
+
+@pytest.mark.django_db
+def test_update_git_account_defaults_to_github_account_dir(tmp_path):
+    (tmp_path / "acc.json").write_text(
+        json.dumps({"owner": {"id": 92008888, "login": "default-dir-user"}}),
+        encoding="utf-8",
+    )
+    with patch(
+        "boost_usage_tracker.update_git_account.get_github_account_dir",
+        return_value=tmp_path,
+    ):
+        result = update_git_account(source=None, table="github_account")
+    assert result["created"] + result["updated"] >= 1
+    assert GitHubAccount.objects.filter(github_account_id=92008888).exists()
+
+
+@pytest.mark.django_db
+def test_update_repository_optional_datetime_columns(tmp_path, github_account):
+    import uuid
+
+    slug = "dt-repo-" + uuid.uuid4().hex[:8]
+    ts = "2024-02-01T12:00:00Z"
+    p = tmp_path / "r.csv"
+    p.write_text(
+        "owner,repo_name,repo_pushed_at,repo_created_at,repo_updated_at\n"
+        f"{github_account.username},{slug},{ts},{ts},{ts}\n",
+        encoding="utf-8",
+    )
+    result = update_repository_table_from_csv(p)
+    assert result["created_repos"] == 1
+
+
+@pytest.mark.django_db
+def test_update_repository_whitespace_description_skipped(tmp_path, github_account):
+    import uuid
+
+    slug = "nodesc-" + uuid.uuid4().hex[:8]
+    p = tmp_path / "r.csv"
+    p.write_text(
+        "owner,repo_name,description\n" f"{github_account.username},{slug},   \n",
+        encoding="utf-8",
+    )
+    update_repository_table_from_csv(p)
+    from github_activity_tracker.models import GitHubRepository
+
+    repo = GitHubRepository.objects.get(owner_account=github_account, repo_name=slug)
+    assert repo.description == ""
+
+
+@pytest.mark.django_db
+def test_update_boostusage_blank_last_commit_ts(
+    tmp_path, ext_repo, external_github_file, boost_file
+):
+    owner = ext_repo.owner_account.username
+    header_fn = boost_file.github_file.filename
+    p = tmp_path / "bu.csv"
+    p.write_text(
+        "owner,repo_name,file_path,boost_header_name,last_commit_ts\n"
+        f"{owner},{ext_repo.repo_name},{external_github_file.filename},"
+        f"{header_fn},\n",
+        encoding="utf-8",
+    )
+    result = update_boostusage_table_from_csv(p)
+    assert result["created"] == 1 or result["updated"] == 1
+
+
+@pytest.mark.django_db
+def test_update_boostusage_updates_existing_row(
+    tmp_path, ext_repo, external_github_file, boost_file
+):
+    owner = ext_repo.owner_account.username
+    header_fn = boost_file.github_file.filename
+    p = tmp_path / "bu.csv"
+    body = (
+        "owner,repo_name,file_path,boost_header_name,last_commit_ts\n"
+        f"{owner},{ext_repo.repo_name},{external_github_file.filename},"
+        f"{header_fn},2024-01-01T00:00:00Z\n"
+    )
+    p.write_text(body, encoding="utf-8")
+    r1 = update_boostusage_table_from_csv(p)
+    assert r1["created"] == 1
+    p.write_text(body, encoding="utf-8")
+    r2 = update_boostusage_table_from_csv(p)
+    assert r2["updated"] == 1
+
+
+@pytest.mark.django_db
+def test_update_githubfile_is_deleted_defaults_false(tmp_path, github_account):
+    from model_bakery import baker
+
+    repo = baker.make(
+        "github_activity_tracker.GitHubRepository",
+        owner_account=github_account,
+        repo_name="gf-default-del",
+    )
+    p = tmp_path / "gf.csv"
+    p.write_text(
+        "owner,repo_name,file_path\n"
+        f"{github_account.username},{repo.repo_name},main.cpp\n",
+        encoding="utf-8",
+    )
+    update_githubfile_table_from_csv(p)
+    from github_activity_tracker.models import GitHubFile
+
+    gf = GitHubFile.objects.get(repo=repo, filename="main.cpp")
+    assert gf.is_deleted is False
+
+
+@pytest.mark.django_db
+def test_update_githubfile_open_os_error(tmp_path):
+    p = tmp_path / "gf.csv"
+    p.write_text("owner,repo_name,file_path\na,b,c\n", encoding="utf-8")
+    with patch(
+        "boost_usage_tracker.update_githubfile_from_csv.Path.open",
+        side_effect=OSError("io"),
+    ):
+        r = update_githubfile_table_from_csv(p)
+    assert any("io" in e.lower() for e in r["errors"])


### PR DESCRIPTION
# What changed
Adds and expands tests under boost_usage_tracker/tests/ to cover previously untested branches:

- post_process: process_single_repo flows (bulk usage, missing-header tmp records, excepted usages, rate-limit propagation, empty-file early exit).
- repo_searcher: Recursive split when search total_count > 1000, merge/dedup, fallback when the range cannot be split further, second-date-range splitting.
- update_git_account / db_from_file: Invalid sources, JSON errors, directory loads, org/enterprise types, default workspace paths, rglob edge cases.
- CSV updaters (update_*_from_csv): Missing files, bad columns, OS errors, skip counters, bool/is_deleted defaults, repository datetime columns, boostusage update paths.
- update_created_repos_by_language: Invalid year range, fail_on_missing_language, warnings, deduped language list, per-year exceptions, optional sleep_seconds.
- boost_searcher: Additional GraphQL batch/code-search/probe paths (mocked client).
services: get_or_create_boost_external_repo race handler (IntegrityError after concurrent insert).

close https://github.com/cppalliance/boost-data-collector/issues/173