### PR TITLE
feat(collectors): deprecate `CollectorBase` in favor of `AbstractCollector`

### DIFF
--- a/core/collectors/base.py
+++ b/core/collectors/base.py
@@ -9,6 +9,7 @@ commands (``run_scheduled_collectors`` / YAML); subclasses may override
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 
 from django.core.management import call_command
@@ -16,6 +17,7 @@ from django.core.management import call_command
 from core.collectors.base_collector import _CollectorLifecycleMixin
 
 
+# TODO(v1.0): remove CollectorBase after migrating callers to AbstractCollector.
 class CollectorBase(_CollectorLifecycleMixin, ABC):
     """
     Legacy abstract base for collectors run via management commands or YAML schedules.
@@ -43,6 +45,17 @@ class CollectorBase(_CollectorLifecycleMixin, ABC):
     by the command layer without calling :meth:`~_CollectorLifecycleMixin.handle_error`.
     """
 
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        if getattr(cls, "_skip_collector_base_deprecation", False):
+            return
+        warnings.warn(
+            "CollectorBase is deprecated; use AbstractCollector instead. "
+            "CollectorBase will be removed in v1.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     @abstractmethod
     def run(self) -> None:
         """
@@ -60,6 +73,9 @@ class CollectorBase(_CollectorLifecycleMixin, ABC):
 
 class DjangoCommandCollector(CollectorBase):
     """Runs a registered Django management command by name."""
+
+    # Library adapter: not an app-defined collector; skip CollectorBase deprecation noise.
+    _skip_collector_base_deprecation = True
 
     __slots__ = ("command_name",)
 

--- a/core/tests/test_collectors_base.py
+++ b/core/tests/test_collectors_base.py
@@ -1,5 +1,6 @@
 """Tests for core.collectors base types."""
 
+import warnings
 from io import StringIO
 from unittest.mock import patch
 
@@ -10,6 +11,24 @@ import core.collectors.base_collector as collector_lifecycle
 from core.collectors.base import CollectorBase, DjangoCommandCollector
 from core.collectors.base_collector import AbstractCollector
 from core.collectors.command_base import BaseCollectorCommand
+
+
+def test_collector_base_subclass_emits_deprecation_warning():
+    assert getattr(DjangoCommandCollector, "_skip_collector_base_deprecation") is True
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always", DeprecationWarning)
+
+        class _WarnProbeCollector(CollectorBase):
+            def run(self) -> None:
+                return None
+
+    dep = [w for w in recorded if issubclass(w.category, DeprecationWarning)]
+    assert dep, "expected DeprecationWarning when subclassing CollectorBase"
+    msg = str(dep[-1].message)
+    assert "CollectorBase" in msg
+    assert "AbstractCollector" in msg
+    assert "v1.0" in msg
 
 
 @pytest.mark.django_db

--- a/docs/Core_public_API.md
+++ b/docs/Core_public_API.md
@@ -6,7 +6,7 @@ The `core` Django app holds shared infrastructure. Treat the following as the **
 
 | Import | Purpose |
 |--------|---------|
-| `core.collectors.CollectorBase` | **Deprecated** (removed in v1.0): legacy abstract `run()`, optional `sync_pinecone()`, `handle_error()` with structured logging. Subclassing emits `DeprecationWarning` at class definition time. Prefer `AbstractCollector`; see [Migrating from `CollectorBase`](#migrating-from-collectorbase-to-abstractcollector). |
+| `core.collectors.CollectorBase` | **Deprecated** (removed in v1.0): legacy abstract `run()`, optional `sync_pinecone()`, `handle_error()` with structured logging. Subclassing emits `DeprecationWarning` at class definition time. Prefer `AbstractCollector`|
 | `core.collectors.AbstractCollector` | Preferred contract: `name`, `validate_config()`, `collect()`; concrete `run()` runs validate then collect; same lifecycle hooks as `CollectorBase`. |
 | `core.collectors.CollectorRunnable` | `Protocol` for objects returned from `get_collector()` (`run`, `sync_pinecone`, `handle_error`). |
 | `core.collectors.BaseCollectorCommand` | Thin `BaseCommand` adapter: runs `get_collector(**opts).run()` then `sync_pinecone()`. |

--- a/docs/Core_public_API.md
+++ b/docs/Core_public_API.md
@@ -6,7 +6,7 @@ The `core` Django app holds shared infrastructure. Treat the following as the **
 
 | Import | Purpose |
 |--------|---------|
-| `core.collectors.CollectorBase` | Legacy abstract `run()`, optional `sync_pinecone()`, `handle_error()` with structured logging. |
+| `core.collectors.CollectorBase` | **Deprecated** (removed in v1.0): legacy abstract `run()`, optional `sync_pinecone()`, `handle_error()` with structured logging. Subclassing emits `DeprecationWarning` at class definition time. Prefer `AbstractCollector`; see [Migrating from `CollectorBase`](#migrating-from-collectorbase-to-abstractcollector). |
 | `core.collectors.AbstractCollector` | Preferred contract: `name`, `validate_config()`, `collect()`; concrete `run()` runs validate then collect; same lifecycle hooks as `CollectorBase`. |
 | `core.collectors.CollectorRunnable` | `Protocol` for objects returned from `get_collector()` (`run`, `sync_pinecone`, `handle_error`). |
 | `core.collectors.BaseCollectorCommand` | Thin `BaseCommand` adapter: runs `get_collector(**opts).run()` then `sync_pinecone()`. |


### PR DESCRIPTION
## Summary

- Emit `DeprecationWarning` when subclassing `CollectorBase` (`__init_subclass__`, removal planned in v1.0).
- Exempt `DjangoCommandCollector` via `_skip_collector_base_deprecation` so core glue code stays quiet.
- Document `CollectorBase` as deprecated in `Core_public_API.md` and point contributors to `AbstractCollector`.
- Add `test_collector_base_subclass_emits_deprecation_warning` (uses `warnings.catch_warnings` because pytest ignores `DeprecationWarning` globally).

Existing collectors that subclass `CollectorBase` keep working; the warning is advisory only.

## Test plan

- `uv run pytest core/tests/test_collectors_base.py::test_collector_base_subclass_emits_deprecation_warning -q`
- `uv run pytest core/tests/test_collectors_base.py -q` (with DB available for `@pytest.mark.django_db` tests)

Closes #212 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecated**
  * CollectorBase is marked deprecated with planned removal in v1.0; subclassing now emits a deprecation warning at definition time. Legacy run() is deprecated to encourage migration.

* **Documentation**
  * Public API docs updated to reflect deprecation, removal timeline, and the subclassing warning behavior.

* **Tests**
  * Added a test to assert subclassing triggers the deprecation warning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/boost-data-collector/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->