### PR TITLE
chore: require PostgreSQL for pytest; add docker-compose.test.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,33 +1,37 @@
-# Copy this file to .env and fill in your values.
+# ==============================================================================
+# Environment configuration (template)
+# ==============================================================================
+# Copy this file to `.env` in the project root and replace placeholder values.
+# Do not commit a real `.env` file; keep secrets in a password manager or your
+# platform's secret store (for example Google Secret Manager).
 
-# =============================================================================
-# Database (PostgreSQL) - use one of the options below
-# =============================================================================
-# Django reads DATABASE_URL; all components can also be set via DB_* overrides.
-# Format: postgres://USER:PASSWORD@HOST:PORT/NAME
-# For postgresql 3 (psycopg): use postgres:// or postgresql://
+# ==============================================================================
+# Database and automated tests
+# ==============================================================================
+# Primary connection string. Django reads `DATABASE_URL` via django-environ.
+# Use `postgres://` or `postgresql://` (Psycopg 3 accepts both).
+#
+# Alternative: omit `DATABASE_URL` and set `DB_NAME`, `DB_USER`, `DB_PASSWORD`,
+# `DB_HOST`, `DB_PORT`, and optionally `DB_OPTIONS_SSLMODE` (see block below).
 
-# --- Option A: Local PostgreSQL ---
-# DATABASE_URL=postgres://user:password@localhost:5432/boost_dashboard
-
-# --- Option B: Google Cloud SQL (via Cloud SQL Auth Proxy) ---
-# Run the proxy locally, then connect to localhost as if it were the instance:
+# --- Examples by hosting type (uncomment and edit one) ---
+# Local PostgreSQL:
+# DATABASE_URL=postgres://USER:PASSWORD@localhost:5432/boost_dashboard
+#
+# Google Cloud SQL via Auth Proxy (run proxy first, then point at localhost):
 #   cloud_sql_proxy -instances=PROJECT:REGION:INSTANCE=tcp:5432
 # DATABASE_URL=postgres://USER:PASSWORD@127.0.0.1:5432/boost_dashboard
-
-# --- Option C: Google Cloud SQL (direct, public IP with SSL) ---
-# Use the instance's public IP and require SSL (replace with your instance IP).
+#
+# Cloud SQL over public IP with SSL:
 # DATABASE_URL=postgres://USER:PASSWORD@PUBLIC_IP:5432/boost_dashboard?sslmode=require
-
-# --- Option D: Google Cloud SQL (Unix socket, e.g. Cloud Run / GKE) ---
-# When running on GCP, you can use the Unix socket path.
+#
+# Cloud SQL Unix socket (Cloud Run / GKE):
 # DATABASE_URL=postgres://USER:PASSWORD@/boost_dashboard?host=/cloudsql/PROJECT:REGION:INSTANCE
 
-# Default (local) - uncomment and edit for your setup:
+# Starter value for local development (edit user, password, and database name):
 DATABASE_URL=postgres://user:password@localhost:5432/boost_dashboard
 
-# Optional: use separate vars instead of DATABASE_URL (e.g. for Google Secret Manager).
-# Leave DATABASE_URL unset and set:
+# DB_* form (optional; e.g. when injecting secrets without a single URL string):
 # DB_NAME=boost_dashboard
 # DB_USER=your_user
 # DB_PASSWORD=your_password
@@ -35,276 +39,233 @@ DATABASE_URL=postgres://user:password@localhost:5432/boost_dashboard
 # DB_PORT=5432
 # DB_OPTIONS_SSLMODE=require
 
-# =============================================================================
-# Django
-# =============================================================================
+# --- Pytest (`config.test_settings`, see `pytest.ini`) ---
+# Tests require PostgreSQL. There is no SQLite fallback. Typical workflow:
+#   docker compose -f docker-compose.test.yml up -d
+#   export DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres
+#   export SECRET_KEY=for-testing-only
+#   python -m pytest
+# Details: README.md, section "Running tests".
+
+# ==============================================================================
+# Django core
+# ==============================================================================
 # SECRET_KEY=your-secret-key-here
 # DEBUG=False
 # ALLOWED_HOSTS=localhost,127.0.0.1,.run.app
+# STATIC_URL=static/
+# FORCE_SCRIPT_NAME=
 
-# --- Production: Docker on Ubuntu + nginx + PostgreSQL on the host ---
-# docker-compose.yml maps host.docker.internal → the host (Linux). Point DATABASE_URL at it.
-# Match pg_hba / listen_addresses on the host (see docs/Deployment.md).
+# Reverse proxy / TLS (trusted proxy only):
+# USE_X_FORWARDED_HOST=False
+# USE_TLS_PROXY_HEADERS=False
+# CSRF_TRUSTED_ORIGINS=https://your.domain
+
+# --- Docker on Linux with Postgres on the host ---
+# `docker-compose.yml` sets `host.docker.internal` to reach the host. Align
+# `listen_addresses` / `pg_hba.conf` with your URL. See docs/Deployment.md.
 # DATABASE_URL=postgres://boost_dashboard_user:STRONG_PASSWORD@host.docker.internal:5432/boost_dashboard
