### PR TITLE
docs: expand Deployment guide (GitHub SSH, clone path, pg_restore, CppAlliance)

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -21,7 +21,7 @@ SSH into server → pull latest code → restart containers
 
 ## GitHub Environments and Secrets
 
-The deploy workflow uses **GitHub Environments** so that each branch uses the right server. Required secrets are **environment-scoped** (`SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`) and optional `SSH_PORT` (defaults to `22`) and `SSH_KEY_PASSPHRASE` — set per environment (production / staging), not as PROD_* / DEV_* repository secrets.
+The deploy workflow uses **GitHub Environments** so that each branch uses the right server. Required secrets are **environment-scoped** (`SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`) and optional `SSH_PORT` (defaults to `22`) and `SSH_KEY_PASSPHRASE` — set per environment (production / staging), not as PROD*\* / DEV*\* repository secrets.
 
 ### 1. Create the environments
 
@@ -36,12 +36,12 @@ For **production**, it is recommended to enable **Required reviewers** to add a 
 
 In each environment (**production** and **staging**), add the following **Environment secrets** (same names in both; different values per server):
 
-| Secret | Description |
-|--------|-------------|
-| `SSH_HOST` | IP address or hostname of the server |
-| `SSH_USER` | SSH username (e.g. `gcp-cppalliance`) |
-| `SSH_PRIVATE_KEY` | SSH private key (full content, including header/footer) |
-| `SSH_PORT` | SSH port (optional, defaults to `22`) |
+| Secret               | Description                                                                            |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| `SSH_HOST`           | IP address or hostname of the server                                                   |
+| `SSH_USER`           | SSH username for the deploy account on the server                                      |
+| `SSH_PRIVATE_KEY`    | SSH private key (full content, including header/footer)                                |
+| `SSH_PORT`           | SSH port (optional, defaults to `22`)                                                  |
 | `SSH_KEY_PASSPHRASE` | Passphrase for the SSH private key (optional; only if the key is passphrase-protected) |
 
 GitHub injects the correct set based on the branch: `main` → production environment secrets, `develop` → staging environment secrets.
@@ -50,10 +50,10 @@ GitHub injects the correct set based on the branch: `main` → production enviro
 
 These can stay as **Repository secrets** (Settings → Secrets and variables → Actions) if you use them:
 
-| Secret | Description |
-|--------|-------------|
+| Secret                | Description                                                                                                                   |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `DEPLOY_SCRIPT_TOKEN` | Token to authenticate downloading a custom `deploy.sh`. Required only if `DEPLOY_SCRIPT_URL` is set and needs authentication. |
-| `DEPLOY_SCRIPT_URL` | Override the deploy script URL. Defaults to `deploy.sh` at the current commit SHA. |
+| `DEPLOY_SCRIPT_URL`   | Override the deploy script URL. Defaults to `deploy.sh` at the current commit SHA.                                            |
 
 ---
 
@@ -71,7 +71,7 @@ Docker and Docker Compose are also required. Refer to the [official Docker docs]
 
 ## Server SSH key for GitHub
 
-The account that runs `git pull` on the server (same as `SSH_USER` in GitHub Actions) needs a key **on the server** that GitHub accepts for `git@github.com:cppalliance/boost-data-collector.git`. This is separate from the **`SSH_PRIVATE_KEY`** GitHub stores to log *into* the server.
+The account that runs `git pull` on the server (same as `SSH_USER` in GitHub Actions) needs a key **on the server** that GitHub accepts for `git@github.com:YOUR_GITHUB_ORG/boost-data-collector.git`. This is separate from the **`SSH_PRIVATE_KEY`** GitHub stores to log _into_ the server.
 
 1. Install the private key under a dedicated name (example: `~/.ssh/id_ed25519_github`) and the matching `.pub` next to it. You can copy it from your workstation with `scp` (path to the key on your machine → `user@server:~/.ssh/...`).
 2. `~/.ssh/config`:
@@ -101,7 +101,7 @@ Push to `main` or `develop` (or re-run the Deploy workflow). The script will clo
 
 **Step 2 — Add `.env` on the server**
 
-SSH into the server as the same user GitHub Actions uses (e.g. `gcp-cppalliance`) and create the file inside the cloned directory:
+SSH into the server as the same user GitHub Actions uses (the account named in `SSH_USER`) and create the file inside the cloned directory:
 
 ```bash
 cd /opt/boost-data-collector
@@ -116,11 +116,11 @@ Use `.env.example` and the YAML example as references for required variables and
 If you create or edit `.env` with `sudo` (e.g. `sudo nano`), the file is often owned by **root** with mode `600`. **Docker Compose reads `.env` as the user running `make build` / `make up`** (your deploy user), which causes `permission denied`. Fix ownership after saving:
 
 ```bash
