### PR TITLE
test: broaden coverage for clang, core, GitHub, and Slack tracker apps

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,36 @@
+# Coverage.py — used by pytest-cov (`pytest --cov`, CI), Makefile `test-cov`, and:
+#   python -m pytest --cov=. --cov-report=term-missing --cov-fail-under=90
+# Docs: https://coverage.readthedocs.io/en/latest/config.html
+
+[run]
+source = .
+branch = false
+omit =
+    */migrations/*
+    */tests/*
+    .venv/*
+    venv/*
+    env/*
+    .eggs/*
+    */site-packages/*
+    staticfiles/*
+    htmlcov/*
+    .test_artifacts/*
+    manage.py
+
+[report]
+precision = 2
+show_missing = true
+skip_empty = true
+exclude_lines =
+    pragma: no cover
+    pragma: no branch
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError
+    if TYPE_CHECKING:
+    if typing.TYPE_CHECKING:
+    @overload
+    @abstractmethod
+    @abc.abstractmethod
+    if __name__ == .__main__.:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Test with pytest
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+          USE_POSTGRES_TESTS: "1"
           SECRET_KEY: for-testing-only
           DJANGO_SETTINGS_MODULE: config.test_settings
         run: |

--- a/clang_github_tracker/tests/test_backfill.py
+++ b/clang_github_tracker/tests/test_backfill.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 from clang_github_tracker.models import ClangGithubCommit, ClangGithubIssueItem
 from clang_github_tracker.workspace import OWNER, REPO
@@ -60,3 +61,56 @@ def test_backfill_from_raw(tmp_path, monkeypatch):
     assert ClangGithubIssueItem.objects.filter(number=3, is_pull_request=False).exists()
     assert ClangGithubIssueItem.objects.filter(number=4, is_pull_request=True).exists()
     assert ClangGithubCommit.objects.filter(sha=sha).exists()
+
+
+@pytest.mark.django_db
+def test_backfill_raises_when_raw_root_missing(tmp_path, monkeypatch):
+    missing = tmp_path / "nope"
+    monkeypatch.setattr(
+        "clang_github_tracker.management.commands.backfill_clang_github_tracker.get_raw_repo_dir",
+        lambda *a, **k: missing,
+    )
+    with pytest.raises(CommandError, match="Raw repo dir missing"):
+        call_command("backfill_clang_github_tracker")
+
+
+@pytest.mark.django_db
+def test_backfill_skips_bad_commit_json_and_invalid_sha(tmp_path, monkeypatch):
+    root = tmp_path / "raw" / OWNER / REPO
+    (root / "commits").mkdir(parents=True)
+    (root / "commits" / "bad.json").write_text("{", encoding="utf-8")
+    (root / "commits" / "short.json").write_text(
+        json.dumps({"sha": "tooshort", "commit": {}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "clang_github_tracker.management.commands.backfill_clang_github_tracker.get_raw_repo_dir",
+        lambda *a, **k: root,
+    )
+    call_command("backfill_clang_github_tracker")
+    assert ClangGithubCommit.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_backfill_commit_chunk_flush(monkeypatch, tmp_path):
+    import clang_github_tracker.management.commands.backfill_clang_github_tracker as bf
+
+    monkeypatch.setattr(bf, "_RAW_CHUNK_EVERY", 2)
+    root = tmp_path / "raw" / OWNER / REPO
+    (root / "commits").mkdir(parents=True)
+    for i in range(3):
+        sha = f"{i:040x}"
+        (root / "commits" / f"{sha}.json").write_text(
+            json.dumps(
+                {
+                    "sha": sha,
+                    "commit": {"author": {"date": "2024-05-01T00:00:00Z"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+    monkeypatch.setattr(
+        "clang_github_tracker.management.commands.backfill_clang_github_tracker.get_raw_repo_dir",
+        lambda *a, **k: root,
+    )
+    call_command("backfill_clang_github_tracker")
+    assert ClangGithubCommit.objects.count() == 3

--- a/clang_github_tracker/tests/test_preprocessors.py
+++ b/clang_github_tracker/tests/test_preprocessors.py
@@ -167,9 +167,11 @@ def test_pr_preprocessor_naive_final_sync_and_bad_json(mock_build, tmp_path, set
     assert mock_build.call_count >= 1
 
     p.write_text("{", encoding="utf-8")
+    calls_before = mock_build.call_count
     with patch(
         "clang_github_tracker.preprocessors.pr_preprocessor.get_raw_source_pr_path",
         return_value=p,
     ):
         docs, _ = pr_preprocessor.preprocess_for_pinecone([], None)
     assert docs == []
+    assert mock_build.call_count == calls_before

--- a/clang_github_tracker/tests/test_preprocessors.py
+++ b/clang_github_tracker/tests/test_preprocessors.py
@@ -1,6 +1,7 @@
 """Tests for DB-driven clang preprocessors."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -90,3 +91,83 @@ def test_pr_preprocessor_failed_id_parsing(mock_build, tmp_path, settings):
     assert chunked is False
     assert mock_build.call_count == 1
     assert len(docs) == 1
+
+
+@pytest.mark.django_db
+@patch("clang_github_tracker.preprocessors.issue_preprocessor.build_issue_document")
+def test_issue_preprocessor_naive_final_sync_made_aware(mock_build, tmp_path, settings):
+    settings.CLANG_GITHUB_OWNER = "llvm"
+    settings.CLANG_GITHUB_REPO = "llvm-project"
+    mock_build.return_value = {"content": "x", "metadata": {}}
+    p = tmp_path / "1.json"
+    p.write_text("{}", encoding="utf-8")
+    ClangGithubIssueItem.objects.create(
+        number=1,
+        is_pull_request=False,
+        github_updated_at=timezone.now(),
+    )
+    naive = datetime(2020, 1, 1, 0, 0, 0)
+    with patch(
+        "clang_github_tracker.preprocessors.issue_preprocessor.get_raw_source_issue_path",
+        return_value=p,
+    ):
+        issue_preprocessor.preprocess_for_pinecone([], naive)
+    assert mock_build.call_count >= 1
+
+
+@pytest.mark.django_db
+@patch("clang_github_tracker.preprocessors.issue_preprocessor.build_issue_document")
+def test_issue_preprocessor_skips_missing_raw_and_bad_json(mock_build, tmp_path, settings):
+    settings.CLANG_GITHUB_OWNER = "llvm"
+    settings.CLANG_GITHUB_REPO = "llvm-project"
+    ClangGithubIssueItem.objects.create(
+        number=1,
+        is_pull_request=False,
+        github_updated_at=timezone.now(),
+    )
+    bad = Path("/nonexistent/issue_1.json")
+    with patch(
+        "clang_github_tracker.preprocessors.issue_preprocessor.get_raw_source_issue_path",
+        return_value=bad,
+    ):
+        docs, _ = issue_preprocessor.preprocess_for_pinecone([], None)
+    assert docs == [] and mock_build.call_count == 0
+
+    p = tmp_path / "1.json"
+    p.write_text("not-json", encoding="utf-8")
+    with patch(
+        "clang_github_tracker.preprocessors.issue_preprocessor.get_raw_source_issue_path",
+        return_value=p,
+    ):
+        docs2, _ = issue_preprocessor.preprocess_for_pinecone([], None)
+    assert docs2 == [] and mock_build.call_count == 0
+
+
+@pytest.mark.django_db
+@patch("clang_github_tracker.preprocessors.pr_preprocessor.build_pr_document")
+def test_pr_preprocessor_naive_final_sync_and_bad_json(mock_build, tmp_path, settings):
+    settings.CLANG_GITHUB_OWNER = "llvm"
+    settings.CLANG_GITHUB_REPO = "llvm-project"
+    mock_build.return_value = {"content": "p", "metadata": {}}
+    p = tmp_path / "2.json"
+    p.write_text("{}", encoding="utf-8")
+    ClangGithubIssueItem.objects.create(
+        number=2,
+        is_pull_request=True,
+        github_updated_at=timezone.now(),
+    )
+    naive = datetime(2020, 1, 1, 0, 0, 0)
+    with patch(
+        "clang_github_tracker.preprocessors.pr_preprocessor.get_raw_source_pr_path",
+        return_value=p,
+    ):
+        pr_preprocessor.preprocess_for_pinecone([], naive)
+    assert mock_build.call_count >= 1
+
+    p.write_text("{", encoding="utf-8")
+    with patch(
+        "clang_github_tracker.preprocessors.pr_preprocessor.get_raw_source_pr_path",
+        return_value=p,
+    ):
+        docs, _ = pr_preprocessor.preprocess_for_pinecone([], None)
+    assert docs == []

--- a/clang_github_tracker/tests/test_preprocessors.py
+++ b/clang_github_tracker/tests/test_preprocessors.py
@@ -117,7 +117,9 @@ def test_issue_preprocessor_naive_final_sync_made_aware(mock_build, tmp_path, se
 
 @pytest.mark.django_db
 @patch("clang_github_tracker.preprocessors.issue_preprocessor.build_issue_document")
-def test_issue_preprocessor_skips_missing_raw_and_bad_json(mock_build, tmp_path, settings):
+def test_issue_preprocessor_skips_missing_raw_and_bad_json(
+    mock_build, tmp_path, settings
+):
     settings.CLANG_GITHUB_OWNER = "llvm"
     settings.CLANG_GITHUB_REPO = "llvm-project"
     ClangGithubIssueItem.objects.create(

--- a/clang_github_tracker/tests/test_publisher.py
+++ b/clang_github_tracker/tests/test_publisher.py
@@ -226,7 +226,10 @@ def test_publish_invalid_repo_backslash(raw_and_md):
 
 
 @pytest.mark.django_db
-@patch("clang_github_tracker.publisher.get_github_token", side_effect=ValueError("no token"))
+@patch(
+    "clang_github_tracker.publisher.get_github_token",
+    side_effect=ValueError("no token"),
+)
 def test_publish_clang_token_error_wraps(_tok, raw_and_md):
     raw, md, _ = raw_and_md
     with _author_settings(raw):
@@ -259,9 +262,7 @@ def test_publish_prepare_clone_fails(
 @patch("clang_github_tracker.publisher.pull")
 @patch("clang_github_tracker.publisher.prepare_repo_for_pull")
 @patch("clang_github_tracker.publisher.get_github_token", return_value="tok")
-def test_publish_pull_fails(
-    _token, _prepare, mock_pull, _reset, _push, raw_and_md
-):
+def test_publish_pull_fails(_token, _prepare, mock_pull, _reset, _push, raw_and_md):
     raw, md, _clone_root = raw_and_md
     err = subprocess.CalledProcessError(1, ["git"])
     err.stderr = "pull failed"

--- a/clang_github_tracker/tests/test_publisher.py
+++ b/clang_github_tracker/tests/test_publisher.py
@@ -8,7 +8,11 @@ import pytest
 from django.core.management.base import CommandError
 from django.test import override_settings
 
-from clang_github_tracker.publisher import publish_clang_markdown
+from clang_github_tracker.publisher import (
+    _redacted_git_subprocess_error,
+    _reset_hard_to_upstream,
+    publish_clang_markdown,
+)
 
 
 @pytest.fixture
@@ -187,3 +191,116 @@ def test_publish_clang_markdown_clones_when_no_git_dir(
     with _author_settings(raw):
         publish_clang_markdown(md, "acme", "priv", "main", {})
     mock_clone.assert_called_once()
+
+
+def test_redacted_git_subprocess_error_falls_back_to_str():
+    err = subprocess.CalledProcessError(1, ["git"])
+    err.stderr = None
+    err.stdout = None
+    text = _redacted_git_subprocess_error(err)
+    assert "CalledProcessError" in text or "1" in text
+
+
+@pytest.mark.django_db
+def test_publish_clang_markdown_empty_repo_slug(raw_and_md):
+    raw, md, _ = raw_and_md
+    with _author_settings(raw):
+        with pytest.raises(CommandError, match="Invalid GitHub repo"):
+            publish_clang_markdown(md, "acme", "", "main", {})
+
+
+@pytest.mark.django_db
+def test_publish_invalid_owner_dot(raw_and_md):
+    raw, md, _ = raw_and_md
+    with _author_settings(raw):
+        with pytest.raises(CommandError, match="Invalid GitHub owner"):
+            publish_clang_markdown(md, ".", "priv", "main", {})
+
+
+@pytest.mark.django_db
+def test_publish_invalid_repo_backslash(raw_and_md):
+    raw, md, _ = raw_and_md
+    with _author_settings(raw):
+        with pytest.raises(CommandError, match="Invalid GitHub repo"):
+            publish_clang_markdown(md, "acme", r"a\b", "main", {})
+
+
+@pytest.mark.django_db
+@patch("clang_github_tracker.publisher.get_github_token", side_effect=ValueError("no token"))
+def test_publish_clang_token_error_wraps(_tok, raw_and_md):
+    raw, md, _ = raw_and_md
+    with _author_settings(raw):
+        with pytest.raises(CommandError, match="no token"):
+            publish_clang_markdown(md, "acme", "priv", "main", {})
+
+
+@pytest.mark.django_db
+@patch("clang_github_tracker.publisher.git_push")
+@patch("clang_github_tracker.publisher._reset_hard_to_upstream")
+@patch("clang_github_tracker.publisher.pull")
+@patch("clang_github_tracker.publisher.prepare_repo_for_pull")
+@patch("clang_github_tracker.publisher.get_github_token", return_value="tok")
+def test_publish_prepare_clone_fails(
+    _token, mock_prepare, _pull, _reset, _push, raw_and_md
+):
+    raw, md, _clone_root = raw_and_md
+    err = subprocess.CalledProcessError(1, ["git"])
+    err.stderr = "prep failed"
+    err.stdout = ""
+    mock_prepare.side_effect = err
+    with _author_settings(raw):
+        with pytest.raises(CommandError, match="prepare clone"):
+            publish_clang_markdown(md, "acme", "priv", "main", {})
+
+
+@pytest.mark.django_db
+@patch("clang_github_tracker.publisher.git_push")
+@patch("clang_github_tracker.publisher._reset_hard_to_upstream")
+@patch("clang_github_tracker.publisher.pull")
+@patch("clang_github_tracker.publisher.prepare_repo_for_pull")
+@patch("clang_github_tracker.publisher.get_github_token", return_value="tok")
+def test_publish_pull_fails(
+    _token, _prepare, mock_pull, _reset, _push, raw_and_md
+):
+    raw, md, _clone_root = raw_and_md
+    err = subprocess.CalledProcessError(1, ["git"])
+    err.stderr = "pull failed"
+    err.stdout = ""
+    mock_pull.side_effect = err
+    with _author_settings(raw):
+        with pytest.raises(CommandError, match="Git pull failed"):
+            publish_clang_markdown(md, "acme", "priv", "main", {})
+
+
+@pytest.mark.django_db
+@patch("clang_github_tracker.publisher.git_push")
+@patch("clang_github_tracker.publisher.pull")
+@patch("clang_github_tracker.publisher.prepare_repo_for_pull")
+@patch("clang_github_tracker.publisher.clone_repo")
+@patch("clang_github_tracker.publisher.get_github_token", return_value="tok")
+def test_publish_clone_repo_fails(
+    _token, mock_clone, _prepare, _pull, _push, tmp_path: Path
+):
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    md = tmp_path / "md"
+    md.mkdir()
+    clone = raw / "clang_github_tracker" / "acme" / "priv"
+    clone.mkdir(parents=True)
+    err = subprocess.CalledProcessError(1, ["git", "clone"])
+    err.stderr = "not found"
+    err.stdout = ""
+    mock_clone.side_effect = err
+    with _author_settings(raw):
+        with pytest.raises(CommandError, match="Git clone failed"):
+            publish_clang_markdown(md, "acme", "priv", "main", {})
+
+
+def test_reset_hard_to_upstream_failure(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    err = subprocess.CalledProcessError(1, ["git"])
+    err.stderr = "reset bad"
+    err.stdout = ""
+    with patch("clang_github_tracker.publisher.subprocess.run", side_effect=err):
+        with pytest.raises(CommandError, match="Could not reset"):
+            _reset_hard_to_upstream(tmp_path, "origin", "main")

--- a/clang_github_tracker/tests/test_services.py
+++ b/clang_github_tracker/tests/test_services.py
@@ -237,3 +237,27 @@ def test_upsert_issue_items_batch_merge_with_db_keeps_pr_once_true():
     clang_services.upsert_issue_items_batch([(21, True, t0, t0)])
     clang_services.upsert_issue_items_batch([(21, False, t0, t0)])
     assert ClangGithubIssueItem.objects.get(number=21).is_pull_request is True
+
+
+@pytest.mark.django_db
+def test_upsert_commit_rejects_non_40_char_sha():
+    with pytest.raises(ValueError, match="40 hex"):
+        clang_services.upsert_commit("abc", github_committed_at=timezone.now())
+
+
+@pytest.mark.django_db
+def test_flush_commits_and_issue_chunks_empty_return_zero():
+    assert clang_services._flush_commits_chunk([]) == (0, 0)
+    assert clang_services._flush_issue_items_chunk([]) == (0, 0)
+
+
+@pytest.mark.django_db
+def test_upsert_commits_batch_invalid_batch_size_and_skips_short_sha():
+    sha = "f" * 40
+    t0 = timezone.now()
+    ins, upd = clang_services.upsert_commits_batch(
+        [(sha, t0), ("short", t0)], batch_size=0
+    )
+    assert ins == 1 and upd == 0
+    ins2, upd2 = clang_services.upsert_commits_batch([(sha, t0)], batch_size=99_999)
+    assert ins2 == 0 and upd2 == 1

--- a/clang_github_tracker/tests/test_sync_raw.py
+++ b/clang_github_tracker/tests/test_sync_raw.py
@@ -16,6 +16,8 @@ def test_ensure_utc():
     u = sync_raw._ensure_utc(naive)
     assert u.tzinfo == timezone.utc
     assert sync_raw._ensure_utc(None) is None
+    aware = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    assert sync_raw._ensure_utc(aware) == aware
 
 
 def test_valid_positive_issue_number():
@@ -102,6 +104,72 @@ def test_process_pending_skips_bad_json(tmp_path, monkeypatch):
     assert c == 0 and i == [] and p == []
 
 
+def test_process_pending_issue_bad_json_and_non_dict(tmp_path, monkeypatch):
+    monkeypatch.setattr(sync_raw, "iter_existing_commit_jsons", lambda o, r: [])
+    monkeypatch.setattr(
+        sync_raw,
+        "iter_existing_issue_jsons",
+        lambda o, r: [tmp_path / "i_bad.json", tmp_path / "i_list.json"],
+    )
+    monkeypatch.setattr(sync_raw, "iter_existing_pr_jsons", lambda o, r: [])
+    (tmp_path / "i_bad.json").write_text("{", encoding="utf-8")
+    (tmp_path / "i_list.json").write_text("[1]", encoding="utf-8")
+    c, i, p = sync_raw.process_pending_clang_staging("o", "r")
+    assert c == 0 and i == [] and p == []
+
+
+def test_process_pending_pr_bad_json(tmp_path, monkeypatch):
+    monkeypatch.setattr(sync_raw, "iter_existing_commit_jsons", lambda o, r: [])
+    monkeypatch.setattr(sync_raw, "iter_existing_issue_jsons", lambda o, r: [])
+    monkeypatch.setattr(
+        sync_raw,
+        "iter_existing_pr_jsons",
+        lambda o, r: [tmp_path / "p_bad.json"],
+    )
+    (tmp_path / "p_bad.json").write_text("{", encoding="utf-8")
+    c, i, p = sync_raw.process_pending_clang_staging("o", "r")
+    assert c == 0 and i == [] and p == []
+
+
+def test_process_pending_commit_non_dict_skipped(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sync_raw,
+        "iter_existing_commit_jsons",
+        lambda o, r: [tmp_path / "c.json"],
+    )
+    monkeypatch.setattr(sync_raw, "iter_existing_issue_jsons", lambda o, r: [])
+    monkeypatch.setattr(sync_raw, "iter_existing_pr_jsons", lambda o, r: [])
+    (tmp_path / "c.json").write_text("[1]", encoding="utf-8")
+    c, i, p = sync_raw.process_pending_clang_staging("o", "r")
+    assert c == 0 and i == [] and p == []
+
+
+def test_process_pending_issue_non_dict_skipped(tmp_path, monkeypatch):
+    monkeypatch.setattr(sync_raw, "iter_existing_commit_jsons", lambda o, r: [])
+    monkeypatch.setattr(
+        sync_raw,
+        "iter_existing_issue_jsons",
+        lambda o, r: [tmp_path / "i.json"],
+    )
+    monkeypatch.setattr(sync_raw, "iter_existing_pr_jsons", lambda o, r: [])
+    (tmp_path / "i.json").write_text("[]", encoding="utf-8")
+    c, i, p = sync_raw.process_pending_clang_staging("o", "r")
+    assert c == 0 and i == [] and p == []
+
+
+def test_process_pending_pr_non_dict_skipped(tmp_path, monkeypatch):
+    monkeypatch.setattr(sync_raw, "iter_existing_commit_jsons", lambda o, r: [])
+    monkeypatch.setattr(sync_raw, "iter_existing_issue_jsons", lambda o, r: [])
+    monkeypatch.setattr(
+        sync_raw,
+        "iter_existing_pr_jsons",
+        lambda o, r: [tmp_path / "p.json"],
+    )
+    (tmp_path / "p.json").write_text("null", encoding="utf-8")
+    c, i, p = sync_raw.process_pending_clang_staging("o", "r")
+    assert c == 0 and i == [] and p == []
+
+
 @pytest.mark.django_db
 def test_sync_clang_github_activity_promotes_then_raises_rate_limit():
     commit = {"sha": "abc123", "commit": {"author": {"date": "2024-01-01T00:00:00Z"}}}
@@ -169,6 +237,70 @@ def test_promote_issue_success(tmp_path):
 
 
 @pytest.mark.django_db
+def test_promote_issue_db_failure_keeps_staging(tmp_path):
+    sp = tmp_path / "i.json"
+    item = {
+        "number": 7,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+    }
+    sync_raw._write_staging_json(sp, item)
+    with patch.object(
+        sync_raw.clang_services, "upsert_issue_item", side_effect=RuntimeError("db")
+    ):
+        assert sync_raw._promote_issue_staging("o", "r", sp, item) is False
+    assert sp.exists()
+
+
+@pytest.mark.django_db
+def test_promote_issue_raw_failure_keeps_staging(tmp_path):
+    sp = tmp_path / "i.json"
+    item = {
+        "number": 42,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+    }
+    sync_raw._write_staging_json(sp, item)
+    with patch.object(sync_raw.clang_services, "upsert_issue_item", return_value=None):
+        with patch.object(
+            sync_raw, "save_issue_raw_source", side_effect=OSError("raw")
+        ):
+            assert sync_raw._promote_issue_staging("llvm", "llvm-project", sp, item) is False
+    assert sp.exists()
+
+
+@pytest.mark.django_db
+def test_promote_pr_raw_failure_keeps_staging(tmp_path):
+    sp = tmp_path / "p.json"
+    item = {
+        "number": 99,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+    }
+    sync_raw._write_staging_json(sp, item)
+    with patch.object(sync_raw.clang_services, "upsert_issue_item", return_value=None):
+        with patch.object(sync_raw, "save_pr_raw_source", side_effect=OSError("raw")):
+            assert sync_raw._promote_pr_staging("llvm", "llvm-project", sp, item) is False
+    assert sp.exists()
+
+
+@pytest.mark.django_db
+def test_promote_pr_db_failure_keeps_staging(tmp_path):
+    sp = tmp_path / "p.json"
+    item = {
+        "number": 8,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+    }
+    sync_raw._write_staging_json(sp, item)
+    with patch.object(
+        sync_raw.clang_services, "upsert_issue_item", side_effect=RuntimeError("db")
+    ):
+        assert sync_raw._promote_pr_staging("o", "r", sp, item) is False
+    assert sp.exists()
+
+
+@pytest.mark.django_db
 def test_promote_pr_success(tmp_path):
     sp = tmp_path / "p.json"
     item = {
@@ -196,3 +328,112 @@ def test_sync_propagates_connection_exception():
             ):
                 with pytest.raises(sync_raw.ConnectionException):
                     sync_raw.sync_clang_github_activity()
+
+
+@pytest.mark.django_db
+def test_sync_clang_github_activity_issues_and_prs_branches():
+    """Exercise PR/issue branches: string numbers, skips, and successful promotion."""
+
+    def fake_commits(*_a, **_k):
+        yield from ()
+
+    pr_item = {
+        "pr_info": {
+            "number": 12,
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-02T00:00:00Z",
+        },
+        "number": 12,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+    }
+    bad_pr = {"pr_info": {"number": None}}
+    bad_pr2 = {"pr_info": {"number": "x"}}
+    bad_pr3 = {"pr_info": {"number": True}}
+    issue_item = {
+        "issue_info": {
+            "number": 5,
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-02T00:00:00Z",
+        },
+        "number": 5,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+    }
+    bad_issue = {"issue_info": {"number": None}}
+    legacy_issue = {
+        "number": 9,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+    }
+
+    def fake_issues(*_a, **_k):
+        for x in (
+            bad_pr,
+            bad_pr2,
+            bad_pr3,
+            pr_item,
+            bad_issue,
+            issue_item,
+            legacy_issue,
+        ):
+            yield x
+
+    with patch.object(sync_raw, "get_github_client", return_value=MagicMock()):
+        with patch.object(
+            sync_raw, "process_pending_clang_staging", return_value=(0, [], [])
+        ):
+            with patch.object(
+                sync_raw.fetcher, "fetch_commits_from_github", fake_commits
+            ):
+                with patch.object(
+                    sync_raw.fetcher,
+                    "fetch_issues_and_prs_from_github",
+                    fake_issues,
+                ):
+                    with patch.object(sync_raw, "_write_staging_json"):
+                        with patch.object(
+                            sync_raw, "get_pr_json_path", return_value=Path("p.json")
+                        ):
+                            with patch.object(
+                                sync_raw, "get_issue_json_path", return_value=Path(
+                                    "i.json"
+                                )
+                            ):
+                                with patch.object(
+                                    sync_raw, "_promote_pr_staging", return_value=True
+                                ):
+                                    with patch.object(
+                                        sync_raw,
+                                        "_promote_issue_staging",
+                                        return_value=True,
+                                    ):
+                                        c, issues, prs = sync_raw.sync_clang_github_activity()
+    assert c == 0
+    assert 12 in prs
+    assert 5 in issues
+    assert 9 in issues
+
+
+@pytest.mark.django_db
+def test_sync_clang_skips_empty_sha_from_fetcher():
+    def fake_commits(*_a, **_k):
+        yield {"sha": "", "commit": {}}
+        yield {"sha": "   ", "commit": {}}
+
+    with patch.object(sync_raw, "get_github_client", return_value=MagicMock()):
+        with patch.object(
+            sync_raw, "process_pending_clang_staging", return_value=(0, [], [])
+        ):
+            with patch.object(
+                sync_raw.fetcher, "fetch_commits_from_github", fake_commits
+            ):
+                with patch.object(
+                    sync_raw.fetcher,
+                    "fetch_issues_and_prs_from_github",
+                    lambda *_a, **_k: iter(()),
+                ):
+                    with patch.object(sync_raw, "_write_staging_json") as w:
+                        c, _, _ = sync_raw.sync_clang_github_activity()
+    assert c == 0
+    assert w.call_count == 0

--- a/clang_github_tracker/tests/test_sync_raw.py
+++ b/clang_github_tracker/tests/test_sync_raw.py
@@ -265,7 +265,10 @@ def test_promote_issue_raw_failure_keeps_staging(tmp_path):
         with patch.object(
             sync_raw, "save_issue_raw_source", side_effect=OSError("raw")
         ):
-            assert sync_raw._promote_issue_staging("llvm", "llvm-project", sp, item) is False
+            assert (
+                sync_raw._promote_issue_staging("llvm", "llvm-project", sp, item)
+                is False
+            )
     assert sp.exists()
 
 
@@ -280,7 +283,9 @@ def test_promote_pr_raw_failure_keeps_staging(tmp_path):
     sync_raw._write_staging_json(sp, item)
     with patch.object(sync_raw.clang_services, "upsert_issue_item", return_value=None):
         with patch.object(sync_raw, "save_pr_raw_source", side_effect=OSError("raw")):
-            assert sync_raw._promote_pr_staging("llvm", "llvm-project", sp, item) is False
+            assert (
+                sync_raw._promote_pr_staging("llvm", "llvm-project", sp, item) is False
+            )
     assert sp.exists()
 
 
@@ -396,9 +401,9 @@ def test_sync_clang_github_activity_issues_and_prs_branches():
                             sync_raw, "get_pr_json_path", return_value=Path("p.json")
                         ):
                             with patch.object(
-                                sync_raw, "get_issue_json_path", return_value=Path(
-                                    "i.json"
-                                )
+                                sync_raw,
+                                "get_issue_json_path",
+                                return_value=Path("i.json"),
                             ):
                                 with patch.object(
                                     sync_raw, "_promote_pr_staging", return_value=True
@@ -408,7 +413,9 @@ def test_sync_clang_github_activity_issues_and_prs_branches():
                                         "_promote_issue_staging",
                                         return_value=True,
                                     ):
-                                        c, issues, prs = sync_raw.sync_clang_github_activity()
+                                        c, issues, prs = (
+                                            sync_raw.sync_clang_github_activity()
+                                        )
     assert c == 0
     assert 12 in prs
     assert 5 in issues

--- a/clang_github_tracker/tests/test_workspace.py
+++ b/clang_github_tracker/tests/test_workspace.py
@@ -19,7 +19,7 @@ def test_sanitize_segment_via_get_raw_repo_dir_invalid():
 
 @patch("clang_github_tracker.workspace.get_workspace_path")
 def test_get_raw_root_creates_parents(mock_get_ws: MagicMock, tmp_path: Path):
-    app_dir = tmp_path / "gh"
+    _app_dir = tmp_path / "gh"
     mock_get_ws.return_value = tmp_path / "raw"
     root = ws.get_raw_root()
     assert root == tmp_path / "raw" / "github_activity_tracker"
@@ -27,9 +27,7 @@ def test_get_raw_root_creates_parents(mock_get_ws: MagicMock, tmp_path: Path):
 
 
 @patch("clang_github_tracker.workspace.get_workspace_path")
-def test_get_raw_repo_dir_create_false_no_mkdir(
-    mock_get_ws: MagicMock, tmp_path: Path
-):
+def test_get_raw_repo_dir_create_false_no_mkdir(mock_get_ws: MagicMock, tmp_path: Path):
     mock_get_ws.return_value = tmp_path / "raw"
     p = ws.get_raw_repo_dir("llvm", "llvm-project", create=False)
     assert p == tmp_path / "raw" / "github_activity_tracker" / "llvm" / "llvm-project"

--- a/clang_github_tracker/tests/test_workspace.py
+++ b/clang_github_tracker/tests/test_workspace.py
@@ -1,0 +1,46 @@
+"""Tests for clang_github_tracker.workspace."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clang_github_tracker import workspace as ws
+
+
+def test_sanitize_segment_via_get_raw_repo_dir_invalid():
+    with pytest.raises(ValueError, match="Invalid GitHub owner"):
+        ws.get_raw_repo_dir(owner="", repo="llvm-project", create=False)
+    with pytest.raises(ValueError, match="Invalid GitHub owner"):
+        ws.get_raw_repo_dir(owner="bad owner", repo="y", create=False)
+    with pytest.raises(ValueError, match="Invalid GitHub repo"):
+        ws.get_raw_repo_dir(owner="llvm", repo="bad/repo", create=False)
+
+
+@patch("clang_github_tracker.workspace.get_workspace_path")
+def test_get_raw_root_creates_parents(mock_get_ws: MagicMock, tmp_path: Path):
+    app_dir = tmp_path / "gh"
+    mock_get_ws.return_value = tmp_path / "raw"
+    root = ws.get_raw_root()
+    assert root == tmp_path / "raw" / "github_activity_tracker"
+    assert root.is_dir()
+
+
+@patch("clang_github_tracker.workspace.get_workspace_path")
+def test_get_raw_repo_dir_create_false_no_mkdir(
+    mock_get_ws: MagicMock, tmp_path: Path
+):
+    mock_get_ws.return_value = tmp_path / "raw"
+    p = ws.get_raw_repo_dir("llvm", "llvm-project", create=False)
+    assert p == tmp_path / "raw" / "github_activity_tracker" / "llvm" / "llvm-project"
+    assert not p.exists()
+
+
+@patch("clang_github_tracker.workspace.get_workspace_path")
+def test_get_raw_repo_dir_default_create_makes_dirs(
+    mock_get_ws: MagicMock, tmp_path: Path
+):
+    mock_get_ws.return_value = tmp_path / "raw"
+    p = ws.get_raw_repo_dir("llvm", "llvm-project")
+    assert p.is_dir()
+    assert p == tmp_path / "raw" / "github_activity_tracker" / "llvm" / "llvm-project"

--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -4,19 +4,32 @@ Imports base settings, then overrides for fast and isolated tests.
 """
 
 import os
+import sys
 from pathlib import Path
 
 from .settings import *  # noqa: F401, F403
 
-# Use SQLite in-memory for speed when DATABASE_URL not set (e.g. local pytest).
-# CI can set DATABASE_URL=sqlite:///test.sqlite3 or leave unset for :memory:
-if not os.environ.get("DATABASE_URL", "").strip():
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": ":memory:",
-        }
+_SQLITE_TEST_DB = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
     }
+}
+
+# Prefer SQLite for pytest so a developer .env DATABASE_URL (Docker Postgres) does not
+# require a running server. CI Postgres jobs set USE_POSTGRES_TESTS=1 so DATABASE_URL
+# still applies under pytest.
+_under_pytest = "pytest" in sys.modules
+_use_postgres_tests = os.environ.get("USE_POSTGRES_TESTS", "").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+)
+_want_sqlite = (not os.environ.get("DATABASE_URL", "").strip()) or (
+    _under_pytest and not _use_postgres_tests
+)
+if _want_sqlite:
+    DATABASES = _SQLITE_TEST_DB
 
 PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.MD5PasswordHasher",

--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -9,19 +9,17 @@ from pathlib import Path
 
 from .settings import *  # noqa: F401, F403
 
-# Use SQLite in-memory when DATABASE_URL is unset (typical local pytest).
-# GitHub Actions test job sets DATABASE_URL to the workflow's postgres service (see .github/workflows/actions.yml).
-if not os.environ.get("DATABASE_URL", "").strip():
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": ":memory:",
-        }
+# In-memory SQLite for fast, isolated tests when we are not targeting Postgres (see below).
+_SQLITE_TEST_DB = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
     }
+}
 
-# Prefer SQLite for pytest so a developer .env DATABASE_URL (Docker Postgres) does not
-# require a running server. CI Postgres jobs set USE_POSTGRES_TESTS=1 so DATABASE_URL
-# still applies under pytest.
+# Prefer SQLite when DATABASE_URL is unset, or under pytest without USE_POSTGRES_TESTS so a
+# developer .env DATABASE_URL (Docker Postgres) does not require a running server.
+# GitHub Actions Postgres jobs set USE_POSTGRES_TESTS=1 so DATABASE_URL still applies under pytest.
 _under_pytest = "pytest" in sys.modules
 _use_postgres_tests = os.environ.get("USE_POSTGRES_TESTS", "").strip().lower() in (
     "1",

--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -18,7 +18,6 @@ if not os.environ.get("DATABASE_URL", "").strip():
             "NAME": ":memory:",
         }
     }
-}
 
 # Prefer SQLite for pytest so a developer .env DATABASE_URL (Docker Postgres) does not
 # require a running server. CI Postgres jobs set USE_POSTGRES_TESTS=1 so DATABASE_URL

--- a/core/errors.py
+++ b/core/errors.py
@@ -90,6 +90,16 @@ _WIN_SOCK_WINERRORS: frozenset[int] = frozenset(
 )
 
 
+def _os_error_windows_code(exc: OSError) -> int | None:
+    """Windows code from ``exc.winerror``, or from ``exc.args[3]`` on POSIX (ignored slot)."""
+    win = getattr(exc, "winerror", None)
+    if isinstance(win, int):
+        return win
+    if len(exc.args) >= 4 and isinstance(exc.args[3], int):
+        return exc.args[3]
+    return None
+
+
 def _classify_os_error(exc: OSError) -> CollectorFailureCategory:
     """
     ``OSError`` spans sockets/pipes and filesystem/disk; only classify clear network
@@ -117,8 +127,8 @@ def _classify_os_error(exc: OSError) -> CollectorFailureCategory:
         if errno_val in _LOCAL_IO_ERRNOS:
             return CollectorFailureCategory.UNKNOWN
 
-    winerror = getattr(exc, "winerror", None)
-    if winerror is not None and winerror in _WIN_SOCK_WINERRORS:
+    win_code = _os_error_windows_code(exc)
+    if win_code is not None and win_code in _WIN_SOCK_WINERRORS:
         return CollectorFailureCategory.NETWORK
 
     return CollectorFailureCategory.UNKNOWN

--- a/core/tests/github_ops/test_git_ops_clone_errors.py
+++ b/core/tests/github_ops/test_git_ops_clone_errors.py
@@ -18,16 +18,23 @@ def fake_token():
 def test_clone_repo_timeout_reraises_with_redacted_cmd(
     mock_run, _mock_token, tmp_path, fake_token
 ):
+    dest = tmp_path / "dest"
     mock_run.side_effect = subprocess.TimeoutExpired(
-        cmd=["git", "clone", "x", str(tmp_path / "d")],
+        cmd=[
+            "git",
+            "clone",
+            f"https://x-access-token:{fake_token}@github.com/o/r.git",
+            str(dest),
+        ],
         timeout=1,
         output="out",
         stderr="err",
     )
-    dest = tmp_path / "dest"
     with pytest.raises(subprocess.TimeoutExpired) as ei:
         git_ops.clone_repo("https://github.com/o/r.git", dest, token=fake_token)
-    assert fake_token not in str(ei.value.cmd)
+    cmd_joined = " ".join(map(str, ei.value.cmd))
+    assert fake_token not in cmd_joined
+    assert "https://github.com/o/r.git" in ei.value.cmd[2]
 
 
 @patch("core.operations.github_ops.git_ops.get_github_token", return_value="tok")
@@ -35,14 +42,26 @@ def test_clone_repo_timeout_reraises_with_redacted_cmd(
 def test_clone_repo_called_process_error_reraises_sanitized_stderr(
     mock_run, _mock_token, tmp_path, fake_token
 ):
+    dest = tmp_path / "dest2"
     mock_run.side_effect = subprocess.CalledProcessError(
         1,
-        ["git", "clone"],
+        [
+            "git",
+            "clone",
+            f"https://x-access-token:{fake_token}@github.com/o/r.git",
+            str(dest),
+            "--depth",
+            "1",
+        ],
         output=None,
-        stderr=f"fatal: auth failed x-access-token:{fake_token}\n",
+        stderr=(
+            f"fatal: unable to access "
+            f"'https://x-access-token:{fake_token}@github.com/o/r.git/': denied\n"
+        ),
     )
-    dest = tmp_path / "dest2"
     with pytest.raises(subprocess.CalledProcessError) as ei:
         git_ops.clone_repo("o/r", dest, token=fake_token, depth=1)
-    assert fake_token not in " ".join(ei.value.cmd)
-    assert "--depth" in " ".join(ei.value.cmd)
+    cmd_joined = " ".join(map(str, ei.value.cmd))
+    assert fake_token not in cmd_joined
+    assert fake_token not in (ei.value.stderr or "")
+    assert "--depth" in cmd_joined

--- a/core/tests/github_ops/test_git_ops_clone_errors.py
+++ b/core/tests/github_ops/test_git_ops_clone_errors.py
@@ -1,0 +1,49 @@
+"""Tests for clone_repo error paths (timeout / failure) with redacted exceptions."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from core.operations.github_ops import git_ops
+
+
+@pytest.fixture
+def fake_token():
+    return "ghp_super_secret_do_not_leak"
+
+
+@patch("core.operations.github_ops.git_ops.get_github_token", return_value="tok")
+@patch("core.operations.github_ops.git_ops.subprocess.run")
+def test_clone_repo_timeout_reraises_with_redacted_cmd(
+    mock_run, _mock_token, tmp_path, fake_token
+):
+    mock_run.side_effect = subprocess.TimeoutExpired(
+        cmd=["git", "clone", "x", str(tmp_path / "d")],
+        timeout=1,
+        output="out",
+        stderr="err",
+    )
+    dest = tmp_path / "dest"
+    with pytest.raises(subprocess.TimeoutExpired) as ei:
+        git_ops.clone_repo("https://github.com/o/r.git", dest, token=fake_token)
+    assert fake_token not in str(ei.value.cmd)
+
+
+@patch("core.operations.github_ops.git_ops.get_github_token", return_value="tok")
+@patch("core.operations.github_ops.git_ops.subprocess.run")
+def test_clone_repo_called_process_error_reraises_sanitized_stderr(
+    mock_run, _mock_token, tmp_path, fake_token
+):
+    mock_run.side_effect = subprocess.CalledProcessError(
+        1,
+        ["git", "clone"],
+        output=None,
+        stderr=f"fatal: auth failed x-access-token:{fake_token}\n",
+    )
+    dest = tmp_path / "dest2"
+    with pytest.raises(subprocess.CalledProcessError) as ei:
+        git_ops.clone_repo("o/r", dest, token=fake_token, depth=1)
+    assert fake_token not in " ".join(ei.value.cmd)
+    assert "--depth" in " ".join(ei.value.cmd)

--- a/core/tests/github_ops/test_git_ops_clone_errors.py
+++ b/core/tests/github_ops/test_git_ops_clone_errors.py
@@ -10,7 +10,7 @@ from core.operations.github_ops import git_ops
 
 @pytest.fixture
 def fake_token():
-    return "ghp_super_secret_do_not_leak"
+    return "fake_token_for_redaction_tests_only"
 
 
 @patch("core.operations.github_ops.git_ops.get_github_token", return_value="tok")

--- a/core/tests/github_ops/test_git_ops_clone_errors.py
+++ b/core/tests/github_ops/test_git_ops_clone_errors.py
@@ -1,7 +1,6 @@
 """Tests for clone_repo error paths (timeout / failure) with redacted exceptions."""
 
 import subprocess
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest

--- a/core/tests/github_ops/test_git_ops_list_remote_directory.py
+++ b/core/tests/github_ops/test_git_ops_list_remote_directory.py
@@ -47,9 +47,7 @@ def test_list_remote_directory_graphql_builds_paths(mock_session_cls):
     mock_sess.post.return_value = mock_resp
     mock_session_cls.return_value = mock_sess
 
-    out = git_ops._list_remote_directory_graphql(
-        "o", "r", "main", "issues/2024", "tok"
-    )
+    out = git_ops._list_remote_directory_graphql("o", "r", "main", "issues/2024", "tok")
     assert out == ["issues/2024/f.md"]
 
 
@@ -57,7 +55,9 @@ def test_list_remote_directory_graphql_builds_paths(mock_session_cls):
 def test_list_remote_directory_graphql_root_prefix(mock_session_cls):
     mock_resp = MagicMock()
     mock_resp.json.return_value = {
-        "data": {"repository": {"object": {"entries": [{"name": "README", "type": "blob"}]}}},
+        "data": {
+            "repository": {"object": {"entries": [{"name": "README", "type": "blob"}]}}
+        },
     }
     mock_resp.raise_for_status = MagicMock()
     mock_sess = MagicMock()
@@ -88,23 +88,3 @@ def test_list_remote_directory_graphql_missing_object(mock_session_cls):
     mock_sess.post.return_value = mock_resp
     mock_session_cls.return_value = mock_sess
     assert git_ops._list_remote_directory_graphql("o", "r", "main", "p", "tok") == []
-
-
-@patch(
-    "core.operations.github_ops.git_ops._list_remote_directory_graphql",
-    return_value=["issues/2024/x.md"],
-)
-def test_list_remote_directory_returns_paths(_mock_gql):
-    out = git_ops.list_remote_directory(
-        "boostorg", "boost", "master", "issues/2024", token="tok"
-    )
-    assert out == ["issues/2024/x.md"]
-
-
-@patch(
-    "core.operations.github_ops.git_ops._list_remote_directory_graphql",
-    side_effect=RuntimeError("graphql failed"),
-)
-@patch("core.operations.github_ops.git_ops.get_github_token", return_value="tok")
-def test_list_remote_directory_swallows_exceptions(_mock_token, _mock_gql):
-    assert git_ops.list_remote_directory("o", "r", "main", "src") == []

--- a/core/tests/github_ops/test_git_ops_list_remote_directory.py
+++ b/core/tests/github_ops/test_git_ops_list_remote_directory.py
@@ -1,0 +1,110 @@
+"""Tests for git_ops.list_remote_directory."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.operations.github_ops import git_ops
+
+
+@patch(
+    "core.operations.github_ops.git_ops._list_remote_directory_graphql",
+    return_value=["issues/2024/x.md"],
+)
+def test_list_remote_directory_returns_paths(_mock_gql):
+    out = git_ops.list_remote_directory(
+        "boostorg", "boost", "master", "issues/2024", token="tok"
+    )
+    assert out == ["issues/2024/x.md"]
+
+
+@patch(
+    "core.operations.github_ops.git_ops._list_remote_directory_graphql",
+    side_effect=RuntimeError("graphql failed"),
+)
+@patch("core.operations.github_ops.git_ops.get_github_token", return_value="tok")
+def test_list_remote_directory_swallows_exceptions(_mock_token, _mock_gql):
+    assert git_ops.list_remote_directory("o", "r", "main", "src") == []
+
+
+@patch("core.operations.github_ops.git_ops.requests.Session")
+def test_list_remote_directory_graphql_builds_paths(mock_session_cls):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "data": {
+            "repository": {
+                "object": {
+                    "entries": [
+                        {"name": "f.md", "type": "blob"},
+                        {"name": "sub", "type": "tree"},
+                    ],
+                },
+            },
+        },
+    }
+    mock_resp.raise_for_status = MagicMock()
+    mock_sess = MagicMock()
+    mock_sess.post.return_value = mock_resp
+    mock_session_cls.return_value = mock_sess
+
+    out = git_ops._list_remote_directory_graphql(
+        "o", "r", "main", "issues/2024", "tok"
+    )
+    assert out == ["issues/2024/f.md"]
+
+
+@patch("core.operations.github_ops.git_ops.requests.Session")
+def test_list_remote_directory_graphql_root_prefix(mock_session_cls):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "data": {"repository": {"object": {"entries": [{"name": "README", "type": "blob"}]}}},
+    }
+    mock_resp.raise_for_status = MagicMock()
+    mock_sess = MagicMock()
+    mock_sess.post.return_value = mock_resp
+    mock_session_cls.return_value = mock_sess
+    out = git_ops._list_remote_directory_graphql("o", "r", "main", "", "tok")
+    assert out == ["README"]
+
+
+@patch("core.operations.github_ops.git_ops.requests.Session")
+def test_list_remote_directory_graphql_errors_raise(mock_session_cls):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"errors": [{"message": "bad query"}]}
+    mock_resp.raise_for_status = MagicMock()
+    mock_sess = MagicMock()
+    mock_sess.post.return_value = mock_resp
+    mock_session_cls.return_value = mock_sess
+    with pytest.raises(RuntimeError, match="bad query"):
+        git_ops._list_remote_directory_graphql("o", "r", "main", "p", "tok")
+
+
+@patch("core.operations.github_ops.git_ops.requests.Session")
+def test_list_remote_directory_graphql_missing_object(mock_session_cls):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"data": {"repository": {"object": None}}}
+    mock_resp.raise_for_status = MagicMock()
+    mock_sess = MagicMock()
+    mock_sess.post.return_value = mock_resp
+    mock_session_cls.return_value = mock_sess
+    assert git_ops._list_remote_directory_graphql("o", "r", "main", "p", "tok") == []
+
+
+@patch(
+    "core.operations.github_ops.git_ops._list_remote_directory_graphql",
+    return_value=["issues/2024/x.md"],
+)
+def test_list_remote_directory_returns_paths(_mock_gql):
+    out = git_ops.list_remote_directory(
+        "boostorg", "boost", "master", "issues/2024", token="tok"
+    )
+    assert out == ["issues/2024/x.md"]
+
+
+@patch(
+    "core.operations.github_ops.git_ops._list_remote_directory_graphql",
+    side_effect=RuntimeError("graphql failed"),
+)
+@patch("core.operations.github_ops.git_ops.get_github_token", return_value="tok")
+def test_list_remote_directory_swallows_exceptions(_mock_token, _mock_gql):
+    assert git_ops.list_remote_directory("o", "r", "main", "src") == []

--- a/core/tests/github_ops/test_git_ops_session_wait.py
+++ b/core/tests/github_ops/test_git_ops_session_wait.py
@@ -3,7 +3,6 @@
 import time
 from unittest.mock import MagicMock
 
-import pytest
 
 from core.operations.github_ops import git_ops as go
 

--- a/core/tests/github_ops/test_git_ops_session_wait.py
+++ b/core/tests/github_ops/test_git_ops_session_wait.py
@@ -1,0 +1,58 @@
+"""Tests for git_ops worker session and GitHub 403 wait helper."""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.operations.github_ops import git_ops as go
+
+
+def test_get_worker_session_reuses_same_token():
+    go._thread_local.session = None  # type: ignore[attr-defined]
+    s1 = go._get_worker_session("same-token")
+    s2 = go._get_worker_session("same-token")
+    assert s1 is s2
+    assert "Authorization" in s1.headers
+
+
+def test_get_worker_session_new_session_when_token_changes():
+    go._thread_local.session = None  # type: ignore[attr-defined]
+    a = go._get_worker_session("token-a")
+    b = go._get_worker_session("token-b")
+    assert a is not b
+    assert "token-a" in a.headers["Authorization"]
+    assert "token-b" in b.headers["Authorization"]
+
+
+def _mock_resp(headers):
+    r = MagicMock()
+    r.headers = headers
+    return r
+
+
+def test_wait_seconds_403_rate_limit_reset_path():
+    future = int(time.time()) + 120
+    r = _mock_resp(
+        {"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": str(future)},
+    )
+    w = go._wait_seconds_for_github_403(r, attempt=0)
+    assert 1.0 <= w <= go._UPLOAD_FOLDER_403_MAX_SLEEP_SEC
+
+
+def test_wait_seconds_403_invalid_remaining_falls_through_to_retry_after():
+    r = _mock_resp({"X-RateLimit-Remaining": "nope", "Retry-After": "2"})
+    w = go._wait_seconds_for_github_403(r, attempt=0)
+    assert 1.0 <= w <= go._UPLOAD_FOLDER_403_MAX_SLEEP_SEC
+
+
+def test_wait_seconds_403_retry_after_invalid_falls_back_exponential():
+    r = _mock_resp({"Retry-After": "not-float"})
+    w = go._wait_seconds_for_github_403(r, attempt=2)
+    assert w >= 60.0
+
+
+def test_wait_seconds_403_retry_after_too_small_becomes_one():
+    r = _mock_resp({"Retry-After": "0.1"})
+    w = go._wait_seconds_for_github_403(r, attempt=0)
+    assert w >= 1.0

--- a/core/tests/github_ops/test_github_client_graphql_gitmodules.py
+++ b/core/tests/github_ops/test_github_client_graphql_gitmodules.py
@@ -41,7 +41,7 @@ def test_get_submodules_from_file_missing_returns_empty():
 def test_get_submodules_from_file_read_error_returns_empty(tmp_path):
     client = GitHubAPIClient("t")
     p = tmp_path / "gm"
-    p.write_text("[submodule \"a\"]\n", encoding="utf-8")
+    p.write_text('[submodule "a"]\n', encoding="utf-8")
     real_open = open
 
     def selective_open(name, *args, **kwargs):

--- a/core/tests/github_ops/test_github_client_graphql_gitmodules.py
+++ b/core/tests/github_ops/test_github_client_graphql_gitmodules.py
@@ -1,0 +1,67 @@
+"""Tests for GitHubAPIClient GraphQL and .gitmodules helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.operations.github_ops.client import GitHubAPIClient
+
+
+def test_graphql_request_returns_data():
+    client = GitHubAPIClient("t")
+    ok = MagicMock()
+    ok.status_code = 200
+    ok.json = MagicMock(return_value={"data": {"repository": {"id": "1"}}})
+    ok.raise_for_status = MagicMock()
+    client._do_request = MagicMock(return_value=ok)
+    client._raise_if_error_and_update_rate_limit = MagicMock()
+    out = client.graphql_request("query Q { __typename }")
+    assert out["data"]["repository"]["id"] == "1"
+
+
+def test_graphql_request_raises_on_errors_key():
+    client = GitHubAPIClient("t")
+    ok = MagicMock()
+    ok.status_code = 200
+    ok.json = MagicMock(
+        return_value={"errors": [{"message": "bad"}, {"message": "worse"}]}
+    )
+    ok.raise_for_status = MagicMock()
+    client._do_request = MagicMock(return_value=ok)
+    client._raise_if_error_and_update_rate_limit = MagicMock()
+    with pytest.raises(Exception, match="GraphQL errors"):
+        client.graphql_request("query { x }")
+
+
+def test_get_submodules_from_file_missing_returns_empty():
+    client = GitHubAPIClient("t")
+    assert client.get_submodules_from_file("/nonexistent/.gitmodules") == []
+
+
+def test_get_submodules_from_file_read_error_returns_empty(tmp_path):
+    client = GitHubAPIClient("t")
+    p = tmp_path / "gm"
+    p.write_text("[submodule \"a\"]\n", encoding="utf-8")
+    real_open = open
+
+    def selective_open(name, *args, **kwargs):
+        if str(name) == str(p):
+            raise OSError("disk")
+        return real_open(name, *args, **kwargs)
+
+    with patch("builtins.open", selective_open):
+        assert client.get_submodules_from_file(str(p)) == []
+
+
+def test_parse_gitmodules_via_local_file(tmp_path):
+    client = GitHubAPIClient("t")
+    content = """
+[submodule "libs/foo"]
+path = libs/foo
+url = ../foo.git
+"""
+    p = tmp_path / ".gitmodules"
+    p.write_text(content, encoding="utf-8")
+    out = client.get_submodules_from_file(str(p), default_owner="boostorg")
+    assert len(out) == 1
+    assert "foo" in out[0].get("repo_name", "")

--- a/core/tests/github_ops/test_github_client_pagination.py
+++ b/core/tests/github_ops/test_github_client_pagination.py
@@ -1,0 +1,102 @@
+"""Tests for GitHubAPIClient pagination helpers, raw GET, and validation."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.operations.github_ops.client import GitHubAPIClient
+
+
+def test_parse_link_next_extracts_url():
+    hdr = '<https://api.github.com/repos/o/r/issues?page=2>; rel="next"'
+    assert (
+        GitHubAPIClient._parse_link_next(hdr)
+        == "https://api.github.com/repos/o/r/issues?page=2"
+    )
+
+
+def test_parse_link_next_none_when_missing():
+    assert GitHubAPIClient._parse_link_next(None) is None
+    assert GitHubAPIClient._parse_link_next("<http://x>; rel=\"prev\"") is None
+
+
+def test_parse_link_rels_builds_dict():
+    hdr = (
+        '<https://api.github.com/a?page=2>; rel="next", '
+        '<https://api.github.com/a?page=10>; rel="last"'
+    )
+    d = GitHubAPIClient._parse_link_rels(hdr)
+    assert d["next"].endswith("page=2")
+    assert d["last"].endswith("page=10")
+
+
+def test_parse_link_rels_empty_header():
+    assert GitHubAPIClient._parse_link_rels("") == {}
+    assert GitHubAPIClient._parse_link_rels(None) == {}
+
+
+def test_validate_rest_pagination_url_rejects_non_https():
+    c = GitHubAPIClient("t")
+    with pytest.raises(ValueError, match="only https"):
+        c._validate_rest_pagination_url("http://api.github.com/repos/x")
+
+
+def test_validate_rest_pagination_url_rejects_wrong_host():
+    c = GitHubAPIClient("t")
+    with pytest.raises(ValueError, match="outside"):
+        c._validate_rest_pagination_url("https://evil.example/page")
+
+
+def test_validate_rest_pagination_url_rejects_relative():
+    c = GitHubAPIClient("t")
+    with pytest.raises(ValueError, match="missing host"):
+        c._validate_rest_pagination_url("/repos/foo")
+
+
+def test_rest_request_returns_empty_when_rest_get_returns_none():
+    c = GitHubAPIClient("t")
+    c._rest_get = MagicMock(return_value=(None, "etag"))
+    assert c.rest_request("/repos/o/r/issues") == {}
+
+
+def test_rest_raw_request_returns_none_when_no_response():
+    c = GitHubAPIClient("t")
+    c._do_request = MagicMock(return_value=None)
+    assert c.rest_raw_request("https://api.github.com/raw") is None
+
+
+def test_rest_request_with_link_empty_when_no_response():
+    c = GitHubAPIClient("t")
+    c._rest_get = MagicMock(return_value=(None, None))
+    data, next_url = c.rest_request_with_link("/repos/o/r/issues")
+    assert data == {}
+    assert next_url is None
+
+
+def test_rest_request_with_all_links_empty_when_no_response():
+    c = GitHubAPIClient("t")
+    c._rest_get = MagicMock(return_value=(None, None))
+    data, links = c.rest_request_with_all_links("/repos/o/r/issues")
+    assert data == {}
+    assert links == {}
+
+
+def test_rest_request_conditional_with_link_304_branch():
+    c = GitHubAPIClient("t")
+    c._rest_get = MagicMock(return_value=(None, 'W/"e"'))
+    data, etag, next_url = c.rest_request_conditional_with_link(
+        "/repos/o/r/issues", etag='W/"e"'
+    )
+    assert data is None
+    assert etag == 'W/"e"'
+    assert next_url is None
+
+
+def test_rest_request_conditional_with_all_links_304_branch():
+    c = GitHubAPIClient("t")
+    c._rest_get = MagicMock(return_value=(None, 'W/"x"'))
+    data, etag, links = c.rest_request_conditional_with_all_links(
+        "/repos/o/r/issues", etag='W/"x"'
+    )
+    assert data is None
+    assert links == {}

--- a/core/tests/github_ops/test_github_client_pagination.py
+++ b/core/tests/github_ops/test_github_client_pagination.py
@@ -17,7 +17,7 @@ def test_parse_link_next_extracts_url():
 
 def test_parse_link_next_none_when_missing():
     assert GitHubAPIClient._parse_link_next(None) is None
-    assert GitHubAPIClient._parse_link_next("<http://x>; rel=\"prev\"") is None
+    assert GitHubAPIClient._parse_link_next('<http://x>; rel="prev"') is None
 
 
 def test_parse_link_rels_builds_dict():

--- a/core/tests/github_ops/test_github_client_rate_limit.py
+++ b/core/tests/github_ops/test_github_client_rate_limit.py
@@ -75,7 +75,8 @@ def test_parse_rate_limit_wait_graphql_errors_in_200_body():
     client = GitHubAPIClient("t")
     r = _resp(200, {"errors": [{"message": "throttled"}]})
     wait = client._parse_rate_limit_wait(r)
-    assert wait is None or isinstance(wait, (int, float))
+    # Throttled GraphQL body without rate-limit headers falls through to None.
+    assert wait is None
 
 
 def test_parse_rate_limit_wait_200_json_decode_error():
@@ -94,7 +95,8 @@ def test_parse_rate_limit_wait_retry_after_http_date():
     client = GitHubAPIClient("t")
     r = _resp(429, headers={"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"})
     w = client._parse_rate_limit_wait(r)
-    assert w is None or w > 0
+    assert isinstance(w, (int, float))
+    assert w > 0
 
 
 def test_parse_rate_limit_wait_retry_after_invalid_then_x_ratelimit():
@@ -109,7 +111,8 @@ def test_parse_rate_limit_wait_retry_after_invalid_then_x_ratelimit():
         },
     )
     w = client._parse_rate_limit_wait(r)
-    assert w is not None and w >= 0
+    assert isinstance(w, int)
+    assert w > 0
 
 
 def test_parse_rate_limit_wait_non_403_429_returns_none():
@@ -125,9 +128,12 @@ def test_parse_rate_limit_remaining_nonzero_returns_none():
 
 def test_update_rate_limit_from_response_skips_invalid_int():
     client = GitHubAPIClient("t")
+    client.rate_limit_remaining = 77
+    client.rate_limit_reset_time = 88
     r = _resp(200, headers={"X-RateLimit-Remaining": "x", "X-RateLimit-Reset": "1"})
     client._update_rate_limit_from_response(r)
-    assert client.rate_limit_remaining is None or client.rate_limit_reset_time is None
+    assert client.rate_limit_remaining == 77
+    assert client.rate_limit_reset_time == 88
 
 
 def test_raise_if_error_http_error_propagates():

--- a/core/tests/github_ops/test_github_client_rate_limit.py
+++ b/core/tests/github_ops/test_github_client_rate_limit.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 
 from core.operations.github_ops.client import (
+    RATE_LIMIT_WAIT_SAFETY_MARGIN_SEC,
     ConnectionException,
     GitHubAPIClient,
     RateLimitException,
@@ -163,8 +164,9 @@ def test_handle_rate_limit_caps_wait_and_calls_check(monkeypatch):
         "core.operations.github_ops.client.time.sleep", lambda s: slept.append(s)
     )
     client._check_rate_limit = MagicMock(return_value=True)
-    client._handle_rate_limit(999_999, max_delay=10)
-    assert slept
+    max_delay = 10
+    client._handle_rate_limit(999_999, max_delay=max_delay)
+    assert slept == [max_delay + RATE_LIMIT_WAIT_SAFETY_MARGIN_SEC]
     client._check_rate_limit.assert_called_once()
 
 

--- a/core/tests/github_ops/test_github_client_rate_limit.py
+++ b/core/tests/github_ops/test_github_client_rate_limit.py
@@ -64,7 +64,9 @@ def test_check_rate_limit_connection_error_retries_then_raises():
 
 def test_check_rate_limit_request_exception_raises():
     client = GitHubAPIClient("t")
-    client.session.get = MagicMock(side_effect=requests.exceptions.RequestException("x"))
+    client.session.get = MagicMock(
+        side_effect=requests.exceptions.RequestException("x")
+    )
     with pytest.raises(requests.exceptions.RequestException):
         client._check_rate_limit()
 

--- a/core/tests/github_ops/test_github_client_rate_limit.py
+++ b/core/tests/github_ops/test_github_client_rate_limit.py
@@ -1,0 +1,197 @@
+"""Targeted tests for GitHubAPIClient rate limiting and _do_request internals."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from core.operations.github_ops.client import (
+    ConnectionException,
+    GitHubAPIClient,
+    RateLimitException,
+)
+
+
+def _resp(
+    status,
+    json_data=None,
+    headers=None,
+    json_side_effect=None,
+):
+    r = MagicMock()
+    r.status_code = status
+    r.headers = headers or {}
+    if json_side_effect is not None:
+        r.json = MagicMock(side_effect=json_side_effect)
+    else:
+        r.json = MagicMock(return_value=json_data if json_data is not None else {})
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def test_check_rate_limit_success_updates_state():
+    client = GitHubAPIClient("t")
+    payload = {
+        "resources": {
+            "core": {"remaining": 42, "reset": int(time.time()) + 3600},
+        },
+    }
+    client.session.get = MagicMock(return_value=_resp(200, payload))
+    assert client._check_rate_limit() is True
+    assert client.rate_limit_remaining == 42
+
+
+def test_check_rate_limit_zero_remaining_raises_when_reset_future():
+    client = GitHubAPIClient("t")
+    reset = int(time.time()) + 120
+    payload = {"resources": {"core": {"remaining": 0, "reset": reset}}}
+    client.session.get = MagicMock(return_value=_resp(200, payload))
+    with pytest.raises(RateLimitException, match="Rate limit exceeded"):
+        client._check_rate_limit()
+
+
+def test_check_rate_limit_connection_error_retries_then_raises():
+    from requests.exceptions import ConnectionError as ReqCE
+
+    client = GitHubAPIClient("t")
+    client.session.get = MagicMock(side_effect=ReqCE("down"))
+    with patch("core.operations.github_ops.client.time.sleep"):
+        with pytest.raises(ConnectionException, match="Connection error after"):
+            client._check_rate_limit()
+    assert client.session.get.call_count == 3
+
+
+def test_check_rate_limit_request_exception_raises():
+    client = GitHubAPIClient("t")
+    client.session.get = MagicMock(side_effect=requests.exceptions.RequestException("x"))
+    with pytest.raises(requests.exceptions.RequestException):
+        client._check_rate_limit()
+
+
+def test_parse_rate_limit_wait_graphql_errors_in_200_body():
+    client = GitHubAPIClient("t")
+    r = _resp(200, {"errors": [{"message": "throttled"}]})
+    wait = client._parse_rate_limit_wait(r)
+    assert wait is None or isinstance(wait, (int, float))
+
+
+def test_parse_rate_limit_wait_200_json_decode_error():
+    client = GitHubAPIClient("t")
+    r = _resp(200, json_side_effect=ValueError("bad json"))
+    assert client._parse_rate_limit_wait(r) is None
+
+
+def test_parse_rate_limit_wait_retry_after_int():
+    client = GitHubAPIClient("t")
+    r = _resp(429, headers={"Retry-After": "10"})
+    assert client._parse_rate_limit_wait(r) == 10
+
+
+def test_parse_rate_limit_wait_retry_after_http_date():
+    client = GitHubAPIClient("t")
+    r = _resp(429, headers={"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"})
+    w = client._parse_rate_limit_wait(r)
+    assert w is None or w > 0
+
+
+def test_parse_rate_limit_wait_retry_after_invalid_then_x_ratelimit():
+    client = GitHubAPIClient("t")
+    future = int(time.time()) + 500
+    r = _resp(
+        403,
+        headers={
+            "Retry-After": "not-a-number-or-date",
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": str(future),
+        },
+    )
+    w = client._parse_rate_limit_wait(r)
+    assert w is not None and w >= 0
+
+
+def test_parse_rate_limit_wait_non_403_429_returns_none():
+    client = GitHubAPIClient("t")
+    assert client._parse_rate_limit_wait(_resp(200, {})) is None
+
+
+def test_parse_rate_limit_remaining_nonzero_returns_none():
+    client = GitHubAPIClient("t")
+    r = _resp(403, headers={"X-RateLimit-Remaining": "5", "X-RateLimit-Reset": "1"})
+    assert client._parse_rate_limit_wait(r) is None
+
+
+def test_update_rate_limit_from_response_skips_invalid_int():
+    client = GitHubAPIClient("t")
+    r = _resp(200, headers={"X-RateLimit-Remaining": "x", "X-RateLimit-Reset": "1"})
+    client._update_rate_limit_from_response(r)
+    assert client.rate_limit_remaining is None or client.rate_limit_reset_time is None
+
+
+def test_raise_if_error_http_error_propagates():
+    client = GitHubAPIClient("t")
+    r = _resp(500)
+    err = requests.exceptions.HTTPError(response=r)
+    r.raise_for_status = MagicMock(side_effect=err)
+    with pytest.raises(requests.exceptions.HTTPError):
+        client._raise_if_error_and_update_rate_limit(r, "label")
+
+
+def test_raise_if_error_request_exception_propagates():
+    client = GitHubAPIClient("t")
+    r = MagicMock()
+    r.raise_for_status = MagicMock(
+        side_effect=requests.exceptions.RequestException("boom")
+    )
+    with pytest.raises(requests.exceptions.RequestException):
+        client._raise_if_error_and_update_rate_limit(r, "label")
+
+
+def test_handle_rate_limit_caps_wait_and_calls_check(monkeypatch):
+    client = GitHubAPIClient("t")
+    slept = []
+
+    monkeypatch.setattr(
+        "core.operations.github_ops.client.time.sleep", lambda s: slept.append(s)
+    )
+    client._check_rate_limit = MagicMock(return_value=True)
+    client._handle_rate_limit(999_999, max_delay=10)
+    assert slept
+    client._check_rate_limit.assert_called_once()
+
+
+def test_do_request_rate_limit_wait_then_success():
+    client = GitHubAPIClient("t")
+    ok = _resp(200, {"ok": True})
+    limited = _resp(429, headers={"Retry-After": "0", "X-RateLimit-Remaining": "0"})
+    client.session.request = MagicMock(side_effect=[limited, ok])
+    client._parse_rate_limit_wait = MagicMock(
+        side_effect=[1, None],
+    )
+    client._handle_rate_limit = MagicMock()
+    with patch("core.operations.github_ops.client.time.sleep"):
+        out = client._do_request(
+            "GET",
+            "https://api.github.com/x",
+            "/x",
+            allow_retry_on_5xx=True,
+            allow_retry_on_connection_errors=True,
+        )
+    assert out.status_code == 200
+
+
+def test_do_request_connection_retry_then_success():
+    from requests.exceptions import ConnectionError as ReqCE
+
+    client = GitHubAPIClient("t")
+    ok = _resp(200, {"a": 1})
+    client.session.request = MagicMock(side_effect=[ReqCE("x"), ok])
+    client._parse_rate_limit_wait = MagicMock(return_value=None)
+    with patch("core.operations.github_ops.client.time.sleep"):
+        out = client._do_request(
+            "GET",
+            "https://api.github.com/y",
+            "/y",
+            allow_retry_on_connection_errors=True,
+        )
+    assert out.json() == {"a": 1}

--- a/core/tests/github_ops/test_github_client_rest_mutations.py
+++ b/core/tests/github_ops/test_github_client_rest_mutations.py
@@ -99,7 +99,11 @@ def test_delete_file_calls_rest_delete_when_sha_present():
     c.get_file_sha = MagicMock(return_value="sha1")
     c.rest_delete = MagicMock(return_value={"commit": {}})
     c.delete_file("o", "r", "f.txt", "m", branch="dev")
-    assert c.rest_delete.called
+    c.get_file_sha.assert_called_once_with("o", "r", "f.txt", ref="dev")
+    c.rest_delete.assert_called_once_with(
+        "/repos/o/r/contents/f.txt",
+        json_data={"message": "m", "sha": "sha1", "branch": "dev"},
+    )
 
 
 def test_rest_request_url_with_all_links_hits_do_request():
@@ -109,11 +113,12 @@ def test_rest_request_url_with_all_links_hits_do_request():
         headers={"Link": '<https://api.github.com/repos/o/r?page=2>; rel="next"'},
     )
     c._rest_get_url = MagicMock(return_value=r)
-    data, links = c.rest_request_url_with_all_links(
-        "https://api.github.com/repos/o/r/issues?page=1"
-    )
+    start = "https://api.github.com/repos/o/r/issues?page=1"
+    data, links = c.rest_request_url_with_all_links(start)
     assert data == {"items": []}
-    assert "next" in links
+    assert links["next"] == "https://api.github.com/repos/o/r?page=2"
+    # Single GET only; callers follow ``links["next"]`` themselves (no auto-traverse).
+    c._rest_get_url.assert_called_once_with(start)
 
 
 def test_rest_request_url_returns_data_and_next():

--- a/core/tests/github_ops/test_github_client_rest_mutations.py
+++ b/core/tests/github_ops/test_github_client_rest_mutations.py
@@ -104,7 +104,10 @@ def test_delete_file_calls_rest_delete_when_sha_present():
 
 def test_rest_request_url_with_all_links_hits_do_request():
     c = GitHubAPIClient("t")
-    r = _ok_json({"items": []}, headers={"Link": '<https://api.github.com/repos/o/r?page=2>; rel="next"'})
+    r = _ok_json(
+        {"items": []},
+        headers={"Link": '<https://api.github.com/repos/o/r?page=2>; rel="next"'},
+    )
     c._rest_get_url = MagicMock(return_value=r)
     data, links = c.rest_request_url_with_all_links(
         "https://api.github.com/repos/o/r/issues?page=1"

--- a/core/tests/github_ops/test_github_client_rest_mutations.py
+++ b/core/tests/github_ops/test_github_client_rest_mutations.py
@@ -1,0 +1,138 @@
+"""Tests for GitHubAPIClient REST PUT/DELETE, file SHA, and paginated GET URL."""
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from core.operations.github_ops.client import GitHubAPIClient
+
+
+def _ok_json(data, status=200, headers=None):
+    r = MagicMock()
+    r.status_code = status
+    r.headers = headers or {}
+    r.json = MagicMock(return_value=data)
+    r.raise_for_status = MagicMock()
+    r.content = b"raw-bytes"
+    return r
+
+
+def test_rest_put_returns_json():
+    c = GitHubAPIClient("t")
+    r = _ok_json({"sha": "abc"})
+    c._do_request = MagicMock(return_value=r)
+    c._raise_if_error_and_update_rate_limit = MagicMock()
+    out = c.rest_put("/repos/o/r/contents/p", json_data={"message": "m"})
+    assert out["sha"] == "abc"
+
+
+def test_rest_delete_returns_none_on_204():
+    c = GitHubAPIClient("t")
+    r = MagicMock()
+    r.status_code = 204
+    r.headers = {}
+    r.json = MagicMock()
+    r.raise_for_status = MagicMock()
+    c._do_request = MagicMock(return_value=r)
+    c._raise_if_error_and_update_rate_limit = MagicMock()
+    assert c.rest_delete("/repos/o/r/contents/p", json_data={"message": "x"}) is None
+
+
+def test_rest_delete_returns_json_when_not_204():
+    c = GitHubAPIClient("t")
+    r = _ok_json({"id": 1}, status=200)
+    c._do_request = MagicMock(return_value=r)
+    c._raise_if_error_and_update_rate_limit = MagicMock()
+    assert c.rest_delete("/repos/o/r/git/refs/tags/t", json_data={})["id"] == 1
+
+
+def test_get_file_sha_returns_sha():
+    c = GitHubAPIClient("t")
+    c.rest_request = MagicMock(return_value={"sha": "deadbeef", "type": "file"})
+    assert c.get_file_sha("o", "r", "README.md") == "deadbeef"
+
+
+def test_get_file_sha_returns_none_for_directory_listing():
+    c = GitHubAPIClient("t")
+    c.rest_request = MagicMock(return_value=[{"name": "a"}])
+    assert c.get_file_sha("o", "r", "dir") is None
+
+
+def test_get_file_sha_returns_none_on_404():
+    c = GitHubAPIClient("t")
+    resp = MagicMock()
+    resp.status_code = 404
+    err = requests.exceptions.HTTPError(response=resp)
+    c.rest_request = MagicMock(side_effect=err)
+    assert c.get_file_sha("o", "r", "missing") is None
+
+
+def test_get_file_sha_re_raises_non_404():
+    c = GitHubAPIClient("t")
+    resp = MagicMock()
+    resp.status_code = 500
+    err = requests.exceptions.HTTPError(response=resp)
+    c.rest_request = MagicMock(side_effect=err)
+    with pytest.raises(requests.exceptions.HTTPError):
+        c.get_file_sha("o", "r", "x")
+
+
+def test_create_or_update_file_calls_rest_put():
+    c = GitHubAPIClient("t")
+    c.rest_put = MagicMock(return_value={"commit": {}})
+    c.create_or_update_file(
+        "o", "r", "f.txt", "Y29udGVudA==", "msg", branch="main", sha="old"
+    )
+    kw = c.rest_put.call_args[1]["json_data"]
+    assert kw["sha"] == "old"
+
+
+def test_delete_file_returns_none_when_no_sha():
+    c = GitHubAPIClient("t")
+    c.get_file_sha = MagicMock(return_value=None)
+    assert c.delete_file("o", "r", "gone.txt", "del") is None
+
+
+def test_delete_file_calls_rest_delete_when_sha_present():
+    c = GitHubAPIClient("t")
+    c.get_file_sha = MagicMock(return_value="sha1")
+    c.rest_delete = MagicMock(return_value={"commit": {}})
+    c.delete_file("o", "r", "f.txt", "m", branch="dev")
+    assert c.rest_delete.called
+
+
+def test_rest_request_url_with_all_links_hits_do_request():
+    c = GitHubAPIClient("t")
+    r = _ok_json({"items": []}, headers={"Link": '<https://api.github.com/repos/o/r?page=2>; rel="next"'})
+    c._rest_get_url = MagicMock(return_value=r)
+    data, links = c.rest_request_url_with_all_links(
+        "https://api.github.com/repos/o/r/issues?page=1"
+    )
+    assert data == {"items": []}
+    assert "next" in links
+
+
+def test_rest_request_url_returns_data_and_next():
+    c = GitHubAPIClient("t")
+    r = _ok_json(
+        [1, 2],
+        headers={"Link": '<https://api.github.com/next>; rel="next"'},
+    )
+    c._rest_get_url = MagicMock(return_value=r)
+    data, nxt = c.rest_request_url("https://api.github.com/repos/o/r/issues?per_page=1")
+    assert data == [1, 2]
+    assert nxt == "https://api.github.com/next"
+
+
+def test_rest_get_raises_http_error_from_raise_for_status():
+    c = GitHubAPIClient("t")
+    bad = MagicMock()
+    bad.status_code = 500
+    bad.headers = {}
+    bad.raise_for_status = MagicMock(
+        side_effect=requests.exceptions.HTTPError(response=bad)
+    )
+    c._do_request = MagicMock(return_value=bad)
+    with pytest.raises(requests.exceptions.HTTPError):
+        c._rest_get("/repos/o/r/issues")

--- a/core/tests/github_ops/test_github_client_submodules_tags.py
+++ b/core/tests/github_ops/test_github_client_submodules_tags.py
@@ -20,7 +20,7 @@ def test_list_contents_root_and_nested():
 
 def test_get_submodules_from_api_file():
     c = GitHubAPIClient("t")
-    raw = b"[submodule \"x\"]\npath = x\nurl = ../x.git\n"
+    raw = b'[submodule "x"]\npath = x\nurl = ../x.git\n'
     b64 = base64.b64encode(raw).decode("ascii")
     c.rest_request = MagicMock(
         return_value={"type": "file", "encoding": "base64", "content": b64}

--- a/core/tests/github_ops/test_github_client_submodules_tags.py
+++ b/core/tests/github_ops/test_github_client_submodules_tags.py
@@ -1,0 +1,104 @@
+"""Tests for GitHubAPIClient.get_submodules, list_contents, get_tag_sha, get_tag_published_at."""
+
+import base64
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from core.operations.github_ops.client import GitHubAPIClient
+
+
+def test_list_contents_root_and_nested():
+    c = GitHubAPIClient("t")
+    c.rest_request = MagicMock(side_effect=[[{"name": "a"}], {"name": "README"}])
+    assert c.list_contents("o", "r") == [{"name": "a"}]
+    assert c.list_contents("o", "r", path="src", ref="main") == {"name": "README"}
+    assert "/contents/src" in c.rest_request.call_args_list[1][0][0]
+
+
+def test_get_submodules_from_api_file():
+    c = GitHubAPIClient("t")
+    raw = b"[submodule \"x\"]\npath = x\nurl = ../x.git\n"
+    b64 = base64.b64encode(raw).decode("ascii")
+    c.rest_request = MagicMock(
+        return_value={"type": "file", "encoding": "base64", "content": b64}
+    )
+    out = c.get_submodules("boostorg", "boost")
+    assert len(out) == 1
+
+
+def test_get_submodules_api_returns_list():
+    c = GitHubAPIClient("t")
+    c.rest_request = MagicMock(return_value=[{"name": "wrong"}])
+    assert c.get_submodules("o", "r") == []
+
+
+def test_get_submodules_api_decode_error_returns_empty():
+    c = GitHubAPIClient("t")
+    c.rest_request = MagicMock(
+        return_value={"type": "file", "encoding": "base64", "content": "!!!"}
+    )
+    assert c.get_submodules("o", "r") == []
+
+
+def test_get_submodules_api_non_file_type():
+    c = GitHubAPIClient("t")
+    c.rest_request = MagicMock(return_value={"type": "symlink"})
+    assert c.get_submodules("o", "r") == []
+
+
+def test_get_submodules_api_404_returns_empty():
+    c = GitHubAPIClient("t")
+    resp = MagicMock(status_code=404)
+    err = requests.exceptions.HTTPError(response=resp)
+    c.rest_request = MagicMock(side_effect=err)
+    assert c.get_submodules("o", "r") == []
+
+
+def test_get_submodules_api_other_http_error_raises():
+    c = GitHubAPIClient("t")
+    resp = MagicMock(status_code=500)
+    err = requests.exceptions.HTTPError(response=resp)
+    c.rest_request = MagicMock(side_effect=err)
+    with pytest.raises(requests.exceptions.HTTPError):
+        c.get_submodules("o", "r")
+
+
+def test_get_submodules_generic_exception_returns_empty():
+    c = GitHubAPIClient("t")
+    c.rest_request = MagicMock(side_effect=RuntimeError("boom"))
+    assert c.get_submodules("o", "r") == []
+
+
+def test_get_tag_sha_none_when_empty_response():
+    c = GitHubAPIClient("t")
+    c.rest_request = MagicMock(return_value={})
+    assert c.get_tag_sha("o", "r", "v1") is None
+
+
+def test_get_tag_sha_returns_object_sha():
+    c = GitHubAPIClient("t")
+    c.rest_request = MagicMock(
+        return_value={"object": {"sha": "abc", "type": "commit"}}
+    )
+    assert c.get_tag_sha("o", "r", "v1") == "abc"
+
+
+def test_get_tag_published_at_none_when_no_author():
+    c = GitHubAPIClient("t")
+    c.rest_request = MagicMock(return_value={"commit": {}})
+    assert c.get_tag_published_at("o", "r", "sha1") is None
+
+
+def test_get_tag_published_at_parses_date():
+    c = GitHubAPIClient("t")
+    c.rest_request = MagicMock(
+        return_value={
+            "author": {"date": "2020-01-15T10:00:00Z"},
+        }
+    )
+    dt = c.get_tag_published_at("o", "r", "sha1")
+    assert isinstance(dt, datetime)
+    assert dt.tzinfo is None or dt.tzinfo == timezone.utc

--- a/core/tests/operations/test_github_export.py
+++ b/core/tests/operations/test_github_export.py
@@ -106,9 +106,7 @@ def test_detect_stale_titled_paths_at_repo_root_skips_non_md(tmp_path: Path):
     new_md = tmp_path / "#3 - New title.md"
     new_md.write_text("b", encoding="utf-8")
     (tmp_path / "notes.txt").write_text("x", encoding="utf-8")
-    stale = detect_stale_titled_paths(
-        tmp_path, {"#3 - New title.md": str(new_md)}
-    )
+    stale = detect_stale_titled_paths(tmp_path, {"#3 - New title.md": str(new_md)})
     assert stale == ["#3 - Old title.md"]
 
 

--- a/core/tests/operations/test_github_export.py
+++ b/core/tests/operations/test_github_export.py
@@ -49,6 +49,14 @@ def test_detect_renames_from_dirs_non_numbered_md_ignored(
     assert detect_renames_from_dirs("o", "r", "main", new_files, token="t") == []
 
 
+@patch("core.operations.md_ops.github_export.list_remote_directory")
+def test_detect_renames_from_dirs_repo_root_relative_paths(mock_list_remote: MagicMock):
+    mock_list_remote.return_value = ["#2 - Old title.md"]
+    new_files = {"#2 - New title.md": "/tmp/x"}
+    out = detect_renames_from_dirs("o", "r", "main", new_files, token="t")
+    assert out == ["#2 - Old title.md"]
+
+
 def test_detect_renames_success_matches_tree():
     """detect_renames uses same semantics as directory listing."""
     tree = [
@@ -91,6 +99,17 @@ def test_detect_stale_titled_paths_missing_month_dir(tmp_path: Path):
 
 def test_detect_stale_titled_paths_empty_new_files(tmp_path: Path):
     assert detect_stale_titled_paths(tmp_path, {}) == []
+
+
+def test_detect_stale_titled_paths_at_repo_root_skips_non_md(tmp_path: Path):
+    (tmp_path / "#3 - Old title.md").write_text("a", encoding="utf-8")
+    new_md = tmp_path / "#3 - New title.md"
+    new_md.write_text("b", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("x", encoding="utf-8")
+    stale = detect_stale_titled_paths(
+        tmp_path, {"#3 - New title.md": str(new_md)}
+    )
+    assert stale == ["#3 - Old title.md"]
 
 
 def test_detect_stale_titled_paths_union_two_dirs(tmp_path: Path):

--- a/core/tests/operations/test_github_export_edges.py
+++ b/core/tests/operations/test_github_export_edges.py
@@ -1,0 +1,40 @@
+"""Extra branch coverage for github_export helpers."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from core.operations.md_ops import github_export as ge
+
+
+def test_detect_renames_skips_blob_with_empty_path():
+    tree = [
+        {"type": "blob", "path": ""},
+        {"type": "tree", "path": "issues/2024/2024-01"},
+    ]
+    new_files = {"issues/2024/2024-01/#1 - New.md": "/x"}
+    assert ge.detect_renames(tree, new_files) == []
+
+
+def test_detect_stale_titled_paths_skips_dot_git_and_dotfiles(tmp_path: Path):
+    month = tmp_path / "issues" / "2024" / "2024-03"
+    month.mkdir(parents=True)
+    (month / "#1 - Old.md").write_text("x", encoding="utf-8")
+    (month / ".hidden.md").write_text("x", encoding="utf-8")
+    gitdir = month / ".git"
+    gitdir.mkdir()
+    (gitdir / "config").write_text("[core]\n", encoding="utf-8")
+    new_files = {"issues/2024/2024-03/#1 - New.md": str(month / "#1 - New.md")}
+    stale = ge.detect_stale_titled_paths(tmp_path, new_files)
+    assert stale == ["issues/2024/2024-03/#1 - Old.md"]
+
+
+def test_parse_dt_non_string_returns_none():
+    assert ge._parse_dt(None) is None
+    assert ge._parse_dt(123) is None
+
+
+def test_md_path_converts_timezone_aware_created_at_to_utc_date_parts(tmp_path: Path):
+    dt = datetime(2024, 6, 30, 21, 0, tzinfo=timezone(timedelta(hours=-5)))
+    p = ge._md_path(tmp_path, "", "issues", dt, 3, "Title")
+    rel = p.relative_to(tmp_path).as_posix()
+    assert "2024-07" in rel

--- a/core/tests/operations/test_github_export_write_md.py
+++ b/core/tests/operations/test_github_export_write_md.py
@@ -62,7 +62,9 @@ def test_write_md_files_writes_issue_and_pr(
         folder_prefix="boost",
     )
     assert len(mapping) == 2
-    issue_md = out_root / "boost" / "issues" / "2024" / "2024-02" / "#7 - Unsafe chars.md"
+    issue_md = (
+        out_root / "boost" / "issues" / "2024" / "2024-02" / "#7 - Unsafe chars.md"
+    )
     pr_md = (
         out_root / "boost" / "pull_requests" / "2024" / "2024-02" / "#3 - PR title.md"
     )

--- a/core/tests/operations/test_github_export_write_md.py
+++ b/core/tests/operations/test_github_export_write_md.py
@@ -1,0 +1,180 @@
+"""Tests for core.operations.md_ops.github_export.write_md_files and helpers."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from core.operations.md_ops.github_export import write_md_files
+
+
+def _minimal_issue(number: int = 7) -> dict:
+    return {
+        "issue_info": {
+            "number": number,
+            "title": 'Unsafe /:*?"<>|chars',
+            "state": "open",
+            "user": {"login": "alice"},
+            "created_at": "2024-02-10T08:00:00Z",
+            "updated_at": "2024-02-10T09:00:00Z",
+            "html_url": f"https://github.com/o/r/issues/{number}",
+            "body": "Body.",
+        },
+        "comments": [],
+    }
+
+
+def _minimal_pr(number: int = 3) -> dict:
+    return {
+        "pr_info": {
+            "number": number,
+            "title": "PR title",
+            "state": "open",
+            "user": {"login": "bob"},
+            "created_at": "2024-02-11T12:00:00+00:00",
+            "updated_at": "2024-02-11T12:00:00+00:00",
+            "html_url": f"https://github.com/o/r/pull/{number}",
+            "body": "PR body.",
+        },
+        "comments": [],
+    }
+
+
+@patch("core.operations.md_ops.github_export.get_raw_source_issue_path")
+@patch("core.operations.md_ops.github_export.get_raw_source_pr_path")
+def test_write_md_files_writes_issue_and_pr(
+    mock_pr_path, mock_issue_path, tmp_path: Path
+):
+    issue_file = tmp_path / "raw_issue.json"
+    pr_file = tmp_path / "raw_pr.json"
+    issue_file.write_text(json.dumps(_minimal_issue(7)), encoding="utf-8")
+    pr_file.write_text(json.dumps(_minimal_pr(3)), encoding="utf-8")
+    mock_issue_path.return_value = issue_file
+    mock_pr_path.return_value = pr_file
+
+    out_root = tmp_path / "export"
+    out_root.mkdir()
+    mapping = write_md_files(
+        "owner",
+        "repo",
+        issue_numbers=[7],
+        pr_numbers=[3],
+        output_dir=out_root,
+        folder_prefix="boost",
+    )
+    assert len(mapping) == 2
+    issue_md = out_root / "boost" / "issues" / "2024" / "2024-02" / "#7 - Unsafe chars.md"
+    pr_md = (
+        out_root / "boost" / "pull_requests" / "2024" / "2024-02" / "#3 - PR title.md"
+    )
+    assert issue_md.is_file()
+    assert pr_md.is_file()
+    body = issue_md.read_text(encoding="utf-8")
+    assert "# #7 -" in body
+    assert "Body." in body
+
+
+@patch("core.operations.md_ops.github_export.get_raw_source_issue_path")
+def test_write_md_files_skips_missing_raw(mock_issue_path, tmp_path: Path):
+    missing = tmp_path / "nope.json"
+    mock_issue_path.return_value = missing
+    out_root = tmp_path / "out"
+    out_root.mkdir()
+    assert write_md_files("o", "r", [99], [], out_root) == {}
+
+
+@patch("core.operations.md_ops.github_export.get_raw_source_issue_path")
+def test_write_md_files_skips_invalid_json(mock_issue_path, tmp_path: Path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{", encoding="utf-8")
+    mock_issue_path.return_value = bad
+    out_root = tmp_path / "out2"
+    out_root.mkdir()
+    assert write_md_files("o", "r", [1], [], out_root) == {}
+
+
+@patch("core.operations.md_ops.github_export.get_raw_source_issue_path")
+def test_write_md_files_uses_fallback_title_and_naive_created_at(
+    mock_issue_path, tmp_path: Path
+):
+    data = {
+        "issue_info": {
+            "number": 5,
+            "title": "",
+            "state": "open",
+            "user": {"login": "u"},
+            "created_at": "not-iso",
+            "body": "",
+        },
+        "comments": [],
+    }
+    f = tmp_path / "i.json"
+    f.write_text(json.dumps(data), encoding="utf-8")
+    mock_issue_path.return_value = f
+    out_root = tmp_path / "out3"
+    out_root.mkdir()
+    write_md_files("o", "r", [5], [], out_root, folder_prefix="")
+    written = list(out_root.rglob("*.md"))
+    assert len(written) == 1
+    assert "issue-5" in written[0].name
+
+
+@patch("core.operations.md_ops.github_export.get_raw_source_issue_path")
+def test_write_md_files_write_failure_logged(mock_issue_path, tmp_path: Path):
+    data = _minimal_issue(2)
+    f = tmp_path / "ok.json"
+    f.write_text(json.dumps(data), encoding="utf-8")
+    mock_issue_path.return_value = f
+    out_root = tmp_path / "out4"
+    out_root.mkdir()
+
+    def boom(*_a, **_k):
+        raise OSError("disk full")
+
+    with patch.object(Path, "write_text", side_effect=boom):
+        assert write_md_files("o", "r", [2], [], out_root) == {}
+
+
+@patch("core.operations.md_ops.github_export.get_raw_source_pr_path")
+def test_write_md_files_pr_write_failure(mock_pr_path, tmp_path: Path):
+    data = {
+        "pr_info": {
+            "number": 9,
+            "title": "PR",
+            "state": "open",
+            "user": {"login": "u"},
+            "created_at": "2024-02-11T12:00:00Z",
+            "body": "",
+        },
+        "comments": [],
+    }
+    f = tmp_path / "pr.json"
+    f.write_text(json.dumps(data), encoding="utf-8")
+    mock_pr_path.return_value = f
+    out_root = tmp_path / "out5"
+    out_root.mkdir()
+
+    def boom(*_a, **_k):
+        raise OSError("write fail")
+
+    with patch.object(Path, "write_text", side_effect=boom):
+        assert write_md_files("o", "r", [], [9], out_root) == {}
+
+
+@patch("core.operations.md_ops.github_export.get_raw_source_pr_path")
+def test_write_md_files_skips_pr_when_raw_json_missing(mock_pr_path, tmp_path: Path):
+    raw = MagicMock()
+    raw.exists.return_value = False
+    mock_pr_path.return_value = raw
+    out_root = tmp_path / "out_missing_pr"
+    out_root.mkdir()
+    assert write_md_files("ow", "rp", [], [3], out_root) == {}
+
+
+@patch("core.operations.md_ops.github_export.get_raw_source_pr_path")
+def test_write_md_files_skips_pr_when_json_invalid(mock_pr_path, tmp_path: Path):
+    f = tmp_path / "bad_pr.json"
+    f.write_text("{", encoding="utf-8")
+    mock_pr_path.return_value = f
+    out_root = tmp_path / "out_bad_pr"
+    out_root.mkdir()
+    assert write_md_files("ow", "rp", [], [3], out_root) == {}

--- a/core/tests/operations/test_md_ops.py
+++ b/core/tests/operations/test_md_ops.py
@@ -62,6 +62,30 @@ def test_issue_json_to_md_closed():
     assert "> Closed at: 2024-01-02 12:00:00 UTC" in md
 
 
+def test_issue_json_to_md_comment_includes_updated_at_when_different():
+    data = {
+        "issue_info": {
+            "number": 1,
+            "title": "T",
+            "state": "open",
+            "user": {"login": "a"},
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z",
+            "body": "",
+        },
+        "comments": [
+            {
+                "user": {"login": "b"},
+                "created_at": "2024-01-02T10:00:00Z",
+                "updated_at": "2024-01-02T11:00:00Z",
+                "body": "Edited reply.",
+            },
+        ],
+    }
+    md = issue_json_to_md(data)
+    assert "> Updated at: 2024-01-02 11:00:00 UTC" in md
+
+
 def test_issue_json_to_md_with_comments():
     """Issue with comments includes Comment 1, Comment 2 sections."""
     data = {

--- a/core/tests/operations/test_pr_to_md_helpers.py
+++ b/core/tests/operations/test_pr_to_md_helpers.py
@@ -19,6 +19,23 @@ def test_parse_diff_hunk_header_and_get_last_n_lines():
     assert m._parse_diff_hunk_header("@@ -5 +7 @@")[0] == 5
 
 
+def test_parse_diff_hunk_header_no_match_returns_default():
+    assert m._parse_diff_hunk_header("no hunk here") == (1, 1)
+
+
+def test_get_last_n_lines_empty_input():
+    assert m.get_last_n_lines("", n=3) == ""
+
+
+def test_get_last_n_lines_only_headers_yields_empty():
+    assert m.get_last_n_lines("@@ -1 +1 @@\n", n=2) == ""
+
+
+def test_parse_plus_lines_with_numbers_empty():
+    assert m._parse_plus_lines_with_numbers("") == []
+    assert m._parse_plus_lines_with_numbers("   ") == []
+
+
 def test_build_comment_tree():
     comments = [
         {"id": 1, "body": "root"},

--- a/core/tests/operations/test_slack_fetcher.py
+++ b/core/tests/operations/test_slack_fetcher.py
@@ -230,6 +230,16 @@ def test_update_tokens_in_env_updates_existing(tmp_path, monkeypatch):
     assert "newc" in text and "newd" in text
 
 
+def test_update_tokens_in_env_appends_missing_xoxc(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = tmp_path / ".env"
+    env.write_text("SLACK_XOXD_TOKEN=oldd\nOTHER=1\n", encoding="utf-8")
+    _update_tokens_in_env("xc", "xd")
+    text = env.read_text(encoding="utf-8")
+    assert "SLACK_XOXC_TOKEN=xc" in text
+    assert "SLACK_XOXD_TOKEN=xd" in text
+
+
 @override_settings(SLACK_XOXC_TOKEN="xc", SLACK_XOXD_TOKEN="xd")
 @patch("core.operations.slack_ops.fetcher.requests.post")
 @patch("core.operations.slack_ops.fetcher.get_default_team_key", return_value="T1")
@@ -304,6 +314,15 @@ def test_download_file_generic_exception(mock_get, tmp_path):
     assert f.download_file("https://x", save_path=str(tmp_path)) is None
 
 
+@patch("core.operations.slack_ops.fetcher.requests.get")
+def test_download_file_zero_max_retries_returns_none_without_request(
+    mock_get, tmp_path
+):
+    f = SlackFetcher(bot_token="tok")
+    assert f.download_file("https://x", save_path=str(tmp_path), max_retries=0) is None
+    mock_get.assert_not_called()
+
+
 def test_get_file_and_download_when_get_file_info_fails():
     f = SlackFetcher(bot_token="t")
     with patch.object(f, "get_file_info", return_value=None):
@@ -368,6 +387,14 @@ def test_fetch_huddle_missing_tokens_and_no_team(_mock_team):
 @patch("core.operations.slack_ops.fetcher.get_default_team_key", return_value="T1")
 def test_fetch_huddle_extract_returns_invalid(mock_extract, _mock_team):
     mock_extract.return_value = {}
+    assert fetch_huddle_transcript("F1") is None
+
+
+@override_settings(SLACK_XOXC_TOKEN="", SLACK_XOXD_TOKEN="")
+@patch("slack_event_handler.utils.slack_tokens.extract_slack_tokens_auto")
+@patch("core.operations.slack_ops.fetcher.get_default_team_key", return_value="T1")
+def test_fetch_huddle_extract_returns_only_xoxc(mock_extract, _mock_team):
+    mock_extract.return_value = {"xoxc": "xc-only"}
     assert fetch_huddle_transcript("F1") is None
 
 

--- a/core/tests/operations/test_slack_tokens.py
+++ b/core/tests/operations/test_slack_tokens.py
@@ -199,3 +199,21 @@ def test_get_slack_app_token_inner_settings_raises():
         with patch("django.conf.settings", _BadSettings()):
             with pytest.raises(ValueError, match="SLACK_APP_TOKEN"):
                 get_slack_app_token("T1")
+
+
+def test_get_slack_bot_token_raises_when_fallback_team_id_empty():
+    with patch(
+        "core.operations.slack_ops.tokens._slack_team_fallback",
+        return_value="",
+    ):
+        with pytest.raises(ValueError, match="team id is required for get_slack_bot_token"):
+            get_slack_bot_token("")
+
+
+def test_get_slack_app_token_raises_when_fallback_team_id_empty():
+    with patch(
+        "core.operations.slack_ops.tokens._slack_team_fallback",
+        return_value="",
+    ):
+        with pytest.raises(ValueError, match="team id is required for get_slack_app_token"):
+            get_slack_app_token("")

--- a/core/tests/operations/test_slack_tokens.py
+++ b/core/tests/operations/test_slack_tokens.py
@@ -206,7 +206,9 @@ def test_get_slack_bot_token_raises_when_fallback_team_id_empty():
         "core.operations.slack_ops.tokens._slack_team_fallback",
         return_value="",
     ):
-        with pytest.raises(ValueError, match="team id is required for get_slack_bot_token"):
+        with pytest.raises(
+            ValueError, match="team id is required for get_slack_bot_token"
+        ):
             get_slack_bot_token("")
 
 
@@ -215,5 +217,7 @@ def test_get_slack_app_token_raises_when_fallback_team_id_empty():
         "core.operations.slack_ops.tokens._slack_team_fallback",
         return_value="",
     ):
-        with pytest.raises(ValueError, match="team id is required for get_slack_app_token"):
+        with pytest.raises(
+            ValueError, match="team id is required for get_slack_app_token"
+        ):
             get_slack_app_token("")

--- a/core/tests/operations/test_stdlib_html_to_md.py
+++ b/core/tests/operations/test_stdlib_html_to_md.py
@@ -65,7 +65,7 @@ def test_converter_get_markdown_collapses_blank_lines():
 def test_img_inside_control_tag_does_not_emit_markdown():
     html = "<html><body><control><img src='/x.png' alt='y'/></control></body></html>"
     md = html_to_markdown(html)
-    assert "![" not in md or "x.png" not in md
+    assert "![" not in md and "x.png" not in md
 
 
 def test_anchor_empty_text_still_emits_url():

--- a/core/tests/operations/test_stdlib_html_to_md.py
+++ b/core/tests/operations/test_stdlib_html_to_md.py
@@ -60,3 +60,15 @@ def test_converter_get_markdown_collapses_blank_lines():
     c.feed("<p>a</p><p>b</p>")
     m = c.get_markdown()
     assert "a" in m and "b" in m
+
+
+def test_img_inside_control_tag_does_not_emit_markdown():
+    html = "<html><body><control><img src='/x.png' alt='y'/></control></body></html>"
+    md = html_to_markdown(html)
+    assert "![" not in md or "x.png" not in md
+
+
+def test_anchor_empty_text_still_emits_url():
+    html = '<html><body><p><a href="https://example.com/path"></a></p></body></html>'
+    md = html_to_markdown(html)
+    assert "example.com" in md

--- a/core/tests/operations/test_transcript_ops_more.py
+++ b/core/tests/operations/test_transcript_ops_more.py
@@ -139,3 +139,55 @@ def test_write_huddle_transcript_md_write_error(tmp_path):
             summary_markdown="",
         )
     assert out is None
+
+
+def test_parse_datetime_range_with_utc_suffix():
+    out = parse_datetime_range(
+        "10:00:00 AM - 11:00:00 AM UTC",
+        date_str="01/15/2024",
+    )
+    assert "PST" in out
+
+
+def test_parse_datetime_range_end_before_start_crosses_midnight():
+    out = parse_datetime_range(
+        "11:00:00 PM - 01:00:00 AM PST",
+        date_str="06/01/24",
+    )
+    assert "PST" in out and "_" in out
+
+
+def test_parse_datetime_range_invalid_date_str_falls_back():
+    out = parse_datetime_range(
+        "10:00:00 AM - 11:00:00 AM PST",
+        date_str="not-a-date",
+    )
+    assert "PST" in out
+
+
+def test_replace_channel_ids_noop_without_channel_id():
+    assert replace_channel_ids_with_names("#C1 here", None, "general") == "#C1 here"
+
+
+def test_generate_transcript_skips_non_dict_block():
+    payload = {
+        "file": {
+            "huddle_transcription": {
+                "blocks": ["bad", {"elements": []}],
+            }
+        }
+    }
+    assert generate_transcript_from_json(payload) == []
+
+
+def test_generate_transcript_non_dict_file_data_returns_empty():
+    assert generate_transcript_from_json({"file": object()}) == []
+
+
+def test_replace_user_ids_prefers_real_name_when_no_display():
+    md = "Hi @U55"
+    out = replace_user_ids_with_usernames(
+        md,
+        {"U55": {"real_name": "Real N", "name": "u55"}},
+    )
+    assert "Real N" in out

--- a/core/tests/test_boost_version_operations.py
+++ b/core/tests/test_boost_version_operations.py
@@ -1,5 +1,7 @@
 """Tests for core.utils.boost_version_operations."""
 
+from unittest.mock import patch
+
 import pytest
 
 from core.utils.boost_version_operations import (
@@ -31,6 +33,11 @@ def test_encode_boost_version_string():
 def test_parse_invalid_returns_none():
     assert parse_boost_version_string("") is None
     assert parse_boost_version_string("not-a-version") is None
+    assert parse_boost_version_string("x.1.0") is None
+    assert parse_boost_version_string("1.1000.0") is None
+    assert parse_boost_version_string("1.0.100") is None
+    assert parse_boost_version_string("-1.0.0") is None
+    assert parse_boost_version_string(".1.0") is None
 
 
 def test_encode_rejects_out_of_range():
@@ -38,6 +45,16 @@ def test_encode_rejects_out_of_range():
         encode_boost_version(1, 1000, 0)
     with pytest.raises(ValueError):
         encode_boost_version(1, 0, 100)
+
+
+def test_encode_rejects_negative_components():
+    with pytest.raises(ValueError):
+        encode_boost_version(-1, 0, 0)
+
+
+def test_decode_rejects_negative_encoded():
+    with pytest.raises(ValueError):
+        decode_boost_version(-1)
 
 
 def test_loose_version_tuple_empty_and_digits():
@@ -67,6 +84,15 @@ def test_compare_loose_version_strings():
 def test_compare_encoded_versions():
     assert compare_encoded_versions(100_000, 200_000) == -1
     assert compare_encoded_versions(108_600, 108_600) == 0
+    assert compare_encoded_versions(200_000, 100_000) == 1
+
+
+def test_encode_boost_version_string_returns_none_when_encode_raises():
+    with patch(
+        "core.utils.boost_version_operations.encode_boost_version",
+        side_effect=ValueError("x"),
+    ):
+        assert encode_boost_version_string("1.0.0") is None
 
 
 def test_parse_stable_boost_release_tag():

--- a/core/tests/test_cleanup_workspace_orphans.py
+++ b/core/tests/test_cleanup_workspace_orphans.py
@@ -109,6 +109,38 @@ def test_cleanup_workspace_orphans_includes_nested_orphan(tmp_path):
 
 
 @pytest.mark.django_db
+def test_cleanup_workspace_orphans_skips_file_when_stat_fails(tmp_path):
+    stale = tmp_path / "badstat.tmp"
+    stale.write_text("x", encoding="utf-8")
+    old = time.time() - 48 * 3600
+    os.utime(stale, (old, old))
+    other = tmp_path / "other.tmp"
+    other.write_text("y", encoding="utf-8")
+    os.utime(other, (old, old))
+    out = StringIO()
+    real_stat = Path.stat
+    real_is_file = Path.is_file
+
+    def selective_is_file(self):
+        if self.name in ("badstat.tmp", "other.tmp"):
+            return True
+        return real_is_file(self)
+
+    def selective_stat(self, *a, **kw):
+        if self.name == "badstat.tmp":
+            raise OSError("stat fail")
+        return real_stat(self, *a, **kw)
+
+    with patch("django.conf.settings.WORKSPACE_DIR", tmp_path):
+        with patch.object(Path, "is_file", selective_is_file):
+            with patch.object(Path, "stat", selective_stat):
+                call_command("cleanup_workspace_orphans", stdout=out)
+    text = out.getvalue()
+    assert "badstat.tmp" not in text
+    assert "other.tmp" in text
+
+
+@pytest.mark.django_db
 def test_cleanup_workspace_orphans_execute_logs_when_unlink_fails(tmp_path):
     stale = tmp_path / "locked.part"
     stale.write_text("x", encoding="utf-8")

--- a/core/tests/test_collectors_base.py
+++ b/core/tests/test_collectors_base.py
@@ -19,6 +19,11 @@ def test_django_command_collector_run_calls_call_command():
     m.assert_called_once_with("run_boost_usage_tracker")
 
 
+def test_django_command_collector_sync_pinecone_default_noop():
+    c = DjangoCommandCollector("check")
+    assert c.sync_pinecone() is None
+
+
 def test_base_collector_command_runs_then_sync_pinecone():
     phases = []
 

--- a/core/tests/test_datetime_parsing.py
+++ b/core/tests/test_datetime_parsing.py
@@ -42,6 +42,8 @@ def test_parse_iso_datetime_z_suffix():
     assert dt.month == 3
     assert dt.day == 15
     assert dt.hour == 10
+    assert dt.minute == 30
+    assert dt.second == 0
 
 
 def test_parse_iso_datetime_date_only():
@@ -54,8 +56,12 @@ def test_parse_iso_datetime_with_offset_strips_tz_to_naive_utc():
     dt = parse_iso_datetime("2024-01-01T00:00:00+05:00")
     assert dt is not None
     assert dt.tzinfo is None
-    assert dt.day == 31
+    assert dt.year == 2023
     assert dt.month == 12
+    assert dt.day == 31
+    assert dt.hour == 19
+    assert dt.minute == 0
+    assert dt.second == 0
 
 
 def test_parse_iso_datetime_invalid_raises():

--- a/core/tests/test_datetime_parsing.py
+++ b/core/tests/test_datetime_parsing.py
@@ -1,0 +1,63 @@
+"""Tests for core.utils.datetime_parsing."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from django.utils import timezone as django_timezone
+
+from core.utils.datetime_parsing import ensure_aware_utc, parse_iso_datetime
+
+
+def test_ensure_aware_utc_none():
+    assert ensure_aware_utc(None) is None
+
+
+def test_ensure_aware_utc_naive_becomes_utc():
+    naive = datetime(2024, 6, 1, 12, 0, 0)
+    assert django_timezone.is_naive(naive)
+    out = ensure_aware_utc(naive)
+    assert out is not None
+    assert out.tzinfo == timezone.utc
+
+
+def test_ensure_aware_utc_aware_converted_to_utc():
+    dt = datetime(2024, 1, 1, 15, 0, 0, tzinfo=timezone(timedelta(hours=2)))
+    out = ensure_aware_utc(dt)
+    assert out is not None
+    assert out.tzinfo == timezone.utc
+    assert out.hour == 13
+
+
+def test_parse_iso_datetime_empty():
+    assert parse_iso_datetime(None) is None
+    assert parse_iso_datetime("") is None
+    assert parse_iso_datetime("   ") is None
+
+
+def test_parse_iso_datetime_z_suffix():
+    dt = parse_iso_datetime("2024-03-15T10:30:00Z")
+    assert dt is not None
+    assert dt.tzinfo is None
+    assert dt.year == 2024
+    assert dt.month == 3
+    assert dt.day == 15
+    assert dt.hour == 10
+
+
+def test_parse_iso_datetime_date_only():
+    dt = parse_iso_datetime("2024-12-25")
+    assert dt is not None
+    assert dt.tzinfo is None
+
+
+def test_parse_iso_datetime_with_offset_strips_tz_to_naive_utc():
+    dt = parse_iso_datetime("2024-01-01T00:00:00+05:00")
+    assert dt is not None
+    assert dt.tzinfo is None
+    assert dt.day == 31
+    assert dt.month == 12
+
+
+def test_parse_iso_datetime_invalid_raises():
+    with pytest.raises(ValueError, match="Invalid ISO datetime"):
+        parse_iso_datetime("not-a-date")

--- a/core/tests/test_errors.py
+++ b/core/tests/test_errors.py
@@ -9,7 +9,11 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.core.management.base import CommandError
 
-from core.errors import CollectorFailureCategory, classify_failure
+from core.errors import (
+    CollectorFailureCategory,
+    _classify_os_error,
+    classify_failure,
+)
 
 _swapped: dict[tuple[str, str], type[BaseException]] = {}
 
@@ -77,6 +81,43 @@ def test_classify_os_error_network_errno():
         classify_failure(OSError(errno.EPIPE, "Broken pipe"))
         is CollectorFailureCategory.NETWORK
     )
+
+
+def test_classify_os_error_direct_errno_network():
+    assert (
+        _classify_os_error(OSError(errno.ENOTCONN, "not connected"))
+        is CollectorFailureCategory.NETWORK
+    )
+
+
+def test_classify_os_error_direct_winerror_network():
+    exc = OSError(0, "wsa", None, 10061)
+    assert _classify_os_error(exc) is CollectorFailureCategory.NETWORK
+
+
+def test_classify_os_error_winerror_network_when_errno_not_in_sets():
+    exc = OSError(999999, "generic message")
+    exc.winerror = 10061
+    assert classify_failure(exc) is CollectorFailureCategory.NETWORK
+
+
+def test_classify_os_error_network_errno_connrefused():
+    assert (
+        classify_failure(OSError(errno.ECONNREFUSED, "refused"))
+        is CollectorFailureCategory.NETWORK
+    )
+
+
+def test_classify_os_error_local_io_errno_unknown():
+    assert (
+        classify_failure(OSError(errno.ENOSPC, "no space"))
+        is CollectorFailureCategory.UNKNOWN
+    )
+
+
+def test_classify_os_error_winerror_network():
+    exc = OSError(0, "wsa", None, 10054)
+    assert classify_failure(exc) is CollectorFailureCategory.NETWORK
 
 
 def test_classify_os_error_connection_error_subclass():

--- a/core/tests/test_send_startup_notification.py
+++ b/core/tests/test_send_startup_notification.py
@@ -8,10 +8,12 @@ from celery.schedules import crontab
 from celery.schedules import schedule as celery_interval_schedule
 
 from django.core.management import call_command
+from urllib.error import URLError
 
 from core.management.commands import send_startup_notification as ss
 
 from core.management.commands.send_startup_notification import (
+    BEAT_LINES_CAP,
     collect_beat_lines,
     describe_celery_schedule,
     post_discord,
@@ -23,7 +25,12 @@ def test_crontab_field_helpers():
     assert ss._crontab_field_to_sorted_ints(None) is None
     assert ss._crontab_field_to_sorted_ints(5) == [5]
     assert ss._crontab_field_to_sorted_ints({3, 1}) == [1, 3]
+    assert ss._crontab_field_to_sorted_ints([1, "2", 3]) == [1, 2, 3]
+    assert ss._crontab_field_to_sorted_ints(["x"]) is None
+    assert ss._crontab_field_to_sorted_ints("not-a-crontab-field") is None
+    assert ss._crontab_is_universal_star(None) is True
     assert ss._crontab_is_universal_star("*") is True
+    assert ss._crontab_is_universal_star("**") is True
     assert ss._crontab_is_universal_star("mon") is False
 
 
@@ -36,6 +43,19 @@ def test_describe_unknown_schedule_uses_repr():
 def test_describe_interval_schedule():
     s = celery_interval_schedule(run_every=timedelta(minutes=30))
     assert "30" in describe_celery_schedule(s)
+
+
+def test_describe_crontab_multi_hour_minute_uses_repr():
+    s = crontab(hour={0, 12}, minute={0, 30})
+    out = describe_celery_schedule(s)
+    assert "hour=" in out or "minute=" in out
+
+
+def test_describe_crontab_includes_dom_and_moy_when_set():
+    s = crontab(hour=1, minute=0, day_of_month="1", month_of_year="1")
+    out = describe_celery_schedule(s)
+    assert "dom=" in out
+    assert "moy=" in out
 
 
 def test_describe_crontab_single_hour_minute():
@@ -61,6 +81,21 @@ def test_collect_beat_lines_sorted():
     lines, total = collect_beat_lines(beat)
     assert total == 2
     assert lines[0].startswith("- `a`")
+
+
+def test_collect_beat_lines_truncation_hint_in_command_body():
+    """BEAT_LINES_CAP limits lines; remainder is summarized when building body."""
+    beat = {
+        f"k{i}": {"task": f"t{i}", "schedule": None} for i in range(BEAT_LINES_CAP + 3)
+    }
+    lines, total = collect_beat_lines(beat)
+    assert total == BEAT_LINES_CAP + 3
+    assert len(lines) == BEAT_LINES_CAP + 3
+    shown = lines[:BEAT_LINES_CAP]
+    beat_block = "\n".join(shown)
+    if total > len(shown):
+        beat_block += f"\n… and {total - len(shown)} more"
+    assert "… and 3 more" in beat_block
 
 
 @patch("core.management.commands.send_startup_notification.request.urlopen")
@@ -123,3 +158,208 @@ def test_command_posts_discord_when_configured(settings):
                 ):
                     call_command("send_startup_notification")
     pd.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_command_db_failure_still_posts(settings):
+    settings.ENABLE_STARTUP_NOTIFICATIONS = True
+    settings.DISCORD_WEBHOOK_URL = "https://discord.example/x"
+    settings.SLACK_WEBHOOK_URL = ""
+    mock_app = MagicMock()
+    mock_app.conf.beat_schedule = {}
+    mock_app.control.inspect.return_value = None
+    with (
+        patch(
+            "core.management.commands.send_startup_notification.post_discord",
+        ) as pd,
+        patch(
+            "core.management.commands.send_startup_notification.connection.ensure_connection",
+            side_effect=RuntimeError("db down"),
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.celery_app",
+            mock_app,
+        ),
+    ):
+        call_command("send_startup_notification")
+    args = pd.call_args[0]
+    assert "DB: failed" in args[2]
+
+
+@pytest.mark.django_db
+def test_command_worker_inspect_failure(settings):
+    settings.ENABLE_STARTUP_NOTIFICATIONS = True
+    settings.DISCORD_WEBHOOK_URL = "https://discord.example/x"
+    settings.SLACK_WEBHOOK_URL = ""
+    mock_app = MagicMock()
+    mock_app.conf.beat_schedule = {}
+    mock_app.control.inspect.side_effect = RuntimeError("no broker")
+    with (
+        patch(
+            "core.management.commands.send_startup_notification.post_discord",
+        ) as pd,
+        patch(
+            "core.management.commands.send_startup_notification.connection.ensure_connection",
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.connection.introspection.table_names",
+            return_value=[],
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.celery_app",
+            mock_app,
+        ),
+    ):
+        call_command("send_startup_notification")
+    body = pd.call_args[0][2]
+    assert "inspect failed" in body
+
+
+@pytest.mark.django_db
+def test_command_exits_on_webhook_error(settings):
+    settings.ENABLE_STARTUP_NOTIFICATIONS = True
+    settings.DISCORD_WEBHOOK_URL = "https://discord.example/x"
+    settings.SLACK_WEBHOOK_URL = ""
+    mock_app = MagicMock()
+    mock_app.conf.beat_schedule = {}
+    mock_app.control.inspect.return_value = None
+    with (
+        patch(
+            "core.management.commands.send_startup_notification.post_discord",
+            side_effect=URLError("bad"),
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.connection.ensure_connection",
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.connection.introspection.table_names",
+            return_value=["t"],
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.celery_app",
+            mock_app,
+        ),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            call_command("send_startup_notification")
+    assert excinfo.value.code == 1
+
+
+@pytest.mark.django_db
+def test_command_beat_block_truncation_in_notification_body(settings):
+    settings.ENABLE_STARTUP_NOTIFICATIONS = True
+    settings.DISCORD_WEBHOOK_URL = "https://discord.example/x"
+    settings.SLACK_WEBHOOK_URL = ""
+    mock_app = MagicMock()
+    mock_app.conf.beat_schedule = {
+        f"k{i}": {"task": f"t{i}", "schedule": None} for i in range(BEAT_LINES_CAP + 4)
+    }
+    mock_app.control.inspect.return_value = None
+    with (
+        patch(
+            "core.management.commands.send_startup_notification.post_discord",
+        ) as pd,
+        patch(
+            "core.management.commands.send_startup_notification.connection.ensure_connection",
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.connection.introspection.table_names",
+            return_value=["t"],
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.celery_app",
+            mock_app,
+        ),
+    ):
+        call_command("send_startup_notification")
+    body = pd.call_args[0][2]
+    assert "… and 4 more" in body
+
+
+@pytest.mark.django_db
+def test_command_generic_exception_from_discord(settings):
+    settings.ENABLE_STARTUP_NOTIFICATIONS = True
+    settings.DISCORD_WEBHOOK_URL = "https://discord.example/x"
+    settings.SLACK_WEBHOOK_URL = ""
+    mock_app = MagicMock()
+    mock_app.conf.beat_schedule = {}
+    mock_app.control.inspect.return_value = None
+    with (
+        patch(
+            "core.management.commands.send_startup_notification.post_discord",
+            side_effect=ValueError("boom"),
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.connection.ensure_connection",
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.connection.introspection.table_names",
+            return_value=["t"],
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.celery_app",
+            mock_app,
+        ),
+    ):
+        with pytest.raises(SystemExit):
+            call_command("send_startup_notification")
+
+
+@pytest.mark.django_db
+def test_command_slack_webhook_urllib_error_exits(settings):
+    settings.ENABLE_STARTUP_NOTIFICATIONS = True
+    settings.DISCORD_WEBHOOK_URL = ""
+    settings.SLACK_WEBHOOK_URL = "https://hooks.slack.example/x"
+    mock_app = MagicMock()
+    mock_app.conf.beat_schedule = {}
+    mock_app.control.inspect.return_value = None
+    with (
+        patch(
+            "core.management.commands.send_startup_notification.post_slack",
+            side_effect=URLError("slack down"),
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.connection.ensure_connection",
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.connection.introspection.table_names",
+            return_value=["t"],
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.celery_app",
+            mock_app,
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            call_command("send_startup_notification")
+    assert exc.value.code == 1
+
+
+@pytest.mark.django_db
+def test_command_slack_webhook_generic_exception_exits(settings):
+    settings.ENABLE_STARTUP_NOTIFICATIONS = True
+    settings.DISCORD_WEBHOOK_URL = ""
+    settings.SLACK_WEBHOOK_URL = "https://hooks.slack.example/x"
+    mock_app = MagicMock()
+    mock_app.conf.beat_schedule = {}
+    mock_app.control.inspect.return_value = None
+    with (
+        patch(
+            "core.management.commands.send_startup_notification.post_slack",
+            side_effect=RuntimeError("slack boom"),
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.connection.ensure_connection",
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.connection.introspection.table_names",
+            return_value=["t"],
+        ),
+        patch(
+            "core.management.commands.send_startup_notification.celery_app",
+            mock_app,
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            call_command("send_startup_notification")
+    assert exc.value.code == 1

--- a/core/tests/test_text_processing.py
+++ b/core/tests/test_text_processing.py
@@ -22,6 +22,8 @@ def test_clean_text_remove_extra_spaces_false_keeps_newlines():
     out = clean_text(raw, remove_extra_spaces=False)
     assert "line1" in out
     assert "line2" in out
+    assert "\n" in out
+    assert out.splitlines() == ["line1", "", "", "line2"]
 
 
 def test_clean_text_unescapes_html_and_invisible_chars():

--- a/core/tests/test_text_processing.py
+++ b/core/tests/test_text_processing.py
@@ -1,0 +1,67 @@
+"""Tests for core.utils.text_processing."""
+
+from core.utils.text_processing import (
+    SLACK_GREETING_WORDS,
+    clean_text,
+    filter_sentence,
+    validate_content_length,
+)
+
+
+def test_clean_text_empty():
+    assert clean_text(None) == ""
+    assert clean_text("") == ""
+
+
+def test_clean_text_collapses_spaces_and_strips():
+    assert clean_text("  a   b  ") == "a b"
+
+
+def test_clean_text_remove_extra_spaces_false_keeps_newlines():
+    raw = "line1\n\n\nline2"
+    out = clean_text(raw, remove_extra_spaces=False)
+    assert "line1" in out
+    assert "line2" in out
+
+
+def test_clean_text_unescapes_html_and_invisible_chars():
+    s = "\xadhello&nbsp;world\u200b"
+    out = clean_text(s)
+    assert "hello" in out
+    assert "world" in out
+
+
+def test_filter_sentence_empty():
+    assert filter_sentence("") == ""
+    assert filter_sentence("   ") == ""
+
+
+def test_filter_sentence_removes_greeting():
+    out = filter_sentence("Hi there, can you help?")
+    assert "help" in out
+
+
+def test_filter_sentence_too_few_words_returns_empty():
+    assert filter_sentence("ok sure", min_words_after=3) == ""
+
+
+def test_filter_sentence_custom_word_lists():
+    out = filter_sentence(
+        "alpha beta gamma delta",
+        greeting_words=["alpha"],
+        unessential_words=["beta"],
+        min_words_after=2,
+    )
+    assert "gamma" in out
+
+
+def test_validate_content_length():
+    assert validate_content_length(None) is False
+    assert validate_content_length("short") is False
+    long_enough = "x" * 50
+    assert validate_content_length(long_enough) is True
+    assert validate_content_length("  " + long_enough) is True
+
+
+def test_slack_constants_non_empty():
+    assert "hello" in SLACK_GREETING_WORDS

--- a/cppa_slack_tracker/sync/sync_message.py
+++ b/cppa_slack_tracker/sync/sync_message.py
@@ -283,9 +283,13 @@ def sync_messages(
                 except Exception as e:
                     logger.debug("Skip message %s: %s", msg.get("ts"), e)
                     error_count += 1
-            workspace_path.unlink()
         except OSError:
-            logger.exception("Failed to process/remove %s", workspace_path)
+            logger.exception("Failed to process messages for %s", workspace_path)
+        else:
+            try:
+                workspace_path.unlink()
+            except Exception:
+                logger.exception("Failed to remove workspace file %s", workspace_path)
 
         d += timedelta(days=1)
 

--- a/cppa_slack_tracker/tests/test_services.py
+++ b/cppa_slack_tracker/tests/test_services.py
@@ -2,6 +2,9 @@
 Tests for cppa_slack_tracker.services.
 """
 
+from datetime import datetime, timezone
+from unittest.mock import patch
+
 import pytest
 
 from cppa_user_tracker.services import get_or_create_slack_user
@@ -305,3 +308,183 @@ class TestSlackService:
         calls = [c[0][0] for c in mock_fetch.call_args_list]
         assert "U99999999" in calls
         assert "-1" not in calls
+
+    def test_get_or_create_slack_team_requires_team_id(self):
+        with pytest.raises(ValueError, match="Slack team ID is required"):
+            get_or_create_slack_team({})
+
+    def test_parse_slack_ts_string_invalid_returns_now_utc(self):
+        before = datetime.now(timezone.utc)
+        dt = _parse_slack_ts_string("not-a-valid-ts")
+        after = datetime.now(timezone.utc)
+        assert before <= dt <= after
+
+    def test_get_or_create_slack_channel_skips_private(self, sample_slack_team):
+        ch, created = get_or_create_slack_channel(
+            {
+                "id": "Cprivate01",
+                "name": "secret",
+                "is_channel": True,
+                "is_private": True,
+            },
+            sample_slack_team,
+        )
+        assert ch is None
+        assert created is False
+
+    def test_get_or_create_slack_channel_topic_when_no_purpose(
+        self, sample_slack_team, sample_slack_user
+    ):
+        cid = "Ctopiconly01"
+        ch, created = get_or_create_slack_channel(
+            {
+                "id": cid,
+                "name": "announcements",
+                "is_channel": True,
+                "is_private": False,
+                "topic": {"value": "Read this first"},
+                "creator": "U12345678",
+            },
+            sample_slack_team,
+        )
+        assert created is True
+        assert ch.description == "Read this first"
+        assert ch.creator == sample_slack_user
+
+    def test_get_or_create_slack_channel_updates_existing(
+        self, sample_slack_team, sample_slack_user, sample_slack_channel
+    ):
+        data = {
+            "id": sample_slack_channel.channel_id,
+            "name": "renamed",
+            "is_channel": True,
+            "is_private": False,
+            "purpose": {"value": "new purpose"},
+            "creator": "U12345678",
+        }
+        ch, created = get_or_create_slack_channel(data, sample_slack_team)
+        assert created is False
+        assert ch.channel_name == "renamed"
+        assert ch.description == "new purpose"
+
+    def test_save_slack_message_channel_join_without_ts_logs(
+        self, sample_slack_channel, caplog
+    ):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            msg = save_slack_message(
+                sample_slack_channel,
+                {"subtype": "channel_join", "user": "U12345678"},
+            )
+        assert msg is None
+        assert "Skipping channel_join without ts" in caplog.text
+
+    def test_save_slack_message_channel_leave_without_ts_logs(
+        self, sample_slack_channel, caplog
+    ):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            msg = save_slack_message(
+                sample_slack_channel,
+                {"subtype": "channel_leave", "user": "U12345678"},
+            )
+        assert msg is None
+        assert "Skipping channel_leave without ts" in caplog.text
+
+    def test_save_slack_message_file_comment_with_comment_dict(
+        self, sample_slack_channel, sample_slack_user
+    ):
+        message_data = {
+            "user": "U12345678",
+            "subtype": "file_comment",
+            "text": "Nice file",
+            "ts": "1609459200.555555",
+            "comment": {"comment": "nested text"},
+        }
+        msg = save_slack_message(sample_slack_channel, message_data)
+        assert msg is not None
+        assert "Nice file" in msg.message
+        assert "nested text" in msg.message
+
+    def test_save_slack_message_file_placeholder_without_user_returns_none(
+        self, sample_slack_channel
+    ):
+        msg = save_slack_message(
+            sample_slack_channel,
+            {"text": "A file was commented on", "ts": "1609459200.666666"},
+        )
+        assert msg is None
+
+    def test_save_slack_message_requires_user_for_normal_message(
+        self, sample_slack_channel
+    ):
+        with pytest.raises(ValueError, match="User not found"):
+            save_slack_message(
+                sample_slack_channel,
+                {"text": "hello", "ts": "1609459200.777777"},
+            )
+
+    def test_add_channel_membership_change_updates_existing_log_is_joined(
+        self, sample_slack_channel, sample_slack_user
+    ):
+        ts = "1609459200.888888"
+        log1 = add_channel_membership_change(
+            sample_slack_channel, "U12345678", ts, is_joined=True
+        )
+        assert log1.is_joined is True
+        log2 = add_channel_membership_change(
+            sample_slack_channel, "U12345678", ts, is_joined=False
+        )
+        assert log2.pk == log1.pk
+        log1.refresh_from_db()
+        assert log1.is_joined is False
+
+    def test_add_channel_membership_rejoin_restores_deleted_membership(
+        self, sample_slack_channel, sample_slack_user, sample_slack_membership
+    ):
+        sample_slack_membership.is_deleted = True
+        sample_slack_membership.save()
+        add_channel_membership_change(
+            sample_slack_channel,
+            "U12345678",
+            "1609459200.999999",
+            is_joined=True,
+        )
+        sample_slack_membership.refresh_from_db()
+        assert not sample_slack_membership.is_deleted
+
+    def test_sync_channel_memberships_skips_unknown_user_ids(
+        self, sample_slack_channel, sample_slack_user
+    ):
+        SlackChannelMembership.objects.create(
+            channel=sample_slack_channel,
+            user=sample_slack_user,
+        )
+        sync_channel_memberships(
+            sample_slack_channel,
+            ["U12345678", "Unonexistent"],
+        )
+        m = SlackChannelMembership.objects.get(
+            channel=sample_slack_channel, user=sample_slack_user
+        )
+        assert not m.is_deleted
+
+    def test_sync_channel_memberships_remove_continues_if_user_missing(
+        self, sample_slack_channel, sample_slack_user
+    ):
+        SlackChannelMembership.objects.create(
+            channel=sample_slack_channel,
+            user=sample_slack_user,
+        )
+        with patch.object(
+            SlackUser.objects,
+            "get",
+            side_effect=SlackUser.DoesNotExist,
+        ):
+            sync_channel_memberships(sample_slack_channel, [])
+        m = SlackChannelMembership.objects.get(
+            channel=sample_slack_channel, user=sample_slack_user
+        )
+        assert not m.is_deleted

--- a/cppa_slack_tracker/tests/test_sync_units.py
+++ b/cppa_slack_tracker/tests/test_sync_units.py
@@ -168,7 +168,7 @@ def test_sync_users_malformed_payload():
         "cppa_slack_tracker.sync.sync_user.fetch_user_list",
         return_value=["not-a-dict"],
     ):
-        ok, err = sync_users("slug", team_id="T1")
+        _ok, err = sync_users("slug", team_id="T1")
     assert err >= 1
 
 
@@ -260,7 +260,7 @@ def test_process_workspace_jsons_not_list(tmp_path, sample_slack_channel, monkey
     )
     p = tmp_path / "x.json"
     p.write_text('{"not":"list"}', encoding="utf-8")
-    s, e = _process_workspace_jsons(sample_slack_channel)
+    s, _e = _process_workspace_jsons(sample_slack_channel)
     assert not p.exists()
     assert s == 0
 
@@ -325,7 +325,7 @@ def test_sync_messages_derived_start_none_messages_without_ts(sample_slack_chann
             start_date=None,
             end_date=date(2025, 1, 1),
         )
-    assert ok == 0
+    assert ok == 0 and err == 0
 
 
 @pytest.mark.django_db
@@ -407,6 +407,7 @@ def test_sync_messages_corrupt_raw_file_still_merges(
             end_date=d,
         )
     assert ok == 1
+    assert err == 0
     data = json.loads(raw.read_text(encoding="utf-8"))
     assert any(m.get("text") == "recovered" for m in data)
 
@@ -441,6 +442,7 @@ def test_sync_messages_write_oserror_skips_day(sample_slack_channel):
             end_date=d,
         )
     assert ok == 0
+    assert err == 0
 
 
 @pytest.mark.django_db
@@ -479,6 +481,7 @@ def test_sync_messages_unlink_failure_after_process(sample_slack_channel):
             end_date=d,
         )
     assert ok == 1
+    assert err == 0
 
 
 @pytest.mark.django_db

--- a/cppa_slack_tracker/tests/test_sync_units.py
+++ b/cppa_slack_tracker/tests/test_sync_units.py
@@ -1,5 +1,6 @@
 """Unit tests for cppa_slack_tracker.sync modules (mocked API / DB edges)."""
 
+import json
 import uuid
 from datetime import date, datetime, timezone
 from unittest.mock import MagicMock, patch
@@ -325,3 +326,217 @@ def test_sync_messages_derived_start_none_messages_without_ts(sample_slack_chann
             end_date=date(2025, 1, 1),
         )
     assert ok == 0
+
+
+@pytest.mark.django_db
+def test_last_message_date_accepts_plain_date_from_db(sample_slack_channel):
+    import cppa_slack_tracker.sync.sync_message as sm
+
+    qs = MagicMock()
+    qs.annotate.return_value = qs
+    qs.order_by.return_value = qs
+    qs.values_list.return_value = qs
+    qs.first.return_value = date(2024, 6, 1)
+    with patch.object(sm.SlackMessage.objects, "filter", return_value=qs):
+        assert sm._last_message_date(sample_slack_channel) == date(2024, 6, 1)
+
+
+@pytest.mark.django_db
+def test_process_workspace_jsons_invalid_json_keeps_file(
+    tmp_path, sample_slack_channel, monkeypatch
+):
+    p = tmp_path / "broken.json"
+    p.write_text("{not-json", encoding="utf-8")
+    monkeypatch.setattr(
+        "cppa_slack_tracker.sync.sync_message.iter_existing_message_jsons",
+        lambda **_: iter([p]),
+    )
+    s, e = _process_workspace_jsons(sample_slack_channel)
+    assert s == 0 and e == 0
+    assert p.exists()
+
+
+@pytest.mark.django_db
+def test_process_workspace_jsons_per_message_error_increments_errors(
+    tmp_path, sample_slack_channel, monkeypatch
+):
+    p = tmp_path / "day.json"
+    p.write_text(
+        json.dumps([{"ts": "1609459200.1", "text": "x", "user": "U12345678"}]),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "cppa_slack_tracker.sync.sync_message.iter_existing_message_jsons",
+        lambda **_: iter([p]),
+    )
+    with patch(
+        "cppa_slack_tracker.sync.sync_message._process_message",
+        side_effect=RuntimeError("save failed"),
+    ):
+        s, e = _process_workspace_jsons(sample_slack_channel)
+    assert s == 0 and e == 1
+    assert not p.exists()
+
+
+@pytest.mark.django_db
+def test_sync_messages_corrupt_raw_file_still_merges(
+    sample_slack_channel,
+):
+    from cppa_slack_tracker.workspace import get_raw_message_json_path
+
+    d = date(2021, 1, 1)
+    raw = get_raw_message_json_path(
+        sample_slack_channel.team.team_name,
+        sample_slack_channel.channel_name,
+        d.strftime("%Y-%m-%d"),
+    )
+    raw.parent.mkdir(parents=True, exist_ok=True)
+    raw.write_text("{broken-json", encoding="utf-8")
+    msg = {
+        "ts": "1609459200.000001",
+        "user": "U12345678",
+        "text": "recovered",
+    }
+    with patch(
+        "cppa_slack_tracker.sync.sync_message.fetch_messages",
+        return_value=[msg],
+    ):
+        ok, err = sync_messages(
+            sample_slack_channel,
+            start_date=d,
+            end_date=d,
+        )
+    assert ok == 1
+    data = json.loads(raw.read_text(encoding="utf-8"))
+    assert any(m.get("text") == "recovered" for m in data)
+
+
+@pytest.mark.django_db
+def test_sync_messages_write_oserror_skips_day(sample_slack_channel):
+    d = date(2021, 1, 1)
+    ws = MagicMock()
+    ws.parent.mkdir = MagicMock()
+    ws.write_text.side_effect = OSError("no space")
+    raw = MagicMock()
+    raw.parent.mkdir = MagicMock()
+    raw.exists.return_value = False
+    msg = {"ts": "1609459200.000002", "user": "U12345678", "text": "x"}
+    with (
+        patch(
+            "cppa_slack_tracker.sync.sync_message.get_message_json_path",
+            return_value=ws,
+        ),
+        patch(
+            "cppa_slack_tracker.sync.sync_message.get_raw_message_json_path",
+            return_value=raw,
+        ),
+        patch(
+            "cppa_slack_tracker.sync.sync_message.fetch_messages",
+            return_value=[msg],
+        ),
+    ):
+        ok, err = sync_messages(
+            sample_slack_channel,
+            start_date=d,
+            end_date=d,
+        )
+    assert ok == 0
+
+
+@pytest.mark.django_db
+def test_sync_messages_unlink_failure_after_process(sample_slack_channel):
+    d = date(2021, 1, 1)
+    ws = MagicMock()
+    ws.parent.mkdir = MagicMock()
+    ws.write_text = MagicMock()
+    ws.unlink.side_effect = RuntimeError("unlink blocked")
+    raw = MagicMock()
+    raw.parent.mkdir = MagicMock()
+    raw.exists.return_value = False
+    raw.write_text = MagicMock()
+    msg = {"ts": "1609459200.000003", "user": "U12345678", "text": "y"}
+    with (
+        patch(
+            "cppa_slack_tracker.sync.sync_message.get_message_json_path",
+            return_value=ws,
+        ),
+        patch(
+            "cppa_slack_tracker.sync.sync_message.get_raw_message_json_path",
+            return_value=raw,
+        ),
+        patch(
+            "cppa_slack_tracker.sync.sync_message.fetch_messages",
+            return_value=[msg],
+        ),
+        patch(
+            "cppa_slack_tracker.sync.sync_message._process_message",
+            return_value=True,
+        ),
+    ):
+        ok, err = sync_messages(
+            sample_slack_channel,
+            start_date=d,
+            end_date=d,
+        )
+    assert ok == 1
+
+
+@pytest.mark.django_db
+def test_sync_channels_single_channel_process_raises(
+    sample_slack_team, sample_slack_channel_data
+):
+    mock_client = MagicMock()
+    mock_client.conversations_info.return_value = {
+        "ok": True,
+        "channel": sample_slack_channel_data,
+    }
+    with (
+        patch(
+            "core.operations.slack_ops.tokens.get_slack_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "cppa_slack_tracker.sync.sync_channel.get_or_create_slack_channel",
+            side_effect=RuntimeError("db"),
+        ),
+    ):
+        ok, err = sync_channels(
+            sample_slack_team,
+            channel_id=sample_slack_channel_data["id"],
+            team_id=sample_slack_team.team_id,
+        )
+    assert ok == 0 and err == 1
+
+
+@pytest.mark.django_db
+def test_sync_channels_list_item_process_raises(
+    sample_slack_team, sample_slack_channel_data
+):
+    with (
+        patch(
+            "cppa_slack_tracker.sync.sync_channel.fetch_channel_list",
+            return_value=[sample_slack_channel_data],
+        ),
+        patch(
+            "cppa_slack_tracker.sync.sync_channel.get_or_create_slack_channel",
+            side_effect=RuntimeError("sync one channel"),
+        ),
+    ):
+        ok, err = sync_channels(sample_slack_team, team_id=sample_slack_team.team_id)
+    assert ok == 0 and err == 1
+
+
+@pytest.mark.django_db
+def test_sync_users_process_user_raises():
+    with (
+        patch(
+            "cppa_slack_tracker.sync.sync_user.fetch_user_list",
+            return_value=[{"id": "Ubad", "name": "x"}],
+        ),
+        patch(
+            "cppa_slack_tracker.sync.sync_user.get_or_create_slack_user",
+            side_effect=RuntimeError("user sync"),
+        ),
+    ):
+        ok, err = sync_users("slug", team_id="T1")
+    assert ok == 0 and err == 1

--- a/github_activity_tracker/tests/test_sync_commits.py
+++ b/github_activity_tracker/tests/test_sync_commits.py
@@ -1,5 +1,6 @@
 from concurrent.futures import Future
 import json
+import logging
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
@@ -442,8 +443,13 @@ def test_sync_commits_skips_fetch_item_without_sha(github_repository, tmp_path):
         sync_commits_mod, "RedisListETagCache", return_value=MagicMock()
     ), patch.object(
         sync_commits_mod, "ThreadPoolExecutor", return_value=_Exec()
-    ):
+    ), patch.object(
+        sync_commits_mod,
+        "_process_commit_data",
+    ) as mock_process_commit_data:
         sync_commits_mod.sync_commits(github_repository)
+
+    mock_process_commit_data.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -479,6 +485,7 @@ def test_sync_commits_raises_rate_limit(github_repository):
 def test_sync_commits_future_result_exception_logged(
     github_repository,
     tmp_path,
+    caplog,
 ):
     sha = "f" * 40
     commit_data = {
@@ -522,8 +529,13 @@ def test_sync_commits_future_result_exception_logged(
         sync_commits_mod, "ThreadPoolExecutor", return_value=_Exec()
     ), patch.object(
         sync_commits_mod, "_process_existing_commit_jsons", return_value=0
+    ), caplog.at_level(
+        logging.ERROR, logger="github_activity_tracker.sync.commits"
     ):
         sync_commits_mod.sync_commits(github_repository)
+
+    logged = " ".join(r.message for r in caplog.records)
+    assert "Big commit task" in logged and "worker boom" in logged
 
 
 @pytest.mark.django_db
@@ -641,7 +653,7 @@ def test_process_big_commit_worker_primary_write_fails_then_fallback():
 
 
 @pytest.mark.django_db
-def test_sync_commits_logs_existing_json_count(github_repository):
+def test_sync_commits_logs_existing_json_count(github_repository, caplog):
     class _Exec:
         def submit(self, *a, **k):
             fut = Future()
@@ -663,8 +675,13 @@ def test_sync_commits_logs_existing_json_count(github_repository):
         sync_commits_mod, "RedisListETagCache", return_value=MagicMock()
     ), patch.object(
         sync_commits_mod, "ThreadPoolExecutor", return_value=_Exec()
+    ), caplog.at_level(
+        logging.INFO, logger="github_activity_tracker.sync.commits"
     ):
         sync_commits_mod.sync_commits(github_repository)
+
+    logged = " ".join(r.message for r in caplog.records)
+    assert "processed 4 existing commit JSON" in logged
 
 
 @pytest.mark.django_db

--- a/github_activity_tracker/tests/test_sync_commits.py
+++ b/github_activity_tracker/tests/test_sync_commits.py
@@ -225,7 +225,8 @@ def test_process_existing_commit_jsons_logs_on_bad_json(github_repository, tmp_p
 
 @pytest.mark.django_db
 def test_process_existing_commit_jsons_success_then_unlink(
-    github_repository, tmp_path,
+    github_repository,
+    tmp_path,
 ):
     sha = "a" * 40
     body = {
@@ -257,7 +258,8 @@ def test_process_existing_commit_jsons_success_then_unlink(
 
 @pytest.mark.django_db
 def test_sync_commits_normal_fetch_and_persist(
-    github_repository, tmp_path,
+    github_repository,
+    tmp_path,
 ):
     sha = "b" * 40
     commit_data = {
@@ -315,7 +317,8 @@ def test_sync_commits_normal_fetch_and_persist(
 
 @pytest.mark.django_db
 def test_sync_commits_big_commit_submits_worker(
-    github_repository, tmp_path,
+    github_repository,
+    tmp_path,
 ):
     sha = "c" * 40
     commit_data = {
@@ -379,7 +382,8 @@ def test_sync_commits_big_commit_submits_worker(
 
 @pytest.mark.django_db
 def test_sync_commits_big_worker_get_files_falls_back(
-    github_repository, tmp_path,
+    github_repository,
+    tmp_path,
 ):
     sha = "e" * 40
     commit_data = {
@@ -473,7 +477,8 @@ def test_sync_commits_raises_rate_limit(github_repository):
 
 @pytest.mark.django_db
 def test_sync_commits_future_result_exception_logged(
-    github_repository, tmp_path,
+    github_repository,
+    tmp_path,
 ):
     sha = "f" * 40
     commit_data = {

--- a/github_activity_tracker/tests/test_sync_commits.py
+++ b/github_activity_tracker/tests/test_sync_commits.py
@@ -1,6 +1,12 @@
+from concurrent.futures import Future
+import json
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from github_activity_tracker.models import FileChangeStatus
+from github_activity_tracker.sync import commits as sync_commits_mod
 from github_activity_tracker.sync.commits import _process_commit_files
 
 
@@ -193,3 +199,494 @@ def test_process_commit_files_renamed_already_linked_does_not_call_set_previous(
         deletions=0,
         patch="",
     )
+
+
+def test_commit_author_name_and_email_variants():
+    assert sync_commits_mod._commit_author_name_and_email({}) == ("unknown", "")
+    d = {"commit": {"author": {"name": None, "email": "  a@b.c "}}}
+    assert sync_commits_mod._commit_author_name_and_email(d) == ("unknown", "a@b.c")
+    d2 = {"commit": {"committer": {"name": "  x  ", "email": ""}}}
+    assert sync_commits_mod._commit_author_name_and_email(d2)[0] == "x"
+
+
+@pytest.mark.django_db
+def test_process_existing_commit_jsons_logs_on_bad_json(github_repository, tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{", encoding="utf-8")
+
+    with patch.object(
+        sync_commits_mod,
+        "iter_existing_commit_jsons",
+        lambda owner, repo: [bad],
+    ):
+        n = sync_commits_mod._process_existing_commit_jsons(github_repository)
+    assert n == 0
+
+
+@pytest.mark.django_db
+def test_process_existing_commit_jsons_success_then_unlink(
+    github_repository, tmp_path,
+):
+    sha = "a" * 40
+    body = {
+        "sha": sha,
+        "author": {
+            "id": github_repository.owner_account.github_account_id,
+            "login": github_repository.owner_account.username,
+            "name": "Owner",
+            "avatar_url": "",
+        },
+        "commit": {
+            "message": "msg",
+            "author": {"date": "2024-01-01T00:00:00Z", "name": "n", "email": "e@e"},
+        },
+        "files": [],
+    }
+    p = tmp_path / f"{sha}.json"
+    p.write_text(json.dumps(body), encoding="utf-8")
+
+    with patch.object(
+        sync_commits_mod,
+        "iter_existing_commit_jsons",
+        lambda owner, repo: [p],
+    ), patch.object(sync_commits_mod, "save_commit_raw_source"):
+        n = sync_commits_mod._process_existing_commit_jsons(github_repository)
+    assert n == 1
+    assert not p.exists()
+
+
+@pytest.mark.django_db
+def test_sync_commits_normal_fetch_and_persist(
+    github_repository, tmp_path,
+):
+    sha = "b" * 40
+    commit_data = {
+        "sha": sha,
+        "author": {
+            "id": github_repository.owner_account.github_account_id,
+            "login": github_repository.owner_account.username,
+            "name": "Owner",
+            "avatar_url": "",
+        },
+        "commit": {
+            "message": "hello",
+            "author": {"date": "2024-02-01T12:00:00Z"},
+        },
+        "files": [],
+    }
+
+    def fake_fetch(client, owner, repo, sd, ed, etag_cache=None):
+        yield commit_data
+
+    json_path = tmp_path / "staged.json"
+
+    class _Exec:
+        def submit(self, fn, *args, **kwargs):
+            fut = Future()
+            fut.set_result(None)
+            return fut
+
+        def shutdown(self, wait=True):
+            return None
+
+    with patch.object(
+        sync_commits_mod, "iter_existing_commit_jsons", lambda o, r: iter(())
+    ), patch.object(
+        sync_commits_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod.fetcher,
+        "fetch_commits_from_github",
+        fake_fetch,
+    ), patch.object(
+        sync_commits_mod.big_commit, "is_commit_truncated", return_value=False
+    ), patch.object(
+        sync_commits_mod, "get_commit_json_path", return_value=json_path
+    ), patch.object(
+        sync_commits_mod, "RedisListETagCache", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod, "save_commit_raw_source"
+    ), patch.object(
+        sync_commits_mod, "ThreadPoolExecutor", return_value=_Exec()
+    ):
+        sync_commits_mod.sync_commits(github_repository)
+
+    assert not json_path.exists()
+
+
+@pytest.mark.django_db
+def test_sync_commits_big_commit_submits_worker(
+    github_repository, tmp_path,
+):
+    sha = "c" * 40
+    commit_data = {
+        "sha": sha,
+        "parents": [{"sha": "d" * 40}],
+        "author": {
+            "id": github_repository.owner_account.github_account_id,
+            "login": github_repository.owner_account.username,
+            "name": "Owner",
+            "avatar_url": "",
+        },
+        "commit": {"message": "big", "author": {"date": "2024-02-02T12:00:00Z"}},
+        "files": [{"filename": "f.py"}] * 300,
+    }
+    out_json = tmp_path / "big_out.json"
+
+    def fake_fetch(client, owner, repo, sd, ed, etag_cache=None):
+        yield commit_data
+
+    class _Exec:
+        def __init__(self):
+            self._futures: list = []
+
+        def submit(self, fn, *args, **kwargs):
+            fn(*args, **kwargs)
+            fut = Future()
+            fut.set_result(None)
+            self._futures.append(fut)
+            return fut
+
+        def shutdown(self, wait=True):
+            return None
+
+    with patch.object(
+        sync_commits_mod, "iter_existing_commit_jsons", lambda o, r: iter(())
+    ), patch.object(
+        sync_commits_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod.fetcher,
+        "fetch_commits_from_github",
+        fake_fetch,
+    ), patch.object(
+        sync_commits_mod.big_commit, "is_commit_truncated", return_value=True
+    ), patch.object(
+        sync_commits_mod.big_commit,
+        "get_full_commit_files",
+        return_value=[{"filename": "only.py", "status": "added"}],
+    ), patch.object(
+        sync_commits_mod, "get_commit_json_path", return_value=out_json
+    ), patch.object(
+        sync_commits_mod, "RedisListETagCache", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod, "ThreadPoolExecutor", side_effect=lambda *a, **k: _Exec()
+    ), patch.object(
+        sync_commits_mod, "_process_existing_commit_jsons", return_value=0
+    ):
+        sync_commits_mod.sync_commits(github_repository)
+
+    assert out_json.is_file()
+
+
+@pytest.mark.django_db
+def test_sync_commits_big_worker_get_files_falls_back(
+    github_repository, tmp_path,
+):
+    sha = "e" * 40
+    commit_data = {
+        "sha": sha,
+        "parents": [],
+        "author": {
+            "id": github_repository.owner_account.github_account_id,
+            "login": github_repository.owner_account.username,
+            "name": "Owner",
+            "avatar_url": "",
+        },
+        "commit": {"message": "m", "author": {"date": "2024-02-03T12:00:00Z"}},
+        "files": [{"filename": "x", "status": "added"}],
+    }
+    out_json = tmp_path / "fb.json"
+
+    with patch.object(
+        sync_commits_mod.big_commit,
+        "get_full_commit_files",
+        side_effect=RuntimeError("git fail"),
+    ), patch.object(sync_commits_mod, "get_commit_json_path", return_value=out_json):
+        sync_commits_mod._process_big_commit_worker(
+            github_repository.owner_account.username,
+            github_repository.repo_name,
+            commit_data,
+        )
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["sha"] == sha
+    assert len(payload["files"]) == 1
+
+
+@pytest.mark.django_db
+def test_sync_commits_skips_fetch_item_without_sha(github_repository, tmp_path):
+    def fake_fetch(client, owner, repo, sd, ed, etag_cache=None):
+        yield {"sha": None}
+        yield {}
+
+    class _Exec:
+        def submit(self, *a, **k):
+            fut = Future()
+            fut.set_result(None)
+            return fut
+
+        def shutdown(self, wait=True):
+            return None
+
+    with patch.object(
+        sync_commits_mod, "iter_existing_commit_jsons", lambda o, r: iter(())
+    ), patch.object(
+        sync_commits_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod.fetcher,
+        "fetch_commits_from_github",
+        fake_fetch,
+    ), patch.object(
+        sync_commits_mod, "RedisListETagCache", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod, "ThreadPoolExecutor", return_value=_Exec()
+    ):
+        sync_commits_mod.sync_commits(github_repository)
+
+
+@pytest.mark.django_db
+def test_sync_commits_raises_rate_limit(github_repository):
+    from core.operations.github_ops.client import RateLimitException
+
+    def boom(*a, **k):
+        raise RateLimitException("rl")
+
+    class _Exec:
+        def submit(self, *a, **k):
+            return Future()
+
+        def shutdown(self, wait=True):
+            return None
+
+    with patch.object(
+        sync_commits_mod, "iter_existing_commit_jsons", lambda o, r: iter(())
+    ), patch.object(
+        sync_commits_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod.fetcher, "fetch_commits_from_github", boom
+    ), patch.object(
+        sync_commits_mod, "RedisListETagCache", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod, "ThreadPoolExecutor", return_value=_Exec()
+    ):
+        with pytest.raises(RateLimitException):
+            sync_commits_mod.sync_commits(github_repository)
+
+
+@pytest.mark.django_db
+def test_sync_commits_future_result_exception_logged(
+    github_repository, tmp_path,
+):
+    sha = "f" * 40
+    commit_data = {
+        "sha": sha,
+        "author": {
+            "id": github_repository.owner_account.github_account_id,
+            "login": github_repository.owner_account.username,
+            "name": "Owner",
+            "avatar_url": "",
+        },
+        "commit": {"message": "m", "author": {"date": "2024-02-04T12:00:00Z"}},
+        "files": [{"filename": "z", "status": "added"}] * 300,
+    }
+
+    def fake_fetch(client, owner, repo, sd, ed, etag_cache=None):
+        yield commit_data
+
+    fut = Future()
+    fut.set_exception(RuntimeError("worker boom"))
+
+    class _Exec:
+        def submit(self, *a, **k):
+            return fut
+
+        def shutdown(self, wait=True):
+            return None
+
+    with patch.object(
+        sync_commits_mod, "iter_existing_commit_jsons", lambda o, r: iter(())
+    ), patch.object(
+        sync_commits_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod.fetcher,
+        "fetch_commits_from_github",
+        fake_fetch,
+    ), patch.object(
+        sync_commits_mod.big_commit, "is_commit_truncated", return_value=True
+    ), patch.object(
+        sync_commits_mod, "RedisListETagCache", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod, "ThreadPoolExecutor", return_value=_Exec()
+    ), patch.object(
+        sync_commits_mod, "_process_existing_commit_jsons", return_value=0
+    ):
+        sync_commits_mod.sync_commits(github_repository)
+
+
+@pytest.mark.django_db
+def test_process_commit_data_unknown_author_and_files(github_repository):
+    sha = "1" * 40
+    data = {
+        "sha": sha,
+        "commit": {
+            "message": "m",
+            "author": {"date": "2024-01-05T00:00:00Z", "name": None, "email": "a@b"},
+        },
+        "files": [{"filename": "x.py", "status": "added", "additions": 1}],
+    }
+    sync_commits_mod._process_commit_data(github_repository, data)
+    assert github_repository.commits.filter(commit_hash=sha).exists()
+
+
+@pytest.mark.django_db
+def test_sync_commits_start_date_from_last_commit(github_repository):
+    from github_activity_tracker.models import GitCommit
+
+    GitCommit.objects.create(
+        repo=github_repository,
+        account=github_repository.owner_account,
+        commit_hash="0" * 40,
+        comment="",
+        commit_at=datetime(2024, 7, 1, tzinfo=timezone.utc),
+    )
+    mock_fetch = MagicMock(return_value=[])
+
+    class _Exec:
+        def submit(self, *a, **k):
+            fut = Future()
+            fut.set_result(None)
+            return fut
+
+        def shutdown(self, wait=True):
+            return None
+
+    with patch.object(
+        sync_commits_mod, "iter_existing_commit_jsons", lambda o, r: iter(())
+    ), patch.object(
+        sync_commits_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod.fetcher,
+        "fetch_commits_from_github",
+        mock_fetch,
+    ), patch.object(
+        sync_commits_mod, "RedisListETagCache", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod, "ThreadPoolExecutor", return_value=_Exec()
+    ):
+        sync_commits_mod.sync_commits(github_repository)
+
+    start = mock_fetch.call_args[0][3]
+    assert start == datetime(2024, 7, 1, 0, 0, 1, tzinfo=timezone.utc)
+
+
+@pytest.mark.django_db
+def test_sync_commits_unexpected_exception(github_repository):
+    class _Exec:
+        def submit(self, *a, **k):
+            fut = Future()
+            fut.set_result(None)
+            return fut
+
+        def shutdown(self, wait=True):
+            return None
+
+    with patch.object(
+        sync_commits_mod, "iter_existing_commit_jsons", lambda o, r: iter(())
+    ), patch.object(
+        sync_commits_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod.fetcher,
+        "fetch_commits_from_github",
+        side_effect=ValueError("unexpected"),
+    ), patch.object(
+        sync_commits_mod, "RedisListETagCache", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod, "ThreadPoolExecutor", return_value=_Exec()
+    ):
+        with pytest.raises(ValueError, match="unexpected"):
+            sync_commits_mod.sync_commits(github_repository)
+
+
+@pytest.mark.django_db
+def test_process_big_commit_worker_primary_write_fails_then_fallback():
+    sha = "2" * 40
+    commit_data = {
+        "sha": sha,
+        "parents": [],
+        "commit": {"message": "m", "author": {"date": "2024-01-01T00:00:00Z"}},
+        "files": [{"filename": "f", "status": "added"}],
+    }
+    primary = MagicMock()
+    primary.parent.mkdir = MagicMock()
+    primary.write_text = MagicMock(side_effect=OSError("disk full"))
+    fallback = MagicMock()
+    fallback.parent.mkdir = MagicMock()
+    fallback.write_text = MagicMock()
+
+    with patch.object(
+        sync_commits_mod,
+        "get_commit_json_path",
+        side_effect=[primary, fallback],
+    ), patch.object(
+        sync_commits_mod.big_commit,
+        "get_full_commit_files",
+        return_value=[{"filename": "g.py", "status": "added"}],
+    ):
+        sync_commits_mod._process_big_commit_worker("o", "r", commit_data)
+
+    fallback.write_text.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_sync_commits_logs_existing_json_count(github_repository):
+    class _Exec:
+        def submit(self, *a, **k):
+            fut = Future()
+            fut.set_result(None)
+            return fut
+
+        def shutdown(self, wait=True):
+            return None
+
+    with patch.object(
+        sync_commits_mod, "_process_existing_commit_jsons", return_value=4
+    ), patch.object(
+        sync_commits_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod.fetcher,
+        "fetch_commits_from_github",
+        lambda *a, **k: iter(()),
+    ), patch.object(
+        sync_commits_mod, "RedisListETagCache", return_value=MagicMock()
+    ), patch.object(
+        sync_commits_mod, "ThreadPoolExecutor", return_value=_Exec()
+    ):
+        sync_commits_mod.sync_commits(github_repository)
+
+
+@pytest.mark.django_db
+def test_process_big_commit_worker_fallback_write_also_fails():
+    sha = "3" * 40
+    commit_data = {
+        "sha": sha,
+        "parents": [],
+        "commit": {"message": "m", "author": {"date": "2024-01-01T00:00:00Z"}},
+        "files": [],
+    }
+    primary = MagicMock()
+    primary.parent.mkdir = MagicMock()
+    primary.write_text = MagicMock(side_effect=OSError("primary fail"))
+    fallback = MagicMock()
+    fallback.parent.mkdir = MagicMock()
+    fallback.write_text = MagicMock(side_effect=OSError("fallback fail"))
+
+    with patch.object(
+        sync_commits_mod,
+        "get_commit_json_path",
+        side_effect=[primary, fallback],
+    ), patch.object(
+        sync_commits_mod.big_commit,
+        "get_full_commit_files",
+        return_value=[{"filename": "z.py", "status": "added"}],
+    ):
+        sync_commits_mod._process_big_commit_worker("o", "r", commit_data)
+
+    fallback.write_text.assert_called_once()

--- a/github_activity_tracker/tests/test_sync_issues_and_prs.py
+++ b/github_activity_tracker/tests/test_sync_issues_and_prs.py
@@ -1,8 +1,12 @@
 """Tests for sync_issues_and_prs unified sync function."""
 
+import json
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from github_activity_tracker.sync import issues_and_prs as issues_mod
 from github_activity_tracker.sync.issues_and_prs import (
     sync_issues_and_prs,
 )
@@ -198,3 +202,445 @@ def test_sync_issues_and_prs_saves_and_removes_json_files(
     mock_json_path.parent.mkdir.assert_called_once()
     mock_json_path.write_text.assert_called_once()
     mock_json_path.unlink.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_process_issue_data_skips_without_user(github_repository):
+    issue = {"number": 1, "user": None}
+    issues_mod._process_issue_data(github_repository, issue)
+
+
+@pytest.mark.django_db
+def test_process_pr_data_skips_without_user(github_repository):
+    pr = {"pr_info": {"number": 2, "user": None}}
+    issues_mod._process_pr_data(github_repository, pr)
+
+
+@pytest.mark.django_db
+def test_process_existing_issue_jsons_bad_file(github_repository, tmp_path):
+    p = tmp_path / "x.json"
+    p.write_text("{", encoding="utf-8")
+    with patch.object(
+        issues_mod,
+        "iter_existing_issue_jsons",
+        lambda owner, repo: [p],
+    ):
+        n, nums = issues_mod._process_existing_issue_jsons(github_repository)
+    assert n == 0 and nums == []
+
+
+@pytest.mark.django_db
+def test_process_existing_pr_jsons_bad_file(github_repository, tmp_path):
+    p = tmp_path / "p.json"
+    p.write_text("{", encoding="utf-8")
+    with patch.object(
+        issues_mod,
+        "iter_existing_pr_jsons",
+        lambda owner, repo: [p],
+    ):
+        n, nums = issues_mod._process_existing_pr_jsons(github_repository)
+    assert n == 0 and nums == []
+
+
+@pytest.mark.django_db
+def test_sync_issues_and_prs_issue_branch_none_number_skipped(github_repository):
+    item = {"issue_info": {"number": None}, "comments": []}
+
+    with patch.object(
+        issues_mod, "_process_existing_issue_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "_process_existing_pr_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        issues_mod.fetcher,
+        "fetch_issues_and_prs_from_github",
+        lambda *a, **k: [item],
+    ), patch.object(issues_mod, "RedisListETagCache", return_value=MagicMock()):
+        out = issues_mod.sync_issues_and_prs(github_repository)
+    assert out["issues"] == []
+
+
+@pytest.mark.django_db
+def test_sync_issues_and_prs_unexpected_error_wraps(github_repository):
+    with patch.object(
+        issues_mod, "_process_existing_issue_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "_process_existing_pr_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "get_github_client", side_effect=RuntimeError("boom")
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            issues_mod.sync_issues_and_prs(github_repository)
+
+
+@pytest.mark.django_db
+def test_sync_issues_start_date_issue_only_branch(github_repository):
+    """When only last_issue exists, start_date is issue_date + 1s."""
+    from github_activity_tracker.models import Issue
+
+    Issue.objects.create(
+        repo=github_repository,
+        account=github_repository.owner_account,
+        issue_id=900002,
+        issue_number=2,
+        title="t",
+        body="",
+        state="open",
+        state_reason="",
+        issue_created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        issue_updated_at=datetime(2024, 4, 10, tzinfo=timezone.utc),
+    )
+
+    mock_fetch = MagicMock(return_value=[])
+
+    with patch.object(
+        issues_mod, "_process_existing_issue_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "_process_existing_pr_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        issues_mod.fetcher,
+        "fetch_issues_and_prs_from_github",
+        mock_fetch,
+    ), patch.object(issues_mod, "RedisListETagCache", return_value=MagicMock()):
+        issues_mod.sync_issues_and_prs(github_repository)
+
+    start = mock_fetch.call_args[0][3]
+    assert start == datetime(2024, 4, 10, 0, 0, 1, tzinfo=timezone.utc)
+
+
+@pytest.mark.django_db
+def test_sync_issues_start_date_pr_only_branch(github_repository):
+    from github_activity_tracker.models import PullRequest
+
+    PullRequest.objects.create(
+        repo=github_repository,
+        account=github_repository.owner_account,
+        pr_id=800001,
+        pr_number=3,
+        title="p",
+        body="",
+        state="open",
+        head_hash="",
+        base_hash="",
+        pr_created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        pr_updated_at=datetime(2024, 5, 5, tzinfo=timezone.utc),
+    )
+
+    mock_fetch = MagicMock(return_value=[])
+
+    with patch.object(
+        issues_mod, "_process_existing_issue_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "_process_existing_pr_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        issues_mod.fetcher,
+        "fetch_issues_and_prs_from_github",
+        mock_fetch,
+    ), patch.object(issues_mod, "RedisListETagCache", return_value=MagicMock()):
+        issues_mod.sync_issues_and_prs(github_repository)
+
+    start = mock_fetch.call_args[0][3]
+    assert start == datetime(2024, 5, 5, 0, 0, 1, tzinfo=timezone.utc)
+
+
+@pytest.mark.django_db
+def test_process_issue_data_assignees_labels_and_comments(
+    github_repository, make_github_account
+):
+    owner_acc = github_repository.owner_account
+    other = make_github_account(
+        github_account_id=888001,
+        username="assignee-user",
+    )
+    data = {
+        "number": 601,
+        "id": 9000601,
+        "title": "Issue T",
+        "body": "body",
+        "state": "open",
+        "state_reason": "",
+        "user": {
+            "id": owner_acc.github_account_id,
+            "login": owner_acc.username,
+            "name": "",
+            "avatar_url": "",
+        },
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+        "closed_at": None,
+        "comments": [
+            {
+                "id": 77001,
+                "body": "c1",
+                "user": {
+                    "id": other.github_account_id,
+                    "login": other.username,
+                    "name": "",
+                    "avatar_url": "",
+                },
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z",
+            },
+            {
+                "id": 77002,
+                "body": "no user",
+                "user": None,
+            },
+        ],
+        "assignees": [
+            {
+                "id": owner_acc.github_account_id,
+                "login": owner_acc.username,
+                "name": "",
+                "avatar_url": "",
+            },
+            {
+                "id": other.github_account_id,
+                "login": other.username,
+                "name": "",
+                "avatar_url": "",
+            },
+        ],
+        "labels": [{"name": "bug"}, {"name": "docs"}],
+    }
+    issues_mod._process_issue_data(github_repository, data)
+    issue = github_repository.issues.get(issue_number=601)
+    assert issue.comments.count() == 1
+    assert issue.assignees.count() == 2
+    assert {il.label_name for il in issue.labels.all()} == {"bug", "docs"}
+
+    data2 = {
+        **data,
+        "comments": [
+            {
+                "id": 77001,
+                "body": "updated",
+                "user": {
+                    "id": other.github_account_id,
+                    "login": other.username,
+                    "name": "",
+                    "avatar_url": "",
+                },
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-03T00:00:00Z",
+            }
+        ],
+        "assignees": [data["assignees"][0]],
+        "labels": [{"name": "bug"}],
+    }
+    issues_mod._process_issue_data(github_repository, data2)
+    issue.refresh_from_db()
+    assert issue.comments.get(issue_comment_id=77001).body == "updated"
+    assert issue.assignees.count() == 1
+    assert {il.label_name for il in issue.labels.all()} == {"bug"}
+
+
+@pytest.mark.django_db
+def test_process_pr_data_reviews_comments_labels(
+    github_repository, make_github_account
+):
+    owner_acc = github_repository.owner_account
+    reviewer = make_github_account(github_account_id=888002, username="rev")
+    pr_payload = {
+        "number": 701,
+        "id": 8000701,
+        "title": "PR",
+        "body": "",
+        "state": "open",
+        "user": {
+            "id": owner_acc.github_account_id,
+            "login": owner_acc.username,
+            "name": "",
+            "avatar_url": "",
+        },
+        "head": {"sha": "abc"},
+        "base": {"sha": "def"},
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+        "merged_at": None,
+        "closed_at": None,
+        "comments": [
+            {
+                "id": 88001,
+                "body": "pc",
+                "user": {
+                    "id": reviewer.github_account_id,
+                    "login": reviewer.username,
+                    "name": "",
+                    "avatar_url": "",
+                },
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z",
+            }
+        ],
+        "reviews": [
+            {
+                "id": 99001,
+                "body": "lgtm",
+                "in_reply_to_id": None,
+                "user": {
+                    "id": reviewer.github_account_id,
+                    "login": reviewer.username,
+                    "name": "",
+                    "avatar_url": "",
+                },
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z",
+            },
+            {
+                "id": 99002,
+                "body": "skip",
+                "user": None,
+            },
+        ],
+        "assignees": [
+            {
+                "id": owner_acc.github_account_id,
+                "login": owner_acc.username,
+                "name": "",
+                "avatar_url": "",
+            },
+            {
+                "id": reviewer.github_account_id,
+                "login": reviewer.username,
+                "name": "",
+                "avatar_url": "",
+            },
+        ],
+        "labels": [{"name": "pr-label"}],
+    }
+    issues_mod._process_pr_data(github_repository, pr_payload)
+    pr = github_repository.pull_requests.get(pr_number=701)
+    assert pr.comments.count() == 1
+    assert pr.reviews.count() == 1
+    assert pr.assignees.count() == 2
+
+    pr_payload2 = {
+        **pr_payload,
+        "assignees": [pr_payload["assignees"][0]],
+        "labels": [],
+    }
+    issues_mod._process_pr_data(github_repository, pr_payload2)
+    pr.refresh_from_db()
+    assert pr.assignees.count() == 1
+    assert list(pr.labels.all()) == []
+
+
+@pytest.mark.django_db
+def test_sync_issues_and_prs_rate_limit(github_repository):
+    from core.operations.github_ops.client import RateLimitException
+
+    with patch.object(
+        issues_mod, "_process_existing_issue_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "_process_existing_pr_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "get_github_client", side_effect=RateLimitException("rl")
+    ):
+        with pytest.raises(RateLimitException):
+            issues_mod.sync_issues_and_prs(github_repository)
+
+
+@pytest.mark.django_db
+def test_process_existing_issue_jsons_success_nested(
+    github_repository, tmp_path,
+):
+    owner_acc = github_repository.owner_account
+    body = {
+        "issue_info": {
+            "number": 602,
+            "id": 9000602,
+            "title": "nested",
+            "body": "",
+            "state": "open",
+            "state_reason": "",
+            "user": {
+                "id": owner_acc.github_account_id,
+                "login": owner_acc.username,
+                "name": "",
+                "avatar_url": "",
+            },
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-02T00:00:00Z",
+            "closed_at": None,
+            "comments": [],
+            "assignees": [],
+            "labels": [],
+        },
+        "comments": [],
+    }
+    p = tmp_path / "602.json"
+    p.write_text(json.dumps(body), encoding="utf-8")
+    with patch.object(
+        issues_mod,
+        "iter_existing_issue_jsons",
+        lambda owner, repo: [p],
+    ), patch.object(issues_mod, "save_issue_raw_source"):
+        n, nums = issues_mod._process_existing_issue_jsons(github_repository)
+    assert n == 1 and nums == [602]
+    assert not p.exists()
+
+
+@pytest.mark.django_db
+def test_sync_issues_pr_info_present_but_number_none(github_repository):
+    item = {"pr_info": {}, "comments": []}
+    with patch.object(
+        issues_mod, "_process_existing_issue_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "_process_existing_pr_jsons", return_value=(0, [])
+    ), patch.object(
+        issues_mod, "get_github_client", return_value=MagicMock()
+    ), patch.object(
+        issues_mod.fetcher,
+        "fetch_issues_and_prs_from_github",
+        lambda *a, **k: [item],
+    ), patch.object(issues_mod, "RedisListETagCache", return_value=MagicMock()):
+        out = issues_mod.sync_issues_and_prs(github_repository)
+    assert out["pull_requests"] == []
+
+
+@pytest.mark.django_db
+def test_process_existing_pr_jsons_success_nested(github_repository, tmp_path):
+    owner_acc = github_repository.owner_account
+    body = {
+        "pr_info": {
+            "number": 703,
+            "id": 8000703,
+            "title": "pr nested",
+            "body": "",
+            "state": "open",
+            "user": {
+                "id": owner_acc.github_account_id,
+                "login": owner_acc.username,
+                "name": "",
+                "avatar_url": "",
+            },
+            "head": {"sha": "a"},
+            "base": {"sha": "b"},
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-02T00:00:00Z",
+            "merged_at": None,
+            "closed_at": None,
+            "comments": [],
+            "reviews": [],
+            "assignees": [],
+            "labels": [],
+        },
+        "comments": [],
+        "reviews": [],
+    }
+    p = tmp_path / "703.json"
+    p.write_text(json.dumps(body), encoding="utf-8")
+    with patch.object(
+        issues_mod,
+        "iter_existing_pr_jsons",
+        lambda owner, repo: [p],
+    ), patch.object(issues_mod, "save_pr_raw_source"):
+        n, nums = issues_mod._process_existing_pr_jsons(github_repository)
+    assert n == 1 and nums == [703]
+    assert not p.exists()

--- a/github_activity_tracker/tests/test_sync_issues_and_prs.py
+++ b/github_activity_tracker/tests/test_sync_issues_and_prs.py
@@ -256,7 +256,9 @@ def test_sync_issues_and_prs_issue_branch_none_number_skipped(github_repository)
         issues_mod.fetcher,
         "fetch_issues_and_prs_from_github",
         lambda *a, **k: [item],
-    ), patch.object(issues_mod, "RedisListETagCache", return_value=MagicMock()):
+    ), patch.object(
+        issues_mod, "RedisListETagCache", return_value=MagicMock()
+    ):
         out = issues_mod.sync_issues_and_prs(github_repository)
     assert out["issues"] == []
 
@@ -304,7 +306,9 @@ def test_sync_issues_start_date_issue_only_branch(github_repository):
         issues_mod.fetcher,
         "fetch_issues_and_prs_from_github",
         mock_fetch,
-    ), patch.object(issues_mod, "RedisListETagCache", return_value=MagicMock()):
+    ), patch.object(
+        issues_mod, "RedisListETagCache", return_value=MagicMock()
+    ):
         issues_mod.sync_issues_and_prs(github_repository)
 
     start = mock_fetch.call_args[0][3]
@@ -341,7 +345,9 @@ def test_sync_issues_start_date_pr_only_branch(github_repository):
         issues_mod.fetcher,
         "fetch_issues_and_prs_from_github",
         mock_fetch,
-    ), patch.object(issues_mod, "RedisListETagCache", return_value=MagicMock()):
+    ), patch.object(
+        issues_mod, "RedisListETagCache", return_value=MagicMock()
+    ):
         issues_mod.sync_issues_and_prs(github_repository)
 
     start = mock_fetch.call_args[0][3]
@@ -548,7 +554,8 @@ def test_sync_issues_and_prs_rate_limit(github_repository):
 
 @pytest.mark.django_db
 def test_process_existing_issue_jsons_success_nested(
-    github_repository, tmp_path,
+    github_repository,
+    tmp_path,
 ):
     owner_acc = github_repository.owner_account
     body = {
@@ -599,7 +606,9 @@ def test_sync_issues_pr_info_present_but_number_none(github_repository):
         issues_mod.fetcher,
         "fetch_issues_and_prs_from_github",
         lambda *a, **k: [item],
-    ), patch.object(issues_mod, "RedisListETagCache", return_value=MagicMock()):
+    ), patch.object(
+        issues_mod, "RedisListETagCache", return_value=MagicMock()
+    ):
         out = issues_mod.sync_issues_and_prs(github_repository)
     assert out["pull_requests"] == []
 

--- a/github_activity_tracker/tests/test_sync_utils.py
+++ b/github_activity_tracker/tests/test_sync_utils.py
@@ -1,8 +1,14 @@
-"""Tests for github_activity_tracker.sync utils (parse_github_user, parse_datetime)."""
+"""Tests for github_activity_tracker.sync.utils (normalize, parse_github_user, parse_datetime)."""
 
 import pytest
 from datetime import datetime, timezone
-from github_activity_tracker.sync.utils import parse_github_user, parse_datetime
+
+from github_activity_tracker.sync.utils import (
+    normalize_issue_json,
+    normalize_pr_json,
+    parse_datetime,
+    parse_github_user,
+)
 
 
 def test_parse_github_user_none():
@@ -71,3 +77,33 @@ def test_parse_datetime_parametrized(date_str, expected_year):
     result = parse_datetime(date_str)
     assert result is not None
     assert result.year == expected_year
+
+
+def test_normalize_issue_json_non_dict_issue_info():
+    out = normalize_issue_json({"issue_info": "bad", "number": 1})
+    assert out["issue_info"] == "bad"
+
+
+def test_normalize_pr_json_non_dict_pr_info():
+    out = normalize_pr_json({"pr_info": None, "number": 2})
+    assert out["pr_info"] is None
+
+
+def test_normalize_issue_nested_non_list_comments_becomes_empty():
+    data = {
+        "issue_info": {"number": 3, "title": "t"},
+        "comments": "not-a-list",
+    }
+    out = normalize_issue_json(data)
+    assert out["comments"] == []
+
+
+def test_normalize_pr_nested_non_list_comments_and_reviews():
+    data = {
+        "pr_info": {"number": 4},
+        "comments": {},
+        "reviews": "x",
+    }
+    out = normalize_pr_json(data)
+    assert out["comments"] == []
+    assert out["reviews"] == []


### PR DESCRIPTION
Closes #167 , closes #170 , closes #171 , closes #172

## Summary

Adds and extends **unit tests** (mostly mocks / fixtures) across **`clang_github_tracker`**, **`core`**, **`github_activity_tracker`**, and **`cppa_slack_tracker`** so sync paths, GitHub helpers, Slack services, and related utilities fail loudly in CI when behavior regresses.

## Changes

### Coverage configuration

- **`.coveragerc`** — pytest-cov / CI alignment (omit patterns, report options).

### By package

| Area | What changed |
|------|----------------|
| **`clang_github_tracker`** | More coverage for backfill, preprocessors, publisher, services, sync raw, workspace. |
| **`core`** | New/expanded tests for GitHub client pagination/rate limit/rest/submodules/tags, git ops (clone errors, remote listing, session wait), markdown/GitHub export, Slack fetcher/tokens, transcripts/HTML/md helpers, errors/classification, startup notification, collectors base, workspace orphans cleanup, datetime/text/version helpers. |
| **`github_activity_tracker`** | Larger suites for sync commits, issues/PRs, and sync utils. |
| **`cppa_slack_tracker`** | Additional **services** and **sync_units** tests. |

## How to test

```bash
pytest -q
#optional per-app spot checks:
pytest -q --cov=clang_github_tracker --cov-report=term-missing
pytest -q --cov=core --cov-report=term-missing
pytest -q --cov=github_activity_tracker --cov-report=term-missing
pytest -q --cov=cppa_slack_tracker --cov-report=term-missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Greatly expanded unit and integration test coverage across many components (Git/GitHub ops, Slack, sync pipelines, exporters, text/MD ops, workspace, commit/issue/PR sync, and more).

* **Chores**
  * Added Coverage.py configuration for consistent reports.
  * CI and test settings updated to opt into Postgres tests via an env flag; pytest now prefers SQLite unless Postgres is explicitly enabled.

* **Bug Fixes**
  * Improved Windows OS error classification to better detect network failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->