-# ALLOWED_HOSTS=dev.cppdigest.org,127.0.0.1,web,localhost
-# CSRF_TRUSTED_ORIGINS=https://dev.cppdigest.org
+# ALLOWED_HOSTS=dev.example.org,127.0.0.1,web,localhost
+# CSRF_TRUSTED_ORIGINS=https://dev.example.org
 # USE_X_FORWARDED_HOST=True
 # USE_TLS_PROXY_HEADERS=True
-# Optional URL prefix (see Deployment.md nginx “subpath” example): set both if the app is not at site root.
+# Subpath deployment (nginx example in Deployment.md): set both together.
 # STATIC_URL=/boost-data-collector/static/
 # FORCE_SCRIPT_NAME=/boost-data-collector
 
-# =============================================================================
-# Workspace orphan cleanup (optional; see docs/Workspace.md)
-# =============================================================================
-# WORKSPACE_ORPHAN_CLEANUP_ENABLED=false
-# WORKSPACE_ORPHAN_USE_QUARANTINE_FOR_INVALID_JSON=false
-# WORKSPACE_ORPHAN_JSON_STALE_MAX_AGE_SECONDS=-1
-# WORKSPACE_ORPHAN_INVALID_JSON_GRACE_SECONDS=5.0
-
-# =============================================================================
-# Logging (optional; defaults: logs under project root, 5 MB rotation, 5 backups)
-# =============================================================================
-# Root log level: DEBUG, INFO, WARNING, ERROR. If unset: DEBUG when DEBUG=True, else INFO.
+# ==============================================================================
+# Logging
+# ==============================================================================
+# Levels: DEBUG, INFO, WARNING, ERROR. If unset: DEBUG when DEBUG=True, else INFO.
 # LOG_LEVEL=DEBUG
 # LOG_DIR=./logs
 # LOG_FILE=app.log
 # LOG_MAX_BYTES=5242880
 # LOG_BACKUP_COUNT=5
 
-# =============================================================================
-# Error Notifications (Discord/Slack)
-# =============================================================================
-# Default-on when at least one webhook URL below is set: ERROR-level logs are sent
-# to Discord and/or Slack (see config/settings.py + config/logging_handlers.py).
-# You do not need to set ENABLE_ERROR_NOTIFICATIONS=true for that behavior.
+# ==============================================================================
+# Error notifications (Discord / Slack)
+# ==============================================================================
+# When at least one webhook URL is set, ERROR-level logs can be sent to
+# Discord and/or Slack (see config/settings.py and config/logging_handlers.py).
+# You do not need ENABLE_ERROR_NOTIFICATIONS=true for that default behavior.
+# ENABLE_ERROR_NOTIFICATIONS=false
 #
-# Opt-out (e.g. webhooks used only for deploy/startup messages, or to silence alerts):
-#   ENABLE_ERROR_NOTIFICATIONS=false
-
-# Discord webhook URL (get from Discord: Server Settings > Integrations > Webhooks)
-# DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN
-
-# Slack webhook URL (get from Slack: https://api.slack.com/messaging/webhooks)
+# DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_TOKEN
 # SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 
-
-# =============================================================================
-# GitHub tokens (multiple use cases)
-# =============================================================================
-# Fallback when a specific token is not set (used for read if no scraping list):
+# ==============================================================================
+# GitHub
+# ==============================================================================
 # GITHUB_TOKEN=ghp_xxxx
-
-# Comma-separated list for API read/scraping (round-robin to spread rate limits):
 # GITHUB_TOKENS_SCRAPING=ghp_aaa,ghp_bbb,ghp_ccc
-
-# For write operations: create PR, create issue, comment on issue, git push
 # GITHUB_TOKEN_WRITE=ghp_xxxx
 
-# =============================================================================
-# Clang GitHub Tracker (raw sync: commits, issues, PRs; Pinecone sync for issues/PRs)
-# =============================================================================
-# GitHub repo to sync (default: llvm/llvm-project).
-# CLANG_GITHUB_OWNER=llvm
-# CLANG_GITHUB_REPO=llvm-project
-# Markdown publish target (optional; see also Clang section above).
-# CLANG_GITHUB_CONTEXT_REPO_OWNER=your-org
-# CLANG_GITHUB_CONTEXT_REPO_NAME=your-repo
-# CLANG_GITHUB_CONTEXT_REPO_BRANCH=main
-# If that repo is private: set GITHUB_TOKEN_WRITE to a PAT that can read+push it
-# (classic: repo scope; fine-grained: grant this repository). Publish uses the
-# write token, not GITHUB_TOKENS_SCRAPING.
-# Pinecone sync (run_cppa_pinecone_sync) — app_type and namespace when triggering from this app.
-# CLANG_GITHUB_PINECONE_APP_TYPE=github-clang
-# CLANG_GITHUB_PINECONE_NAMESPACE=github-clang
+# ==============================================================================
+# Celery
+# ==============================================================================
+# CELERY_BROKER_URL=redis://localhost:6379/0
+# CELERY_RESULT_BACKEND=redis://localhost:6379/0
+# Worker: celery -A config worker -l info
 