-sudo chown gcp-cppalliance:gcp-cppalliance /opt/boost-data-collector/.env
+sudo chown YOUR_DEPLOY_USER:YOUR_DEPLOY_USER /opt/boost-data-collector/.env
 sudo chmod 600 /opt/boost-data-collector/.env
 ```
 
-(Replace `gcp-cppalliance` with your actual `SSH_USER` if different.)
+(Replace `YOUR_DEPLOY_USER` with the same Unix account as `SSH_USER`.)
 
 **Step 3 — Run deploy again**
 
@@ -155,7 +155,7 @@ Compose already sets `extra_hosts: host.docker.internal:host-gateway` on app con
 
 ### Google Cloud Storage (optional seed and backups)
 
-Example bucket name: `bdc-backups` (choose your own).
+Use a private bucket name you control (placeholder: `your-backup-bucket`).
 
 - Upload artifacts manually at first (e.g. workspace zip + DB dump).
 - Prefer **`gcloud storage`** over legacy `gsutil` for copies; it is typically much faster on large objects.
@@ -163,20 +163,20 @@ Example bucket name: `bdc-backups` (choose your own).
 Example: copy from bucket to the VM, then unpack (paths are illustrative):
 
 ```bash
-gcloud storage cp "gs://bdc-backups/workspace-2026-03-24.zip" .
-gcloud storage cp "gs://bdc-backups/boost-data-collector-db-2026-03-25.dump" .
+gcloud storage cp "gs://your-backup-bucket/workspace-2026-03-24.zip" .
+gcloud storage cp "gs://your-backup-bucket/app-database-2026-03-25.dump" .
 unzip workspace-2026-03-24.zip -d /path/to/workspace-parent
 ```
 
 Sync workspace back to the bucket (first full sync can take a long time; later syncs are incremental):
 
 ```bash
-gcloud storage rsync /opt/boost-data-collector/workspace gs://bdc-backups/workspace --recursive
+gcloud storage rsync /opt/boost-data-collector/workspace gs://your-backup-bucket/workspace --recursive
 ```
 
 ### Repository checkout and permissions
 
-The deploy user (e.g. `gcp-cppalliance`) should own the app tree under `/opt/boost-data-collector` so `git`, `make`, and Docker Compose can run without sudo.
+The deploy user (the same Unix account as `SSH_USER`) should own the app tree under `/opt/boost-data-collector` so `git`, `make`, and Docker Compose can run without sudo.
 
 If you are **not** relying on the first CI deploy to create the directory, prepare the tree manually (after [Server SSH key for GitHub](#server-ssh-key-for-github) is working), for example:
 
@@ -184,7 +184,7 @@ If you are **not** relying on the first CI deploy to create the directory, prepa
 sudo mkdir -p /opt/boost-data-collector
 sudo chown -R "$USER:$USER" /opt/boost-data-collector
 cd /opt/boost-data-collector
-git clone -b develop git@github.com:cppalliance/boost-data-collector.git .
+git clone -b develop git@github.com:YOUR_GITHUB_ORG/boost-data-collector.git .
 ```
 
 (`develop` matches the staging branch described above; use `main` for a production-only checkout if you prefer.)
@@ -192,7 +192,7 @@ git clone -b develop git@github.com:cppalliance/boost-data-collector.git .
 If the tree was created as root, normalize ownership:
 
 ```bash
-sudo chown -R gcp-cppalliance:gcp-cppalliance /opt/boost-data-collector
+sudo chown -R YOUR_DEPLOY_USER:YOUR_DEPLOY_USER /opt/boost-data-collector
 ```
 
 Docker bind mounts for `staticfiles` (and optionally a host `workspace` directory if you use one) must be readable/writable by the **UID used inside the image** for the app process (commonly `1000`). Example:
