### PR TITLE
promote test coverage for slack tracker

### DIFF
--- a/core/errors.py
+++ b/core/errors.py
@@ -138,7 +138,9 @@ def classify_failure(exc: BaseException) -> CollectorFailureCategory:
     """
     Map an exception to a failure category for structured logging.
 
-    Keep this conservative: unknown is fine when we cannot infer intent.
+    ``requests.HTTPError`` with ``response.status_code`` 429 maps to
+    :attr:`CollectorFailureCategory.RATE_LIMIT`; 401 and 403 map to
+    :attr:`CollectorFailureCategory.AUTH`. Other cases stay conservative.
     """
     # Django / app
     try:
@@ -165,7 +167,15 @@ def classify_failure(exc: BaseException) -> CollectorFailureCategory:
     exc_mod = type(exc).__module__
     exc_name = type(exc).__name__
     if exc_mod.startswith("requests.exceptions"):
-        if exc_name in ("HTTPError", "SSLError"):
+        if exc_name == "HTTPError":
+            response = getattr(exc, "response", None)
+            status = getattr(response, "status_code", None)
+            if status == 429:
+                return CollectorFailureCategory.RATE_LIMIT
+            if status in (401, 403):
+                return CollectorFailureCategory.AUTH
+            return CollectorFailureCategory.NETWORK
+        if exc_name == "SSLError":
             return CollectorFailureCategory.NETWORK
         if exc_name.endswith("Timeout"):
             return CollectorFailureCategory.TIMEOUT

--- a/core/tests/test_errors.py
+++ b/core/tests/test_errors.py
@@ -166,6 +166,53 @@ def test_classify_requests_exceptions(name, category):
     assert classify_failure(cls("x")) is category
 
 