-# =============================================================================
-# Boost Library Tracker (GitHub activity + Pinecone sync for issues/PRs)
-# =============================================================================
-# GitHub owner for Boost repos (default: boostorg).
-# BOOST_GITHUB_OWNER=boostorg
-# Pinecone sync — app_type and namespace when triggering from this app.
-# BOOST_GITHUB_PINECONE_APP_TYPE=github-boostorg
-# BOOST_GITHUB_PINECONE_NAMESPACE=github-boostorg
-#
-# Target GitHub repo for Markdown export after sync (boostorg/boost + submodules).
-# If OWNER or NAME is unset, MD upload is skipped (see run_boost_library_tracker / run_boost_github_activity_tracker).
-# Renamed from BOOST_LIBRARY_TRACKER_PRIVATE_REPO_* — update any old env vars to the names below.
-# BOOST_LIBRARY_TRACKER_REPO_OWNER=your-org
-# BOOST_LIBRARY_TRACKER_REPO_NAME=your-repo
-# BOOST_LIBRARY_TRACKER_REPO_BRANCH=main
+# ==============================================================================
+# Workspace
+# ==============================================================================
+# Defaults: raw/processed files under `<project>/workspace`.
+# WORKSPACE_DIR=./workspace
+# RAW_DIR=
 
-# =============================================================================
-# Boost Mailing List Tracker (Pinecone sync for mailing list messages)
-# =============================================================================
-# Pinecone sync — app_type and namespace when triggering from this app.
-# BOOST_MAILING_LIST_PINECONE_APP_TYPE=mailing
-# BOOST_MAILING_LIST_PINECONE_NAMESPACE=mailing
+# ==============================================================================
+# Workspace orphan cleanup (optional)
+# ==============================================================================
+# See docs/Workspace.md.
+# WORKSPACE_ORPHAN_CLEANUP_ENABLED=false
+# WORKSPACE_ORPHAN_USE_QUARANTINE_FOR_INVALID_JSON=false
+# WORKSPACE_ORPHAN_JSON_STALE_MAX_AGE_SECONDS=-1
+# WORKSPACE_ORPHAN_INVALID_JSON_GRACE_SECONDS=5.0
 
-# =============================================================================
-# Pinecone (cppa_pinecone_sync — shared index and API keys)
-# =============================================================================
-# Required for sync: set PINECONE_INDEX_NAME and PINECONE_API_KEY to enable sync.
-# Public API key (default). Used when --pinecone-instance=public or unset.
+# ==============================================================================
+# Pinecone (shared, cppa_pinecone_sync)
+# ==============================================================================
+# Sync requires PINECONE_INDEX_NAME and the appropriate API key.
 # PINECONE_API_KEY=pc-xxxx
-# Private API key. Used when --pinecone-instance=private.
 # PINECONE_PRIVATE_API_KEY=pc-xxxx
-# Index name (required). Must be set for run_cppa_slack_tracker / run_cppa_pinecone_sync.
 # PINECONE_INDEX_NAME=boost-dashboard
-# Region and cloud (defaults: us-east-1, aws).
 # PINECONE_ENVIRONMENT=us-east-1
 # PINECONE_CLOUD=aws
-# Chunking and embedding (optional; defaults in settings).
 # PINECONE_BATCH_SIZE=96
 # PINECONE_CHUNK_SIZE=1000
 # PINECONE_CHUNK_OVERLAP=200
 # PINECONE_MIN_TEXT_LENGTH=50
 # PINECONE_MIN_WORDS=5
-# Slack Pinecone namespace prefix (namespace = {prefix}-{team_name}). Default: slack.
 # PINECONE_SLACK_NAMESPACE_PREFIX=slack
-# Slack Pinecone app_type prefix (app_type = {prefix}-{team_name}). Default: slack.
 # PINECONE_SLACK_APP_TYPE_PREFIX=slack
-# Optional: embedding models (defaults: multilingual-e5-large, pinecone-sparse-english-v0).
 # PINECONE_DENSE_MODEL=multilingual-e5-large
 # PINECONE_SPARSE_MODEL=pinecone-sparse-english-v0
 