@@ -335,7 +335,7 @@ CI uses the same targets in a fixed order (`make down` first); see [Deploy Scrip
 
 #### At site root (`/`)
 
-The following example assumes the app is served at the **domain root** (`https://collector.example.org/`) and static files at **`/static/`**.
+The following example assumes the app is served at the **domain root** (`https://app.example.com/`) and static files at **`/static/`**.
 
 ```nginx
 upstream boost_collector_app {
@@ -345,10 +345,10 @@ upstream boost_collector_app {
 
 server {
     listen 443 ssl http2;
-    server_name collector.example.org;
+    server_name app.example.com;
 
-    ssl_certificate     /etc/letsencrypt/live/collector.example.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/collector.example.org/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/app.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/app.example.com/privkey.pem;
 
     client_max_body_size 100M;
 
@@ -371,7 +371,7 @@ server {
 
 #### Optional: URL prefix (subpath)
 
-If the app must live under a prefix (e.g. `https://example.org/boost-data-collector/`), set in `.env`:
+If the app must live under a prefix (e.g. `https://app.example.com/boost-data-collector/`), set in `.env`:
 
 - `FORCE_SCRIPT_NAME=/boost-data-collector` (no trailing slash)
 - `STATIC_URL=/boost-data-collector/static/` (must end with `/`)
@@ -386,10 +386,10 @@ upstream boost_collector_app {
 
 server {
     listen 443 ssl http2;
-    server_name example.org;
+    server_name app.example.com;
 
-    ssl_certificate     /etc/letsencrypt/live/example.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/example.org/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/app.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/app.example.com/privkey.pem;
 
     client_max_body_size 100M;
 
@@ -415,7 +415,7 @@ Reload nginx after testing config (`sudo nginx -t && sudo systemctl reload nginx
 **Selenium (port 4444)** is bound to **`127.0.0.1:4444`** in Compose so it is not exposed on the public interface. Access from your laptop via **SSH port forwarding** if you need the hub from outside the VM:
 
 ```bash
-ssh -L 4444:127.0.0.1:4444 gcp-cppalliance@YOUR_VM_IP
+ssh -L 4444:127.0.0.1:4444 YOUR_DEPLOY_USER@YOUR_SERVER_HOST
 ```
 
 ---

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -104,13 +104,9 @@ Push to `main` or `develop` (or re-run the Deploy workflow). The script will clo
 SSH into the server as the same user GitHub Actions uses (e.g. `gcp-cppalliance`) and create the file inside the cloned directory:
 
 ```bash
+cd /opt/boost-data-collector
 cp .env.example .env
 # edit .env
-```
-
-Also copy and edit the Celery beat schedule template:
-
-```bash
 cp config/boost_collector_schedule.yaml.example config/boost_collector_schedule.yaml
 # edit config/boost_collector_schedule.yaml
 ```
@@ -267,7 +263,8 @@ Backups produced with `pg_dump -Fc` are **not** plain SQL. Restore with **`pg_re
 
 **Where to put the dump file**
 
-- Whoever runs `pg_restore` must be able to read the file: the **`postgres`** OS user when using `sudo -u postgres …`, or your normal login when using the **`bdc`** / `127.0.0.1` example below. Placing the dump under **`/tmp/`** with world-readable permissions (e.g. `644`) during restore is typical.
+- Whoever runs **`pg_restore`** must be able to read the dump: the **`postgres`** OS user when using `sudo -u postgres …`, or the account you use when restoring as **`bdc`** over **`127.0.0.1`** below. **Do not** make backups world-readable (e.g. **`644`** on a shared host): other local users could read sensitive data. Use least privilege instead: **`chmod 600`** (or tighter) and **`chown`** the file to match the restoring account (`postgres` vs your login). Prefer a **private directory** (your `$HOME`, a root-only path such as `/root/…`, or **`/var/lib/postgresql/…`** when only `postgres` should read it) over **`/tmp/`** unless you keep **`600`** and tight ownership there too.
+- To avoid **`postgres`** needing filesystem access to the path, you can stream from an account that already owns a **`600`** dump: **`cat /path/to/dump | sudo -u postgres pg_restore -h /var/run/postgresql -p 5432 -U postgres --verbose --clean --if-exists -d boost_dashboard -`**. Use the same idea without **`sudo`** when you run **`pg_restore`** as **`bdc`**.
 
 **Prefer Unix socket for superuser restore**
 
@@ -277,7 +274,7 @@ Backups produced with `pg_dump -Fc` are **not** plain SQL. Restore with **`pg_re
 sudo -u postgres pg_restore -h /var/run/postgresql -p 5432 -U postgres \
   --verbose --clean --if-exists \
   -d boost_dashboard \
-  /tmp/boost-data-collector-db-2026-03-25.dump
+  /var/lib/postgresql/boost-data-collector-db-2026-03-25.dump
 ```
 
 **Alternative: restore as `bdc` over TCP (`127.0.0.1`)**
@@ -285,10 +282,10 @@ sudo -u postgres pg_restore -h /var/run/postgresql -p 5432 -U postgres \
 If `pg_hba.conf` allows `bdc` from **`127.0.0.1/32`** (password / `scram-sha-256`), you can run `pg_restore` as a normal user instead of `sudo -u postgres`:
 
 ```bash
-pg_restore -h 127.0.0.1 -U bdc -d boost_dashboard --verbose /tmp/bdc-20260514.dump
+pg_restore -h 127.0.0.1 -U bdc -d boost_dashboard --verbose ~/bdc-20260514.dump
 ```
 
-Adjust the dump path as needed. You are prompted for `bdc`'s password unless you use **`PGPASSWORD`** or **`~/.pgpass`**. Add **`--clean --if-exists`** if you want the restore to drop existing objects first (match your dump and risk tolerance).
+Adjust the dump path as needed; set ownership and **`chmod 600`** on the file to match whoever runs **`pg_restore`**. You are prompted for `bdc`'s password unless you use **`PGPASSWORD`** or **`~/.pgpass`**. Add **`--clean --if-exists`** if you want the restore to drop existing objects first (match your dump and risk tolerance).
 
 **After restore — privileges for the app user:** If you restored **as `postgres`** (or another superuser), **`public` tables may remain owned by `postgres`**; DB owner `bdc` still has **no table rights** until you `GRANT` (empty `role_table_grants` for `bdc` is expected). Grants to other roles in the dump (e.g. `app_readonly`) do not apply to `bdc`. If you restored **as `bdc`** and objects are already owned by `bdc`, you may not need the grants—verify if the app reports permission errors.
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -39,7 +39,7 @@ In each environment (**production** and **staging**), add the following **Enviro
 | Secret | Description |
 |--------|-------------|
 | `SSH_HOST` | IP address or hostname of the server |
-| `SSH_USER` | SSH username (e.g. `gcp-cppdigest`) |
+| `SSH_USER` | SSH username (e.g. `gcp-cppalliance`) |
 | `SSH_PRIVATE_KEY` | SSH private key (full content, including header/footer) |
 | `SSH_PORT` | SSH port (optional, defaults to `22`) |
 | `SSH_KEY_PASSPHRASE` | Passphrase for the SSH private key (optional; only if the key is passphrase-protected) |
@@ -69,6 +69,26 @@ Docker and Docker Compose are also required. Refer to the [official Docker docs]
 
 ---
 
+## Server SSH key for GitHub
+
+The account that runs `git pull` on the server (same as `SSH_USER` in GitHub Actions) needs a key **on the server** that GitHub accepts for `git@github.com:cppalliance/boost-data-collector.git`. This is separate from the **`SSH_PRIVATE_KEY`** GitHub stores to log *into* the server.
+
+1. Install the private key under a dedicated name (example: `~/.ssh/id_ed25519_github`) and the matching `.pub` next to it. You can copy it from your workstation with `scp` (path to the key on your machine → `user@server:~/.ssh/...`).
+2. `~/.ssh/config`:
+
+```sshconfig
+Host github.com
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_github
+    IdentitiesOnly yes
+```
+
+3. Restrict permissions: `chmod 700 ~/.ssh`, `chmod 600 ~/.ssh/id_ed25519_github ~/.ssh/config`, `chmod 644 ~/.ssh/id_ed25519_github.pub`.
+4. Verify: `ssh -T git@github.com` (expect a GitHub success / username message).
+
+---
+
 ## One-Time Server Setup
 
 ### 1. Create the `.env` file (two-step process)
@@ -81,16 +101,30 @@ Push to `main` or `develop` (or re-run the Deploy workflow). The script will clo
 
 **Step 2 — Add `.env` on the server**
 
-SSH into the server as the same user GitHub Actions uses (e.g. `gcp-cppdigest`) and create the file inside the cloned directory. Use `.env.example` as a reference.
+SSH into the server as the same user GitHub Actions uses (e.g. `gcp-cppalliance`) and create the file inside the cloned directory:
+
+```bash
+cp .env.example .env
+# edit .env
+```
+
+Also copy and edit the Celery beat schedule template:
+
+```bash
+cp config/boost_collector_schedule.yaml.example config/boost_collector_schedule.yaml
+# edit config/boost_collector_schedule.yaml
+```
+
+Use `.env.example` and the YAML example as references for required variables and schedule entries.
 
 If you create or edit `.env` with `sudo` (e.g. `sudo nano`), the file is often owned by **root** with mode `600`. **Docker Compose reads `.env` as the user running `make build` / `make up`** (your deploy user), which causes `permission denied`. Fix ownership after saving:
 
 ```bash
-sudo chown gcp-cppdigest:gcp-cppdigest /opt/boost-data-collector/.env
+sudo chown gcp-cppalliance:gcp-cppalliance /opt/boost-data-collector/.env
 sudo chmod 600 /opt/boost-data-collector/.env
 ```
 
-(Replace `gcp-cppdigest` with your actual `SSH_USER` if different.)
+(Replace `gcp-cppalliance` with your actual `SSH_USER` if different.)
 
 **Step 3 — Run deploy again**
 
@@ -146,12 +180,23 @@ gcloud storage rsync /opt/boost-data-collector/workspace gs://bdc-backups/worksp
 
 ### Repository checkout and permissions
 
-The deploy user (e.g. `gcp-cppdigest`) should own the app tree under `/opt/boost-data-collector` so `git`, `make`, and Docker Compose can run without sudo.
+The deploy user (e.g. `gcp-cppalliance`) should own the app tree under `/opt/boost-data-collector` so `git`, `make`, and Docker Compose can run without sudo.
+
+If you are **not** relying on the first CI deploy to create the directory, prepare the tree manually (after [Server SSH key for GitHub](#server-ssh-key-for-github) is working), for example:
+
+```bash
+sudo mkdir -p /opt/boost-data-collector
+sudo chown -R "$USER:$USER" /opt/boost-data-collector
+cd /opt/boost-data-collector
+git clone -b develop git@github.com:cppalliance/boost-data-collector.git .
+```
+
+(`develop` matches the staging branch described above; use `main` for a production-only checkout if you prefer.)
 
 If the tree was created as root, normalize ownership:
 
 ```bash
-sudo chown -R gcp-cppdigest:gcp-cppdigest /opt/boost-data-collector
+sudo chown -R gcp-cppalliance:gcp-cppalliance /opt/boost-data-collector
 ```
 
 Docker bind mounts for `staticfiles` (and optionally a host `workspace` directory if you use one) must be readable/writable by the **UID used inside the image** for the app process (commonly `1000`). Example:
@@ -174,10 +219,11 @@ Create the application role and database **once** (use a strong password; the ex
 sudo -u postgres psql
 ```
 
-In the `psql` session:
+In the `psql` session (as superuser, e.g. `postgres`):
 
 ```sql
 CREATE ROLE bdc WITH LOGIN PASSWORD 'REPLACE_WITH_STRONG_PASSWORD';
+-- equivalent: CREATE USER bdc WITH PASSWORD 'REPLACE_WITH_STRONG_PASSWORD';
 DROP DATABASE IF EXISTS boost_dashboard;
 CREATE DATABASE boost_dashboard OWNER bdc;
 GRANT ALL PRIVILEGES ON DATABASE boost_dashboard TO bdc;
@@ -187,7 +233,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO bdc;
 CREATE ROLE app_readonly NOLOGIN;
 ```
 
-Run these statements as a superuser (e.g. `postgres`). The app role does not need `CREATEDB`; the database is created explicitly above. If you need a separate migration-only user with broader rights, create that role separately.
+The app role does not need `CREATEDB`; the database is created explicitly above. If you need a separate migration-only user with broader rights, create that role separately.
 
 If your dump replays `GRANT … TO app_readonly`, the `app_readonly` role must exist before restore (as above).
 
@@ -221,7 +267,7 @@ Backups produced with `pg_dump -Fc` are **not** plain SQL. Restore with **`pg_re
 
 **Where to put the dump file**
 
-- The **`postgres`** OS user must be able to read the file. Placing it under **`/tmp/`** with world-readable permissions (e.g. `644`) during restore is typical.
+- Whoever runs `pg_restore` must be able to read the file: the **`postgres`** OS user when using `sudo -u postgres …`, or your normal login when using the **`bdc`** / `127.0.0.1` example below. Placing the dump under **`/tmp/`** with world-readable permissions (e.g. `644`) during restore is typical.
 
 **Prefer Unix socket for superuser restore**
 
@@ -234,7 +280,17 @@ sudo -u postgres pg_restore -h /var/run/postgresql -p 5432 -U postgres \
   /tmp/boost-data-collector-db-2026-03-25.dump
 ```
 
-**After restore — privileges for the app user:** Restore as `postgres` leaves **`public` tables owned by `postgres`**; DB owner `bdc` still has **no table rights** until you `GRANT` (empty `role_table_grants` for `bdc` is expected). Grants to other roles in the dump (e.g. `app_readonly`) do not apply to `bdc`.
+**Alternative: restore as `bdc` over TCP (`127.0.0.1`)**
+
+If `pg_hba.conf` allows `bdc` from **`127.0.0.1/32`** (password / `scram-sha-256`), you can run `pg_restore` as a normal user instead of `sudo -u postgres`:
+
+```bash
+pg_restore -h 127.0.0.1 -U bdc -d boost_dashboard --verbose /tmp/bdc-20260514.dump
+```
+
+Adjust the dump path as needed. You are prompted for `bdc`'s password unless you use **`PGPASSWORD`** or **`~/.pgpass`**. Add **`--clean --if-exists`** if you want the restore to drop existing objects first (match your dump and risk tolerance).
+
+**After restore — privileges for the app user:** If you restored **as `postgres`** (or another superuser), **`public` tables may remain owned by `postgres`**; DB owner `bdc` still has **no table rights** until you `GRANT` (empty `role_table_grants` for `bdc` is expected). Grants to other roles in the dump (e.g. `app_readonly`) do not apply to `bdc`. If you restored **as `bdc`** and objects are already owned by `bdc`, you may not need the grants—verify if the app reports permission errors.
 
 1. As superuser: `\c boost_dashboard`, then run (adjust role name if not `bdc`):
 
@@ -274,7 +330,7 @@ make up
 make health  # optional smoke checks (see Makefile)
 ```
 
-The deploy script runs `make down`, `make build`, `make up`, then polls `make health`.
+CI uses the same targets in a fixed order (`make down` first); see [Deploy Script Behavior](#deploy-script-behavior).
 
 ### nginx reverse proxy
 
@@ -362,7 +418,7 @@ Reload nginx after testing config (`sudo nginx -t && sudo systemctl reload nginx
 **Selenium (port 4444)** is bound to **`127.0.0.1:4444`** in Compose so it is not exposed on the public interface. Access from your laptop via **SSH port forwarding** if you need the hub from outside the VM:
 
 ```bash
-ssh -L 4444:127.0.0.1:4444 gcp-cppdigest@YOUR_VM_IP
+ssh -L 4444:127.0.0.1:4444 gcp-cppalliance@YOUR_VM_IP
 ```
 
 ---
@@ -394,12 +450,7 @@ When secrets or config values change, SSH into the server and edit the file dire
 nano /opt/boost-data-collector/.env
 ```
 
-Ensure the deploy user still owns the file if you used `sudo` to edit:
-
-```bash
-sudo chown gcp-cppdigest:gcp-cppdigest /opt/boost-data-collector/.env
-sudo chmod 600 /opt/boost-data-collector/.env
-```
+If you saved with `sudo`, fix ownership and mode for the deploy user as in [Step 2 — Add `.env` on the server](#1-create-the-env-file-two-step-process).
 
 Then restart the containers to pick up the new values:
 


### PR DESCRIPTION
## Summary

- Document server-side SSH for `git@github.com` (separate from the GitHub Actions deploy key) and optional manual clone into `/opt/boost-data-collector`.
- Document copying `boost_collector_schedule.yaml` from the example alongside `.env` setup.
- Align deploy-user examples with CppAlliance (`gcp-cppalliance`).
- Document `pg_restore` as `bdc` over `127.0.0.1`, clarify dump file readability and post-restore grants for postgres vs `bdc` restores.
- Reduce duplication: link “Updating `.env`” to Step 2 for ownership; point Docker stack at deploy-script behavior for CI’s `make` sequence.

Closes #186 

The dev server is running on `staging.insights.cppalliance.org`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified GitHub Environments secret scope and updated required/optional secret guidance
  * Added server-side SSH key setup, host config, permission hardening, and verification steps
  * Expanded .env creation/update with Celery schedule template and sudo-safe chown/chmod guidance
  * Added manual repo checkout/ownership workflow and deploy-user ownership normalization
  * Clarified DB role/restore guidance including streaming and localhost/TCP alternative
  * Updated deploy sequencing, nginx example server names/cert paths, and generic port-forwarding placeholders

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/boost-data-collector/pull/203)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->