+def _http_error_with_status(status_code: int | None):
+    pytest.importorskip("requests")
+    import requests
+
+    exc = requests.HTTPError()
+    if status_code is None:
+        exc.response = None
+    else:
+        resp = requests.Response()
+        resp.status_code = status_code
+        exc.response = resp
+    return exc
+
+
+def test_classify_requests_http_error_429_rate_limit():
+    assert (
+        classify_failure(_http_error_with_status(429))
+        is CollectorFailureCategory.RATE_LIMIT
+    )
+
+
+def test_classify_requests_http_error_401_auth():
+    assert (
+        classify_failure(_http_error_with_status(401)) is CollectorFailureCategory.AUTH
+    )
+
+
+def test_classify_requests_http_error_403_auth():
+    assert (
+        classify_failure(_http_error_with_status(403)) is CollectorFailureCategory.AUTH
+    )
+
+
+def test_classify_requests_http_error_other_status_network():
+    assert (
+        classify_failure(_http_error_with_status(500))
+        is CollectorFailureCategory.NETWORK
+    )
+
+
+def test_classify_requests_http_error_no_response_network():
+    assert (
+        classify_failure(_http_error_with_status(None))
+        is CollectorFailureCategory.NETWORK
+    )
+
+
 @pytest.mark.parametrize(
     ("name", "category"),
     [

--- a/cppa_slack_tracker/tests/test_slack_http_and_tokens.py
+++ b/cppa_slack_tracker/tests/test_slack_http_and_tokens.py
@@ -1,0 +1,115 @@
+"""
+Slack HTTP client and token resolution tests under cppa_slack_tracker (issue coverage).
+
+Uses unittest.mock; exercises SlackAPIClient rate-limit/auth paths and token helpers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.errors import CollectorFailureCategory, classify_failure
+from core.operations.slack_ops.client import SlackAPIClient
+from core.operations.slack_ops.tokens import (
+    get_slack_app_token,
+    get_slack_client,
+)
+
+
+def test_rate_limit_429_header_retries_then_succeeds():
+    """HTTP 429 with Retry-After: client retries then returns JSON."""
+    c = SlackAPIClient("xoxb-test")
+    ok = MagicMock(
+        status_code=200,
+        json=lambda: {"ok": True, "channels": []},
+        headers={},
+        raise_for_status=MagicMock(),
+    )
+    rate_limited = MagicMock(
+        status_code=429,
+        headers={"Retry-After": "1"},
+        json=lambda: {},
+        raise_for_status=MagicMock(),
+    )
+    c.session.get = MagicMock(side_effect=[rate_limited, ok])
+    with patch("core.operations.slack_ops.client.time.sleep") as sleep_mock:
+        out = c.conversations_list()
+    assert out == {"ok": True, "channels": []}
+    sleep_mock.assert_called_once_with(1)
+
+
+def test_rate_limit_body_error_rate_limited_retries():
+    """Slack body error=rate_limited: client reads Retry-After header and retries."""
+    c = SlackAPIClient("xoxb-test")
+    first = MagicMock(
+        status_code=200,
+        json=lambda: {"ok": False, "error": "rate_limited"},
+        headers={"Retry-After": "2"},
+        raise_for_status=MagicMock(),
+    )
+    second = MagicMock(
+        status_code=200,
+        json=lambda: {"ok": True, "channels": [{"id": "C1"}]},
+        headers={},
+        raise_for_status=MagicMock(),
+    )
+    c.session.get = MagicMock(side_effect=[first, second])
+    with patch("core.operations.slack_ops.client.time.sleep") as sleep_mock:
+        out = c.conversations_list()
+    assert out["ok"] is True
+    assert out["channels"] == [{"id": "C1"}]
+    sleep_mock.assert_called_once_with(2)
+
+
+def test_auth_failure_invalid_auth_body():
+    """Slack returns ok=False invalid_auth in JSON; client returns dict (no raise)."""
+    c = SlackAPIClient("xoxb-bad")
+    resp = MagicMock(
+        status_code=200,
+        json=lambda: {"ok": False, "error": "invalid_auth"},
+        headers={},
+        raise_for_status=MagicMock(),
+    )
+    c.session.get = MagicMock(return_value=resp)
+    with patch("core.operations.slack_ops.client.time.sleep"):
+        out = c.conversations_list()
+    assert out == {"ok": False, "error": "invalid_auth"}
+
+
+def test_auth_failure_http_401_classifies_as_auth():
+    """CollectorFailureCategory: HTTP 401 maps to AUTH."""
+    pytest.importorskip("requests")
+    import requests
+
+    exc = requests.HTTPError()
+    resp = requests.Response()
+    resp.status_code = 401
+    exc.response = resp
+    assert classify_failure(exc) is CollectorFailureCategory.AUTH
+
+
+def test_get_slack_client_with_explicit_bot_token():
+    client = get_slack_client(bot_token="xoxb-test")
+    assert client.token == "xoxb-test"
+
+
+def test_get_slack_client_for_team_id_resolves_from_settings(settings):
+    settings.SLACK_BOT_TOKEN = {"T1": "xoxb-from-settings"}
+    settings.SLACK_TEAM_ID = "T1"
+    client = get_slack_client(team_id="T1")
+    assert client.token == "xoxb-from-settings"
+
+
+def test_get_slack_app_token_happy_path(settings):
+    settings.SLACK_APP_TOKEN = {"T1": "xapp-ok"}
+    settings.SLACK_TEAM_ID = "T1"
+    assert get_slack_app_token("T1") == "xapp-ok"
+
+
+def test_get_slack_app_token_missing_raises_value_error(settings):
+    settings.SLACK_APP_TOKEN = {}
+    settings.SLACK_TEAM_ID = "T1"
+    with pytest.raises(ValueError, match="SLACK_APP_TOKEN"):
+        get_slack_app_token("T1")


### PR DESCRIPTION
### Implemented
1. core/errors.py
  - For requests.exceptions.HTTPError, classify_failure now uses exc.response.status_code: 429 → RATE_LIMIT, 401/403 → AUTH, everything else in that branch → NETWORK.
  - SSLError still maps straight to NETWORK (unchanged).
  - Docstring updated to describe HTTP status handling.
2. core/tests/test_errors.py
  - Helpers + tests for real requests.HTTPError: 429, 401, 403, 500, and response=None (expects NETWORK where appropriate).
3. cppa_slack_tracker/tests/test_slack_http_and_tokens.py (new)
  - 429 + Retry-After → retry then success (conversations_list() + mocked session.get).
  - Body rate_limited + header Retry-After → retry then success.
  - invalid_auth JSON → returned as-is (no raise).
  - HTTPError + 401 → classify_failure → AUTH.
  - Bot token: explicit bot_token and team_id + SLACK_BOT_TOKEN.
  - App token: happy path + missing token ValueError.
4. Unrelated fix (full suite was failing)
- cppa_youtube_script_tracker/tests/test_utils_.py: test_extract_speakers_from_description_intro_pattern used in on a list as if it were a string; it now checks any("Herb Sutter" in x for x in got).

### Verification
  - pytest --cov --cov-fail-under=90: 2562 passed, coverage ~90.93% (above 90%).
  - pytest cppa_slack_tracker/tests/ --cov=cppa_slack_tracker: 177 passed, package coverage ~92.94% (above 80%).
  
 close https://github.com/cppalliance/boost-data-collector/issues/195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced HTTP error classification to properly distinguish between rate limit responses (429), authentication failures (401/403), and general network errors for more accurate error handling and recovery.

* **Tests**
  * Added extensive test coverage for HTTP error classification scenarios, rate limit retry mechanisms, authentication failure cases, and Slack token resolution helpers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/boost-data-collector/pull/196)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->