-# =============================================================================
-# Boost Usage Tracker
-# =============================================================================
-# Languages for run_update_created_repos_by_language (comma-separated).
-# Must match names in github_activity_tracker.Language (e.g., C++, Python, Rust).
+# ==============================================================================
+# Clang GitHub tracker
+# ==============================================================================
+# Sync target (defaults: llvm/llvm-project).
+# CLANG_GITHUB_OWNER=llvm
+# CLANG_GITHUB_REPO=llvm-project
+# Optional Markdown export repository (private repos need GITHUB_TOKEN_WRITE):
+# CLANG_GITHUB_CONTEXT_REPO_OWNER=your-org
+# CLANG_GITHUB_CONTEXT_REPO_NAME=your-repo
+# CLANG_GITHUB_CONTEXT_REPO_BRANCH=main
+# CLANG_GITHUB_PINECONE_APP_TYPE=github-clang
+# CLANG_GITHUB_PINECONE_NAMESPACE=github-clang
+
+# ==============================================================================
+# Boost library tracker
+# ==============================================================================
+# BOOST_GITHUB_OWNER=boostorg
+# BOOST_GITHUB_PINECONE_APP_TYPE=github-boostorg
+# BOOST_GITHUB_PINECONE_NAMESPACE=github-boostorg
+# Markdown export after sync (omit owner/name to skip upload). Vars were renamed
+# from BOOST_LIBRARY_TRACKER_PRIVATE_REPO_* — update legacy deployments.
+# BOOST_LIBRARY_TRACKER_REPO_OWNER=your-org
+# BOOST_LIBRARY_TRACKER_REPO_NAME=your-repo
+# BOOST_LIBRARY_TRACKER_REPO_BRANCH=main
+
+# ==============================================================================
+# Boost mailing list tracker
+# ==============================================================================
+# BOOST_MAILING_LIST_PINECONE_APP_TYPE=mailing
+# BOOST_MAILING_LIST_PINECONE_NAMESPACE=mailing
+
+# ==============================================================================
+# Boost usage tracker
+# ==============================================================================
+# Comma-separated; names must match github_activity_tracker.Language.
 # REPO_COUNT_LANGUAGES=C++,Python,Rust
 
-# =============================================================================
-# Boost Library Usage Dashboard
-# =============================================================================
-# Target repo for publishing (run_boost_library_usage_dashboard without --skip-publish).
-# Clone/pull/push uses GITHUB_TOKEN_WRITE (see GitHub tokens above).
+# ==============================================================================
+# Boost library usage dashboard
+# ==============================================================================
+# Publishing uses GITHUB_TOKEN_WRITE.
 # BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_OWNER=your-org
 # BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_REPO=your-dashboard-repo
 # BOOST_LIBRARY_USAGE_DASHBOARD_PUBLISH_BRANCH=main
-
-# Git commit author identity used when publishing (defaults shown)
 # GIT_AUTHOR_NAME=unknown
 # GIT_AUTHOR_EMAIL=unknown@noreply.github.com
 
-# =============================================================================
-# Workspace (optional; default: project_root/workspace)
-# =============================================================================
-
-# =============================================================================
-# Celery (optional; for scheduled collectors via YAML / Beat)
-# =============================================================================
-# Run worker: celery -A config worker -l info
-
-# =============================================================================
-# Slack (cppa_slack_tracker, cppa_slack_transcript_tracker, operations.slack_ops)
-# =============================================================================
-# Optional: GitHub repo for Slack huddle transcript uploads
+# ==============================================================================
+# Slack (cppa_slack_tracker, cppa_slack_transcript_tracker, slack_event_handler)
+# ==============================================================================
 # GITHUB_SLACK_HUDDLE_REPO_OWNER=your-org
 # GITHUB_SLACK_HUDDLE_REPO_NAME=your-repo
-
-# Bot token: config/settings.py builds SLACK_BOT_TOKEN (a dict, team_id -> token)
-# from prefixed env vars. Set SLACK_TEAM_IDS (comma-separated) and one var per
-# team: SLACK_BOT_TOKEN_<id>. If id or token is missing at lookup,
-# an error is logged and ValueError is raised.
-
-# Example (multiple teams):
+#
+# Bot tokens: set SLACK_TEAM_IDS, then SLACK_BOT_TOKEN_<team_id> per team.
 # SLACK_TEAM_IDS=T01234ABCD,T05678EFGH
 # SLACK_TEAM_ID=T01234ABCD
-# SLACK_BOT_TOKEN_T01234ABCD=xoxb-xxx...
-# SLACK_BOT_TOKEN_T05678EFGH=xoxb-yyy...
-
-# App-level token (Basic Information > App-Level Tokens): required for Socket Mode
-# listener. One per team: SLACK_APP_TOKEN_<id>. Scope: connections:write
+# SLACK_BOT_TOKEN_T01234ABCD=xoxb-xxx
+# SLACK_BOT_TOKEN_T05678EFGH=xoxb-yyy
+#
+# Socket Mode (App-Level Tokens), scope connections:write:
 # SLACK_APP_TOKEN_T01234ABCD=xapp-xxxx
 # SLACK_APP_TOKEN_T05678EFGH=xapp-yyyy
-
-# Team scope (slack_event_handler): which features are enabled per team. Comma-separated.
-# 0 = huddle support, 1 = PR bot. Omit or leave empty for both (0, 1).
+#
+# slack_event_handler: feature flags per team (0 = huddle, 1 = PR bot; empty = both).
 # SLACK_TEAM_SCOPE_T01234ABCD=0
 # SLACK_TEAM_SCOPE_T05678EFGH=1
-# SLACK_TEAM_SCOPE_T09999BOTH=0, 1
-
-# Slack PR bot (slack_event_handler): GitHub org and token for posting PR comments
+#
+# Slack PR bot:
 # SLACK_PR_BOT_TEAM=your-org
 # SLACK_PR_BOT_GITHUB_TOKEN=ghp_xxxx
 # SLACK_PR_BOT_CHANNEL_NAME=slack-bot
 # SLACK_PR_BOT_COMMENT_TEMPLATE=Automated comment from Slack bot.
 # SLACK_PR_BOT_COMMENTS_MAX_PER_WINDOW=5
 # SLACK_PR_BOT_COMMENTS_WINDOW_SECONDS=3600
-
-# Internal session tokens (ToS-sensitive): only read when ALLOW_INTERNAL_SLACK_TOKENS=true
-# after compliance review.
+#
+# Internal session tokens (compliance-gated):
 # ALLOW_INTERNAL_SLACK_TOKENS=false
 # SLACK_XOXC_TOKEN=xoxc-...
 # SLACK_XOXD_TOKEN=...
 
-# =============================================================================
-# Selenium / Chrome (optional; for Slack xoxc/xoxd token extraction only)
-# =============================================================================
+# ==============================================================================
+# Selenium / Chrome (Slack token extraction helpers only)
+# ==============================================================================
 # SELENIUM_HUB_URL=http://localhost:4444/wd/hub
-# CHROME_PROFILE_PATH= (default: <WORKSPACE_DIR>/cppa_slack_transcript_tracker/chrome_profile)
+# CHROME_PROFILE_PATH=
 
-# =============================================================================
-# Discord (for discord_activity_tracker)
-# =============================================================================
-# METHOD 1: Bot token (requires bot authorization, preferred if allowed)
-# DISCORD_TOKEN=MTAxNzM4ODc2NzY5MzE5NDI0MA.GK7Vz8.abcdefghijklmnopqrstuvwxyz1234567890ABC
-
-# METHOD 2: User token (TOS violation, use only if bot method fails)
-# How to obtain: docs/operations/discord_chat_exporter.md — upstream Tyrrrz "Token and IDs" + CLI `guide`
-# DISCORD_USER_TOKEN=MTAxNzM4ODc2NzY5MzE5NDI0MA.GK7Vz8.abcdefghijklmnopqrstuvwxyz1234567890ABC
-
-# Server ID (right-click server name with Developer Mode enabled, or get from invite URL)
-# C/C++ Together: 331718482485837825
+# ==============================================================================
+# Discord (discord_activity_tracker)
+# ==============================================================================
+# Preferred: bot token.
+# DISCORD_TOKEN=your.bot.token
+#
+# User token violates Discord ToS; use only if the bot path is impossible.
+# See docs/operations/discord_chat_exporter.md (Tyrrrz upstream: Token and IDs, CLI guide).
+# DISCORD_USER_TOKEN=your.user.token
+#
 # DISCORD_SERVER_ID=987654321098765432
-
-# Markdown export root (default: <WORKSPACE_DIR>/discord_activity_tracker/discord-cplusplus-together-context)
-# Override only if you export into a separate git clone elsewhere.
 # DISCORD_CONTEXT_REPO_PATH=/absolute/path/to/discord-cplusplus-together-context
-# Git commit/push after Markdown export when True (also requires --skip-remote-push unset)
 # DISCORD_CONTEXT_AUTO_COMMIT=false
-
-# DiscordChatExporter CLI — optional absolute path to the executable (macOS/Linux/Windows).
-# Download: https://github.com/Tyrrrz/DiscordChatExporter/releases/latest (DiscordChatExporter.Cli)
-# Default if unset: .../script/DiscordChatExporter.Cli (macOS/Linux) or .../DiscordChatExporter.Cli.exe (Windows)
+#
+# DiscordChatExporter CLI:
+# https://github.com/Tyrrrz/DiscordChatExporter/releases
 # DISCORD_CHAT_EXPORTER_CLI=/path/to/DiscordChatExporter.Cli
-# macOS: run DiscordChatExporter via system dotnet + DLL (avoids blocked bundled libhostfxr on
-# external disks / quarantine). Requires ``brew install dotnet`` (or SDK). Point at Cli.dll next to the extracted CLI.
-# DISCORD_CHAT_EXPORTER_DOTNET_DLL=/path/to/workspace/discord_activity_tracker/script/DiscordChatExporter.Cli.dll
-# Optional explicit dotnet executable if not on PATH:
+# macOS: system dotnet + DLL (avoids quarantined bundled runtime on some disks):
+# DISCORD_CHAT_EXPORTER_DOTNET_DLL=/path/to/DiscordChatExporter.Cli.dll
 # DISCORD_CHAT_EXPORTER_DOTNET=/usr/local/share/dotnet/dotnet
-# macOS: strip extended attrs on the script folder before export (helps Gatekeeper; only enable if you trust the CLI files)
 # DISCORD_CHAT_EXPORTER_MACOS_CLEAR_QUARANTINE=false
-# Parallel channel exports (1 = safest RAM; raise only if exports are stable)
 # DISCORD_CHAT_EXPORTER_PARALLEL=1
-# Include voice channels in exportguild / channels listing (default false)
 # DISCORD_CHAT_EXPORTER_INCLUDE_VC=false
-# macOS defaults true: run ``channels`` then one ``export`` per channel (avoids SIGKILL on huge guilds)
 # DISCORD_CHAT_EXPORTER_SEQUENTIAL_EXPORT=true
-
-# .NET runtime memory tuning — reduces macOS jetsam SIGKILL (-9) caused by memory pressure.
-# These are injected into the DiscordChatExporter subprocess by default; override here only if needed.
-# DOTNET_GCConserveMemory=9           # 0-9: most aggressive GC compaction (default 9)
-# DOTNET_GCHighMemPercent=50          # trigger aggressive GC at 50 % RAM used (default 50; lower = earlier)
-# DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1  # skip ICU library load (~50-150 MB savings at startup)
-
-# Comma-separated channel snowflake IDs to scrape (leave empty to scrape all channels)
+#
+# Injected into the exporter subprocess unless overridden (macOS memory pressure):
+# DOTNET_GCConserveMemory=9
+# DOTNET_GCHighMemPercent=50
+# DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+#
 # DISCORD_CHANNEL_IDS=851121440425639956,123456789012345678
-
-# Pinecone settings for Discord messages (run_cppa_pinecone_sync). Leave unset or empty to skip upsert.
 # PINECONE_DISCORD_APP_TYPE=discord
 # PINECONE_DISCORD_NAMESPACE=discord-messages
 
-# =============================================================================
+# ==============================================================================
 # YouTube (cppa_youtube_script_tracker)
-# =============================================================================
-# YouTube Data API v3 key (console.cloud.google.com → APIs & Services → Credentials)
-# YOUTUBE_API_KEY=...
-
-# Pinecone namespace for YouTube video/transcript sync (default: youtube-scripts)
+# ==============================================================================
+# YOUTUBE_API_KEY=
 # YOUTUBE_PINECONE_NAMESPACE=youtube-scripts
-
-# Earliest published_at to use when DB is empty (ISO 8601, e.g. 2015-01-01T00:00:00Z)
 # YOUTUBE_DEFAULT_PUBLISHED_AFTER=2015-01-01T00:00:00Z

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -123,8 +123,7 @@ jobs:
 
       - name: Test with pytest
         env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
-          USE_POSTGRES_TESTS: "1"
+          DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/postgres
           SECRET_KEY: for-testing-only
           DJANGO_SETTINGS_MODULE: config.test_settings
         run: |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ On Windows, the project configures the worker to use the `solo` pool automatical
 
 ## Running tests
 
-The project uses **pytest** with **pytest-django**. Tests run against `config.test_settings` (SQLite in-memory by default; set `DATABASE_URL` to use PostgreSQL).
+The project uses **pytest** with **pytest-django**. Tests run against **`config.test_settings`**, which **always uses PostgreSQL** (same engine as CI and production). **`DATABASE_URL` must be set** when you run pytest; if it is missing, Django raises a clear error (see [`config/test_settings.py`](config/test_settings.py)).
+
+**Why not SQLite:** the ORM behaves differently on SQLite versus PostgreSQL (for example JSONB, `ILIKE` case rules, types such as arrays, and transaction isolation). Using Postgres for tests catches those issues before CI or production.
 
 1. Install test dependencies (once):
 
@@ -91,42 +93,52 @@ The project uses **pytest** with **pytest-django**. Tests run against `config.te
 pip install -r requirements-dev.txt
 ```
 
-2. Run the full test suite:
+2. Start a local PostgreSQL 16 instance for tests (recommended; uses host port **5433** so it does not clash with Postgres on **5432**):
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+```
+
+3. Set **`DATABASE_URL`** and a dummy **`SECRET_KEY`** for the test process (CI sets these for pytest):
+
+```bash
+# Linux / macOS (Git Bash / WSL)
+export DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres
+export SECRET_KEY=for-testing-only
+```
+
+```bash
+# Windows (Command Prompt)
+set DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres
+set SECRET_KEY=for-testing-only
+```
+
+If you already run PostgreSQL yourself, you may point `DATABASE_URL` at that server instead; the user in the URL must be allowed to **create databases** (pytest-django creates a separate database named `test_<dbname>` with `--reuse-db` from [`pytest.ini`](pytest.ini)).
+
+4. Run the full test suite:
 
 ```bash
 python -m pytest
 ```
 
-3. Optional: run with coverage and enforce a minimum percentage locally:
+5. Optional: run with coverage and enforce a minimum percentage locally:
 
 ```bash
 python -m pytest --tb=short --cov=. --cov-report=term-missing --cov-fail-under=90
 ```
 
-Coverage writes a local **`.coverage`** file (binary SQLite data used by `coverage.py`; safe to delete). It is listed in `.gitignore`.
+Coverage writes a local **`.coverage`** file (binary data used by `coverage.py`; safe to delete). It is listed in `.gitignore`.
 
-**PostgreSQL parity (recommended before merging DB-sensitive changes):** GitHub Actions runs the full suite against Postgres (`DATABASE_URL` in `.github/workflows/actions.yml`; tests use `127.0.0.1` for a stable loopback connection). Locally, `pytest.ini` defaults to SQLite in-memory when `DATABASE_URL` is unset (`config.test_settings`). Run the full suite against Postgres when you touch JSONB, enums, or locks, for example:
+**CI:** [`.github/workflows/actions.yml`](.github/workflows/actions.yml) runs pytest with `DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres` and the same `DJANGO_SETTINGS_MODULE=config.test_settings` as local.
 
-```bash
-# Linux / macOS
-export DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres
-python -m pytest
-```
-
-```bash
-# Windows (Command Prompt)
-set DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres
-python -m pytest
-```
-
-4. Run a subset of tests (e.g. one app or one file):
+6. Run a subset of tests (e.g. one app or one file):
 
 ```bash
 python -m pytest cppa_user_tracker/tests/ -v
 python -m pytest github_activity_tracker/tests/test_sync_utils.py -v
 ```
 
-CI runs pytest with coverage (`--cov`, HTML/XML reports). To match a **local** coverage gate, use **`--cov-fail-under=90`** (see step 3 above). If coverage fails locally or you need a fresh test DB schema after model changes, run once with `python -m pytest --create-db`.
+CI runs pytest with coverage (`--cov`, HTML/XML reports). To match a **local** coverage gate, use **`--cov-fail-under=90`** (see step 5 above). If coverage fails locally or you need a fresh test DB schema after model changes, run once with `python -m pytest --create-db`.
 
 See [docs/Development_guideline.md](docs/Development_guideline.md#testing-workflow) for when to run tests during development.
 

--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -1,49 +1,49 @@
 """
 Test-only Django settings.
-Imports base settings, then overrides for fast and isolated tests.
+Imports base settings, then overrides for isolated tests.
+
+Tests always use PostgreSQL (same as CI and production) so behavior matches
+JSONB, case-sensitive ILIKE, connection pooling, and transaction semantics.
+SQLite is not used: it can hide bugs that only appear on Postgres.
 """
 
 import os
-import sys
 from pathlib import Path
 
+from django.core.exceptions import ImproperlyConfigured
+
 from .settings import *  # noqa: F401, F403
+from .settings import DATABASES  # explicit import for ruff F405 (after star import)
 
 # Never run workspace orphan cleanup during tests (CoreConfig.ready).
 WORKSPACE_ORPHAN_CLEANUP_ENABLED = False
 
-# In-memory SQLite for fast, isolated tests when we are not targeting Postgres (see below).
-_SQLITE_TEST_DB = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": ":memory:",
-    }
-}
+if not (os.environ.get("DATABASE_URL") or "").strip():
+    raise ImproperlyConfigured(
+        "config.test_settings requires DATABASE_URL (PostgreSQL). "
+        "Start the local test database: "
+        "docker compose -f docker-compose.test.yml up -d "
+        "then set DATABASE_URL, for example: "
+        "postgres://postgres:postgres@127.0.0.1:5433/postgres "
+        "See README.md → Running tests."
+    )
 
-# Prefer SQLite when DATABASE_URL is unset, or under pytest without USE_POSTGRES_TESTS so a
-# developer .env DATABASE_URL (Docker Postgres) does not require a running server.
-# GitHub Actions Postgres jobs set USE_POSTGRES_TESTS=1 so DATABASE_URL still applies under pytest.
-_under_pytest = "pytest" in sys.modules
-_use_postgres_tests = os.environ.get("USE_POSTGRES_TESTS", "").strip().lower() in (
-    "1",
-    "true",
-    "yes",
-)
-_want_sqlite = (not os.environ.get("DATABASE_URL", "").strip()) or (
-    _under_pytest and not _use_postgres_tests
-)
-if _want_sqlite:
-    DATABASES = _SQLITE_TEST_DB
-
-# When tests target PostgreSQL (e.g. CI), prefer short-lived connections and a bounded
-# connect timeout so flaky networking fails fast instead of hanging pytest.
+# Prefer short-lived connections and a bounded connect timeout so flaky
+# networking fails fast instead of hanging pytest.
 _default_db = DATABASES.get("default", {})
-if "postgresql" in (_default_db.get("ENGINE") or "").lower():
-    _opts = dict(_default_db.get("OPTIONS") or {})
-    _opts.setdefault("connect_timeout", 15)
-    _default_db["OPTIONS"] = _opts
-    _default_db["CONN_MAX_AGE"] = 0
-    DATABASES["default"] = _default_db
+_engine = (_default_db.get("ENGINE") or "").lower()
+if "postgresql" not in _engine:
+    raise ImproperlyConfigured(
+        "config.test_settings requires PostgreSQL. "
+        f"Got DATABASES['default']['ENGINE']={_default_db.get('ENGINE')!r}; "
+        "use a postgres:// or postgresql:// DATABASE_URL. "
+        "See README.md → Running tests."
+    )
+_opts = dict(_default_db.get("OPTIONS") or {})
+_opts.setdefault("connect_timeout", 15)
+_default_db["OPTIONS"] = _opts
+_default_db["CONN_MAX_AGE"] = 0
+DATABASES["default"] = _default_db
 
 PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.MD5PasswordHasher",

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,19 @@
+# Local PostgreSQL for pytest only. Host port 5433 avoids clashing with a Postgres on 5432.
+# Usage: docker compose -f docker-compose.test.yml up -d
+# Then: export DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres
+# See README.md → Running tests.
+
+services:
+  postgres_test:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "127.0.0.1:5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -51,7 +51,8 @@ For a full list of functions, parameter/return types, and validation (e.g. empty
 
 ### Testing
 
-- **Running tests:** From the project root, install dev deps (`pip install -r requirements-dev.txt`) and run `python -m pytest`. See [README.md](../README.md#running-tests) and [Development_guideline.md](Development_guideline.md#testing-workflow) for full commands and options.
+- **Running tests:** From the project root, install dev deps (`pip install -r requirements-dev.txt`), start the test database (`docker compose -f docker-compose.test.yml up -d`), set `DATABASE_URL` (and `SECRET_KEY` for the process) as in [README.md](../README.md#running-tests), then run `python -m pytest`. Tests **always use PostgreSQL** (`config.test_settings`); there is no SQLite fallback.
+- See [README.md](../README.md#running-tests) and [Development_guideline.md](Development_guideline.md#testing-workflow) for full commands and options.
 - **Unit tests for `services.py`:** Call the service functions and assert on the database (or mocks) as needed.
 - **Other tests:** Prefer service functions when setting up data. If you must create models directly for tests, keep it in test code (e.g. fixtures or test helpers) and avoid doing the same in production code.
 

--- a/docs/Development_guideline.md
+++ b/docs/Development_guideline.md
@@ -99,6 +99,7 @@ Use these steps to get the Django project running on your machine.
 
 Run tests often so you catch problems early.
 
+- **PostgreSQL for pytest:** `config.test_settings` requires `DATABASE_URL` pointing at PostgreSQL (see [README.md](../README.md#running-tests): `docker compose -f docker-compose.test.yml up -d`, then export `DATABASE_URL` / `SECRET_KEY`). This matches CI and avoids SQLite-only passes that fail in production.
 - **Before each commit:** run the test suite for the code you changed (`python -m pytest` or a subset).
 - **For app commands:** ensure the command runs successfully (e.g. `python manage.py run_boost_library_tracker` exits with 0 and does the expected work).
 - **Full workflow:** run `python manage.py run_scheduled_collectors --schedule default --group <group_id>` / `--schedule interval --interval-minutes <n>` when testing the YAML-driven path (matches how Celery Beat invokes it).

--- a/docs/How_to_add_a_collector.md
+++ b/docs/How_to_add_a_collector.md
@@ -219,7 +219,7 @@ groups:
 
 ### `tests/test_skeleton_collector.py`
 
-Tests use the same **pytest + pytest-django** stack as the rest of the repo. CI uses **PostgreSQL** when `DATABASE_URL` is set; locally you can use SQLite in-memory or set `DATABASE_URL` to match CI—see [README.md](../README.md#running-tests).
+Tests use the same **pytest + pytest-django** stack as the rest of the repo. **`config.test_settings` requires PostgreSQL** via `DATABASE_URL` (local Docker: `docker-compose.test.yml`; CI matches the same settings module). See [README.md](../README.md#running-tests).
 
 ```python
 # my_skeleton_tracker/tests/test_skeleton_collector.py


### PR DESCRIPTION
## Summary

- **Tests always use PostgreSQL** via `config.test_settings`: removed SQLite / `USE_POSTGRES_TESTS` behavior, require `DATABASE_URL`, and fail fast with `ImproperlyConfigured` when it is missing or the engine is not Postgres.
- **Local test database**: added `docker-compose.test.yml` (PostgreSQL 16 on host `127.0.0.1:5433`) so developers can match CI without colliding with Postgres on `5432`.
- **CI**: dropped `USE_POSTGRES_TESTS`; pytest uses `DATABASE_URL` with `127.0.0.1` (aligned with the connection smoke step).
- **Docs**: updated `README.md`, `.env.example`, `docs/Contributing.md`, `docs/Development_guideline.md`, and `docs/How_to_add_a_collector.md` for the Postgres-only flow and rationale.
- **Lint**: explicit `from .settings import DATABASES` after `import *` to satisfy Ruff F405.

## How to test locally

1. `docker compose -f docker-compose.test.yml up -d`
2. `export DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres` (and `SECRET_KEY=for-testing-only` if needed)
3. `python -m pytest` (or `uv run pytest` as in CI)

## Checklist

- Full test suite passes against the compose test DB
- CI green on this branch

Closes #183 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing workflow documentation to clarify PostgreSQL is required for running tests locally.
  * Enhanced environment configuration template with improved guidance for database setup and test workflow configuration.

* **Chores**
  * Added Docker Compose configuration for local PostgreSQL test database setup (port 5433).
  * Updated CI workflow database configuration for test execution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/boost-data-collector/pull/197)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->