### PR TITLE
refactor(mailing-list): decouple cppa_user_tracker FK with soft sender_profile_id (pilot)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -48,3 +48,18 @@ forbidden_modules =
     github_activity_tracker.workspace
     github_activity_tracker.preprocessors
 allow_indirect_imports = true
+
+[importlinter:contract:forbid-mailing-list-user-models]
+name = boost_mailing_list_tracker production code must not import cppa_user_tracker.models
+type = forbidden
+source_modules =
+    boost_mailing_list_tracker.models
+    boost_mailing_list_tracker.services
+    boost_mailing_list_tracker.preprocessor
+    boost_mailing_list_tracker.admin
+    boost_mailing_list_tracker.management
+    boost_mailing_list_tracker.fetcher
+    boost_mailing_list_tracker.email_formatter
+forbidden_modules =
+    cppa_user_tracker.models
+allow_indirect_imports = true

--- a/boost_mailing_list_tracker/admin.py
+++ b/boost_mailing_list_tracker/admin.py
@@ -8,7 +8,7 @@ from .models import MailingListMessage
 class MailingListMessageAdmin(ModelAdmin):
     list_display = (
         "id",
-        "sender",
+        "sender_profile_id",
         "msg_id",
         "list_name",
         "subject",
@@ -16,6 +16,5 @@ class MailingListMessageAdmin(ModelAdmin):
         "created_at",
     )
     list_filter = ("list_name", "sent_at")
-    search_fields = ("msg_id", "subject", "sender__display_name")
-    raw_id_fields = ("sender",)
+    search_fields = ("msg_id", "subject")
     date_hierarchy = "sent_at"

--- a/boost_mailing_list_tracker/management/commands/run_boost_mailing_list_tracker.py
+++ b/boost_mailing_list_tracker/management/commands/run_boost_mailing_list_tracker.py
@@ -117,7 +117,7 @@ def _persist_email(email_data: dict) -> tuple[bool, bool]:
         )
 
         _, was_created = get_or_create_mailing_list_message(
-            sender=profile,
+            sender_profile_id=profile.pk,
             msg_id=msg_id,
             parent_id=_clean_text(email_data.get("parent_id", "")),
             thread_id=_clean_text(email_data.get("thread_id", "")),

--- a/boost_mailing_list_tracker/migrations/0003_soft_sender_profile_id.py
+++ b/boost_mailing_list_tracker/migrations/0003_soft_sender_profile_id.py
@@ -1,0 +1,65 @@
+# Generated manually for identity-hub decoupling (soft sender_profile_id).
+
+from django.db import migrations, models
+
+
+def drop_sender_foreign_key(apps, schema_editor):
+    """Drop PostgreSQL FK on sender_id; column values are unchanged."""
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    table = "boost_mailing_list_tracker_mailinglistmessage"
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT tc.constraint_name
+            FROM information_schema.table_constraints AS tc
+            JOIN information_schema.key_column_usage AS kcu
+              ON tc.constraint_name = kcu.constraint_name
+             AND tc.table_schema = kcu.table_schema
+            WHERE tc.table_schema = CURRENT_SCHEMA()
+              AND tc.table_name = %s
+              AND tc.constraint_type = 'FOREIGN KEY'
+              AND kcu.column_name = 'sender_id'
+            """,
+            [table],
+        )
+        for (constraint_name,) in cursor.fetchall():
+            cursor.execute(
+                f'ALTER TABLE "{table}" DROP CONSTRAINT IF EXISTS "{constraint_name}"'
+            )
+
+
+def noop_reverse(apps, schema_editor):
+    """Re-adding FK requires manual verification of sender_id orphans; not automated."""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("boost_mailing_list_tracker", "0002_list_name_choices"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunPython(drop_sender_foreign_key, noop_reverse),
+            ],
+            state_operations=[
+                migrations.RemoveField(
+                    model_name="mailinglistmessage",
+                    name="sender",
+                ),
+                migrations.AddField(
+                    model_name="mailinglistmessage",
+                    name="sender_profile_id",
+                    field=models.BigIntegerField(
+                        db_column="sender_id",
+                        db_index=True,
+                        default=0,
+                        help_text="cppa_user_tracker.MailingListProfile primary key (soft reference).",
+                    ),
+                    preserve_default=False,
+                ),
+            ],
+        ),
+    ]

--- a/boost_mailing_list_tracker/migrations/0003_soft_sender_profile_id.py
+++ b/boost_mailing_list_tracker/migrations/0003_soft_sender_profile_id.py
@@ -1,5 +1,6 @@
 # Generated manually for identity-hub decoupling (soft sender_profile_id).
 
+import django.core.validators
 from django.db import migrations, models
 
 
@@ -55,11 +56,18 @@ class Migration(migrations.Migration):
                     field=models.BigIntegerField(
                         db_column="sender_id",
                         db_index=True,
-                        default=0,
+                        validators=[django.core.validators.MinValueValidator(1)],
                         help_text="cppa_user_tracker.MailingListProfile primary key (soft reference).",
                     ),
                     preserve_default=False,
                 ),
             ],
+        ),
+        migrations.AddConstraint(
+            model_name="mailinglistmessage",
+            constraint=models.CheckConstraint(
+                check=models.Q(("sender_profile_id__gte", 1)),
+                name="boost_mailing_list_tracker_sender_profile_id_gte_1",
+            ),
         ),
     ]

--- a/boost_mailing_list_tracker/models.py
+++ b/boost_mailing_list_tracker/models.py
@@ -1,6 +1,8 @@
 """
 Models per docs/Schema.md section 5: Boost Mailing List Tracker.
-References cppa_user_tracker.MailingListProfile (section 1) as sender.
+
+Sender identity is stored as a soft reference to cppa_user_tracker.MailingListProfile.pk
+(column sender_id). Resolve profiles via cppa_user_tracker.services.
 """
 
 from django.db import models
@@ -15,13 +17,12 @@ class MailingListName(models.TextChoices):
 
 
 class MailingListMessage(models.Model):
-    """Mailing list message (sender -> MailingListProfile, msg_id, subject, content, list_name, sent_at)."""
+    """Mailing list message (sender_profile_id, msg_id, subject, content, list_name, sent_at)."""
 
-    sender = models.ForeignKey(
-        "cppa_user_tracker.MailingListProfile",
-        on_delete=models.CASCADE,
-        related_name="mailing_list_messages",
+    sender_profile_id = models.BigIntegerField(
         db_column="sender_id",
+        db_index=True,
+        help_text="cppa_user_tracker.MailingListProfile primary key (soft reference).",
     )
     msg_id = models.CharField(max_length=255, unique=True, db_index=True)
     parent_id = models.CharField(max_length=255, blank=True, db_index=True)

--- a/boost_mailing_list_tracker/models.py
+++ b/boost_mailing_list_tracker/models.py
@@ -5,6 +5,7 @@ Sender identity is stored as a soft reference to cppa_user_tracker.MailingListPr
 (column sender_id). Resolve profiles via cppa_user_tracker.services.
 """
 
+from django.core.validators import MinValueValidator
 from django.db import models
 
 
@@ -22,6 +23,7 @@ class MailingListMessage(models.Model):
     sender_profile_id = models.BigIntegerField(
         db_column="sender_id",
         db_index=True,
+        validators=[MinValueValidator(1)],
         help_text="cppa_user_tracker.MailingListProfile primary key (soft reference).",
     )
     msg_id = models.CharField(max_length=255, unique=True, db_index=True)
@@ -42,6 +44,12 @@ class MailingListMessage(models.Model):
         ordering = ["-sent_at"]
         verbose_name = "Mailing list message"
         verbose_name_plural = "Mailing list messages"
+        constraints = [
+            models.CheckConstraint(
+                check=models.Q(sender_profile_id__gte=1),
+                name="boost_mailing_list_tracker_sender_profile_id_gte_1",
+            ),
+        ]
 
     def __str__(self):
         return f"{self.list_name}: {self.subject[:60]}" if self.subject else self.msg_id

--- a/boost_mailing_list_tracker/preprocessor.py
+++ b/boost_mailing_list_tracker/preprocessor.py
@@ -16,6 +16,7 @@ from typing import Any
 from django.db.models import Q
 
 from boost_mailing_list_tracker.models import MailingListMessage
+from cppa_user_tracker.services import get_mailing_list_profiles_by_ids
 
 
 def _normalize_failed_ids(failed_ids: list[str]) -> list[str]:
@@ -38,7 +39,7 @@ def _get_sender_display_name(sender: Any) -> str:
     ).strip()
 
 
-def _build_document_content(message: MailingListMessage) -> str:
+def _build_document_content(message: MailingListMessage, sender: Any) -> str:
     """
     Build plain-text content for embedding.
 
@@ -48,7 +49,7 @@ def _build_document_content(message: MailingListMessage) -> str:
     if message.subject:
         parts.append(f"Subject: {message.subject.strip()}")
 
-    sender_name = _get_sender_display_name(message.sender)
+    sender_name = _get_sender_display_name(sender)
     if sender_name:
         parts.append(f"Sender: {sender_name}")
 
@@ -83,9 +84,9 @@ def preprocess_mailing_list_for_pinecone(
     """
     normalized_failed = _normalize_failed_ids(failed_ids or [])
 
-    queryset = MailingListMessage._default_manager.select_related("sender__identity")
+    queryset = MailingListMessage._default_manager.all()
     if final_sync_at is None and not normalized_failed:
-        candidates = queryset.order_by("id")
+        candidates = list(queryset.order_by("id"))
     else:
         criteria = Q()
         if final_sync_at is not None:
@@ -94,7 +95,10 @@ def preprocess_mailing_list_for_pinecone(
             criteria |= Q(created_at__gt=final_sync_at)
         if normalized_failed:
             criteria |= Q(msg_id__in=normalized_failed)
-        candidates = queryset.filter(criteria).order_by("id")
+        candidates = list(queryset.filter(criteria).order_by("id"))
+
+    profile_ids = [m.sender_profile_id for m in candidates]
+    profiles_by_id = get_mailing_list_profiles_by_ids(profile_ids)
 
     docs: list[dict[str, Any]] = []
     seen_msg_ids: set[str] = set()
@@ -104,12 +108,13 @@ def preprocess_mailing_list_for_pinecone(
             continue
         seen_msg_ids.add(msg_id)
 
-        content = _build_document_content(message)
+        sender = profiles_by_id.get(message.sender_profile_id)
+        content = _build_document_content(message, sender)
         if not content:
             # Skip unusable empty docs; pipeline also validates chunks.
             continue
 
-        sender_name = _get_sender_display_name(message.sender)
+        sender_name = _get_sender_display_name(sender)
 
         safe_timestamp = int(message.sent_at.timestamp()) if message.sent_at else 0
         metadata: dict[str, Any] = {

--- a/boost_mailing_list_tracker/services.py
+++ b/boost_mailing_list_tracker/services.py
@@ -38,7 +38,11 @@ def get_or_create_mailing_list_message(
           ValueError: If msg_id is empty or whitespace-only, list_name is invalid,
               or sender_profile_id is not a positive integer.
     """
-    if sender_profile_id < 1:
+    if (
+        not isinstance(sender_profile_id, int)
+        or isinstance(sender_profile_id, bool)
+        or sender_profile_id < 1
+    ):
         raise ValueError("sender_profile_id must be a positive integer.")
 
     if not (msg_id and msg_id.strip()):

--- a/boost_mailing_list_tracker/services.py
+++ b/boost_mailing_list_tracker/services.py
@@ -8,21 +8,16 @@ See CONTRIBUTING.md.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from datetime import datetime
 
 from .models import MailingListMessage, MailingListName
-
-if TYPE_CHECKING:  # pragma: no cover
-    from datetime import datetime
-
-    from cppa_user_tracker.models import MailingListProfile
 
 logger = logging.getLogger(__name__)
 
 
 # --- MailingListMessage ---
 def get_or_create_mailing_list_message(
-    sender: MailingListProfile,
+    sender_profile_id: int,
     msg_id: str,
     sent_at: datetime,
     parent_id: str = "",
@@ -33,12 +28,19 @@ def get_or_create_mailing_list_message(
 ) -> tuple[MailingListMessage, bool]:
     """Get or create a MailingListMessage by msg_id (unique).
 
-    If the message already exists (same msg_id), no fields are updated.
-    Returns (message, created).
+      ``sender_profile_id`` is the primary key of a cppa_user_tracker.MailingListProfile
+    (resolve or create profiles via cppa_user_tracker.services).
 
-    Raises:
-        ValueError: If msg_id is empty or whitespace-only, or list_name is not a valid MailingListName.
+      If the message already exists (same msg_id), no fields are updated.
+      Returns (message, created).
+
+      Raises:
+          ValueError: If msg_id is empty or whitespace-only, list_name is invalid,
+              or sender_profile_id is not a positive integer.
     """
+    if sender_profile_id < 1:
+        raise ValueError("sender_profile_id must be a positive integer.")
+
     if not (msg_id and msg_id.strip()):
         raise ValueError("msg_id must not be empty.")
 
@@ -53,7 +55,7 @@ def get_or_create_mailing_list_message(
     return MailingListMessage.objects.get_or_create(
         msg_id=msg_id.strip(),
         defaults={
-            "sender": sender,
+            "sender_profile_id": sender_profile_id,
             "parent_id": parent_id,
             "thread_id": thread_id,
             "subject": subject,

--- a/boost_mailing_list_tracker/tests/test_fetcher.py
+++ b/boost_mailing_list_tracker/tests/test_fetcher.py
@@ -238,7 +238,7 @@ def test_get_start_date_from_db_returns_iso_utc_format(
 
     dt = datetime(2025, 11, 13, 5, 25, 55, tzinfo=timezone.utc)
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<start-date-test@example.com>",
         sent_at=dt,
         list_name=default_list_name,
@@ -256,13 +256,13 @@ def test_get_start_date_from_db_uses_latest_sent_at(
     from boost_mailing_list_tracker import services
 
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<older@example.com>",
         sent_at=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
         list_name=default_list_name,
     )
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<newer@example.com>",
         sent_at=datetime(2025, 6, 15, 14, 30, 0, tzinfo=timezone.utc),
         list_name=default_list_name,
@@ -281,7 +281,7 @@ def test_get_start_date_from_db_utc_aware_sent_at_iso_format(
 
     dt_utc = datetime(2025, 3, 10, 12, 0, 0, tzinfo=timezone.utc)
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<utc@example.com>",
         sent_at=dt_utc,
         list_name=default_list_name,
@@ -657,7 +657,7 @@ def test_fetch_all_emails_inserts_start_date_from_database_when_blank(
 
     dt = datetime(2024, 3, 1, 12, 0, 0, tzinfo=timezone.utc)
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<db-start@example.com>",
         sent_at=dt,
         list_name=default_list_name,

--- a/boost_mailing_list_tracker/tests/test_models.py
+++ b/boost_mailing_list_tracker/tests/test_models.py
@@ -53,13 +53,16 @@ def test_mailing_list_message_links_sender(
     from boost_mailing_list_tracker import services
 
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<msg-001@example.com>",
         sent_at=sample_sent_at,
         list_name=default_list_name,
     )
-    assert msg.sender_id == mailing_list_profile.pk
-    assert msg.sender == mailing_list_profile
+    assert msg.sender_profile_id == mailing_list_profile.pk
+    from cppa_user_tracker.services import get_mailing_list_profile_by_id
+
+    resolved = get_mailing_list_profile_by_id(msg.sender_profile_id)
+    assert resolved == mailing_list_profile
 
 
 @pytest.mark.django_db
@@ -72,7 +75,7 @@ def test_mailing_list_message_stores_msg_id_and_list_name(
     from boost_mailing_list_tracker import services
 
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<unique-msg@lists.boost.org>",
         sent_at=sample_sent_at,
         list_name=default_list_name,
@@ -91,7 +94,7 @@ def test_mailing_list_message_stores_optional_fields(
     from boost_mailing_list_tracker import services
 
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<with-fields@example.com>",
         sent_at=sample_sent_at,
         parent_id="<parent@example.com>",
@@ -116,7 +119,7 @@ def test_mailing_list_message_has_created_at(
     from boost_mailing_list_tracker import services
 
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<created-at@example.com>",
         sent_at=sample_sent_at,
         list_name=default_list_name,
@@ -140,7 +143,7 @@ def test_mailing_list_message_str_with_subject(
     from boost_mailing_list_tracker import services
 
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<str-subject@example.com>",
         sent_at=sample_sent_at,
         subject="A short subject",
@@ -160,7 +163,7 @@ def test_mailing_list_message_str_fallback_to_msg_id(
     from boost_mailing_list_tracker import services
 
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<no-subject@example.com>",
         sent_at=sample_sent_at,
         subject="",
@@ -179,7 +182,7 @@ def test_mailing_list_message_msg_id_unique(
     from boost_mailing_list_tracker import services
 
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<duplicate@example.com>",
         sent_at=sample_sent_at,
         list_name=default_list_name,
@@ -187,7 +190,7 @@ def test_mailing_list_message_msg_id_unique(
     with pytest.raises(IntegrityError):
         baker.make(
             "boost_mailing_list_tracker.MailingListMessage",
-            sender=mailing_list_profile,
+            sender_profile_id=mailing_list_profile.pk,
             msg_id="<duplicate@example.com>",
             list_name=default_list_name,
             sent_at=sample_sent_at,
@@ -207,7 +210,7 @@ def test_mailing_list_message_optional_fields_can_be_blank(
     from boost_mailing_list_tracker import services
 
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<minimal@example.com>",
         sent_at=sample_sent_at,
         list_name=default_list_name,
@@ -230,7 +233,7 @@ def test_mailing_list_message_sent_at_null_allowed_at_db_level(
     """MailingListMessage.sent_at is nullable (model allows null)."""
     msg = baker.make(
         "boost_mailing_list_tracker.MailingListMessage",
-        sender=mailing_list_profile,
+        sender_profile_id=mailing_list_profile.pk,
         msg_id="<null-sent@example.com>",
         list_name=default_list_name,
         sent_at=None,
@@ -254,7 +257,7 @@ def test_mailing_list_message_msg_id_max_length(
 
     long_id = "x" * 255
     msg, created = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id=long_id,
         sent_at=sample_sent_at,
         list_name=default_list_name,
@@ -275,7 +278,7 @@ def test_mailing_list_message_subject_max_length(
 
     long_subject = "s" * 1024
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<long-subject@example.com>",
         sent_at=sample_sent_at,
         subject=long_subject,
@@ -295,7 +298,7 @@ def test_mailing_list_message_str_truncates_long_subject(
 
     long_subject = "A" * 70
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<long@example.com>",
         sent_at=sample_sent_at,
         subject=long_subject,
@@ -318,7 +321,7 @@ def test_mailing_list_message_str_exactly_60_char_subject(
 
     subject_60 = "x" * 60
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<sixty@example.com>",
         sent_at=sample_sent_at,
         subject=subject_60,
@@ -338,7 +341,7 @@ def test_mailing_list_message_invalid_list_name_validation(
     """MailingListMessage full_clean() raises ValidationError for invalid list_name."""
     msg = baker.make(
         "boost_mailing_list_tracker.MailingListMessage",
-        sender=mailing_list_profile,
+        sender_profile_id=mailing_list_profile.pk,
         msg_id="<invalid-list@example.com>",
         list_name="not-a-valid-choice",
         sent_at=sample_sent_at,
@@ -358,7 +361,7 @@ def test_mailing_list_message_empty_msg_id_rejected_by_db(
 
     with pytest.raises(ValueError, match="msg_id must not be empty"):
         services.get_or_create_mailing_list_message(
-            mailing_list_profile,
+            mailing_list_profile.pk,
             msg_id="",
             sent_at=sample_sent_at,
             list_name=default_list_name,
@@ -380,26 +383,26 @@ def test_mailing_list_message_meta():
     assert MailingListMessage._meta.verbose_name_plural == "Mailing list messages"
 
 
-# --- Relations: CASCADE ---
+# --- Relations: soft sender reference ---
 
 
 @pytest.mark.django_db
-def test_mailing_list_message_cascade_when_sender_deleted(
+def test_mailing_list_message_retained_when_sender_profile_deleted(
     mailing_list_profile,
     default_list_name,
     sample_sent_at,
 ):
-    """Deleting sender (MailingListProfile) deletes related MailingListMessage (CASCADE)."""
+    """Deleting MailingListProfile does not delete messages (soft sender_profile_id)."""
     from boost_mailing_list_tracker import services
 
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
-        msg_id="<cascade@example.com>",
+        mailing_list_profile.pk,
+        msg_id="<soft-ref@example.com>",
         sent_at=sample_sent_at,
         list_name=default_list_name,
     )
     pk = msg.pk
     profile_pk = mailing_list_profile.pk
     mailing_list_profile.delete()
-    assert not MailingListMessage.objects.filter(pk=pk).exists()
-    assert not MailingListMessage.objects.filter(sender_id=profile_pk).exists()
+    assert MailingListMessage.objects.filter(pk=pk).exists()
+    assert MailingListMessage.objects.filter(sender_profile_id=profile_pk).exists()

--- a/boost_mailing_list_tracker/tests/test_models.py
+++ b/boost_mailing_list_tracker/tests/test_models.py
@@ -351,6 +351,38 @@ def test_mailing_list_message_invalid_list_name_validation(
 
 
 @pytest.mark.django_db
+def test_mailing_list_message_invalid_sender_profile_id_validation(
+    default_list_name,
+    sample_sent_at,
+):
+    """full_clean() rejects sender_profile_id below 1 (MinValueValidator)."""
+    msg = MailingListMessage(
+        sender_profile_id=0,
+        msg_id="<zero-sender@example.com>",
+        list_name=default_list_name,
+        sent_at=sample_sent_at,
+    )
+    with pytest.raises(ValidationError):
+        msg.full_clean()
+
+
+@pytest.mark.django_db
+def test_mailing_list_message_invalid_sender_profile_id_db_constraint(
+    default_list_name,
+    sample_sent_at,
+):
+    """Database CheckConstraint rejects sender_profile_id below 1 on save."""
+    msg = MailingListMessage(
+        sender_profile_id=-1,
+        msg_id="<negative-sender@example.com>",
+        list_name=default_list_name,
+        sent_at=sample_sent_at,
+    )
+    with pytest.raises(IntegrityError):
+        msg.save()
+
+
+@pytest.mark.django_db
 def test_mailing_list_message_empty_msg_id_rejected_by_db(
     mailing_list_profile,
     default_list_name,

--- a/boost_mailing_list_tracker/tests/test_preprocessor.py
+++ b/boost_mailing_list_tracker/tests/test_preprocessor.py
@@ -28,7 +28,7 @@ def test_preprocessor_first_sync_returns_all_messages(
     from boost_mailing_list_tracker import services
 
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<a@example.com>",
         sent_at=sample_sent_at,
         subject="Subject A",
@@ -36,7 +36,7 @@ def test_preprocessor_first_sync_returns_all_messages(
         list_name=default_list_name,
     )
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<b@example.com>",
         sent_at=sample_sent_at,
         subject="Subject B",
@@ -62,7 +62,7 @@ def test_preprocessor_incremental_by_created_at(
     from boost_mailing_list_tracker.models import MailingListMessage
 
     old_msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<old@example.com>",
         sent_at=sample_sent_at,
         subject="Old",
@@ -70,7 +70,7 @@ def test_preprocessor_incremental_by_created_at(
         list_name=default_list_name,
     )
     new_msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<new@example.com>",
         sent_at=sample_sent_at,
         subject="New",
@@ -102,7 +102,7 @@ def test_preprocessor_retries_failed_ids_even_if_old(
     from boost_mailing_list_tracker.models import MailingListMessage
 
     retry_msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<retry@example.com>",
         sent_at=sample_sent_at,
         subject="Retry",
@@ -134,7 +134,7 @@ def test_preprocessor_deduplicates_overlap_between_failed_and_incremental(
     from boost_mailing_list_tracker.models import MailingListMessage
 
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<dedupe@example.com>",
         sent_at=sample_sent_at,
         subject="Dedupe",
@@ -162,7 +162,7 @@ def test_preprocessor_document_shape_and_metadata_fields(
     from boost_mailing_list_tracker import services
 
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<shape@example.com>",
         sent_at=sample_sent_at,
         parent_id="<parent@example.com>",
@@ -207,7 +207,7 @@ def test_preprocessor_handles_empty_body_with_metadata_fallback_content(
     from boost_mailing_list_tracker import services
 
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<empty-body@example.com>",
         sent_at=sample_sent_at,
         subject="",
@@ -239,7 +239,7 @@ def test_preprocessor_author_falls_back_to_identity_display_name(
     mailing_list_profile.save()
 
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<identity-author@example.com>",
         sent_at=sample_sent_at,
         subject="Sub",
@@ -265,7 +265,7 @@ def test_preprocess_failed_ids_normalizes_whitespace_and_duplicates(
     from boost_mailing_list_tracker.models import MailingListMessage
 
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<norm-fail@example.com>",
         sent_at=sample_sent_at,
         subject="S",

--- a/boost_mailing_list_tracker/tests/test_services.py
+++ b/boost_mailing_list_tracker/tests/test_services.py
@@ -86,7 +86,12 @@ def test_get_or_create_mailing_list_message_empty_msg_id_raises(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "sender_profile_id",
+    [0, -1, True, "42", None],
+)
 def test_get_or_create_mailing_list_message_invalid_sender_profile_id_raises(
+    sender_profile_id,
     default_list_name,
     sample_sent_at,
 ):
@@ -95,7 +100,7 @@ def test_get_or_create_mailing_list_message_invalid_sender_profile_id_raises(
         ValueError, match="sender_profile_id must be a positive integer"
     ):
         services.get_or_create_mailing_list_message(
-            0,
+            sender_profile_id,
             msg_id="<msg@example.com>",
             sent_at=sample_sent_at,
             list_name=default_list_name,

--- a/boost_mailing_list_tracker/tests/test_services.py
+++ b/boost_mailing_list_tracker/tests/test_services.py
@@ -23,14 +23,14 @@ def test_get_or_create_mailing_list_message_creates_new(
 ):
     """get_or_create_mailing_list_message creates new message and returns (message, True)."""
     msg, created = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<new-msg@example.com>",
         sent_at=sample_sent_at,
         subject="Hello",
         list_name=default_list_name,
     )
     assert created is True
-    assert msg.sender_id == mailing_list_profile.pk
+    assert msg.sender_profile_id == mailing_list_profile.pk
     assert msg.msg_id == "<new-msg@example.com>"
     assert msg.subject == "Hello"
     assert msg.list_name == default_list_name
@@ -45,14 +45,14 @@ def test_get_or_create_mailing_list_message_gets_existing(
 ):
     """get_or_create_mailing_list_message returns existing and (message, False)."""
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<existing@example.com>",
         sent_at=sample_sent_at,
         subject="Original",
         list_name=default_list_name,
     )
     msg2, created2 = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<existing@example.com>",
         sent_at=datetime(2024, 7, 1, tzinfo=timezone.utc),
         subject="Updated subject",
@@ -71,15 +71,32 @@ def test_get_or_create_mailing_list_message_empty_msg_id_raises(
     """get_or_create_mailing_list_message raises ValueError for empty msg_id."""
     with pytest.raises(ValueError, match="msg_id must not be empty"):
         services.get_or_create_mailing_list_message(
-            mailing_list_profile,
+            mailing_list_profile.pk,
             msg_id="",
             sent_at=sample_sent_at,
             list_name=default_list_name,
         )
     with pytest.raises(ValueError, match="msg_id must not be empty"):
         services.get_or_create_mailing_list_message(
-            mailing_list_profile,
+            mailing_list_profile.pk,
             msg_id="   ",
+            sent_at=sample_sent_at,
+            list_name=default_list_name,
+        )
+
+
+@pytest.mark.django_db
+def test_get_or_create_mailing_list_message_invalid_sender_profile_id_raises(
+    default_list_name,
+    sample_sent_at,
+):
+    """get_or_create_mailing_list_message raises ValueError for invalid sender_profile_id."""
+    with pytest.raises(
+        ValueError, match="sender_profile_id must be a positive integer"
+    ):
+        services.get_or_create_mailing_list_message(
+            0,
+            msg_id="<msg@example.com>",
             sent_at=sample_sent_at,
             list_name=default_list_name,
         )
@@ -93,14 +110,14 @@ def test_get_or_create_mailing_list_message_invalid_list_name_raises(
     """get_or_create_mailing_list_message raises ValueError for invalid list_name."""
     with pytest.raises(ValueError, match="list_name must be one of"):
         services.get_or_create_mailing_list_message(
-            mailing_list_profile,
+            mailing_list_profile.pk,
             msg_id="<msg@example.com>",
             sent_at=sample_sent_at,
             list_name="invalid-list",
         )
     with pytest.raises(ValueError, match="list_name must be one of"):
         services.get_or_create_mailing_list_message(
-            mailing_list_profile,
+            mailing_list_profile.pk,
             msg_id="<msg2@example.com>",
             sent_at=sample_sent_at,
             list_name="",
@@ -115,7 +132,7 @@ def test_get_or_create_mailing_list_message_strips_msg_id(
 ):
     """get_or_create_mailing_list_message strips whitespace from msg_id."""
     msg, created = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="  <trimmed@example.com>  ",
         sent_at=sample_sent_at,
         list_name=default_list_name,
@@ -132,7 +149,7 @@ def test_get_or_create_mailing_list_message_all_list_names(
     """get_or_create_mailing_list_message accepts all MailingListName values."""
     for i, list_value in enumerate(MailingListName):
         msg, created = services.get_or_create_mailing_list_message(
-            mailing_list_profile,
+            mailing_list_profile.pk,
             msg_id=f"<msg-{i}@example.com>",
             sent_at=sample_sent_at,
             list_name=list_value.value,
@@ -152,7 +169,7 @@ def test_delete_mailing_list_message_removes_from_db(
 ):
     """delete_mailing_list_message deletes the message from database."""
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<to-delete@example.com>",
         sent_at=sample_sent_at,
         list_name=default_list_name,
@@ -170,7 +187,7 @@ def test_delete_mailing_list_message_returns_none(
 ):
     """delete_mailing_list_message returns None."""
     msg, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<return-none@example.com>",
         sent_at=sample_sent_at,
         list_name=default_list_name,
@@ -187,13 +204,13 @@ def test_delete_mailing_list_message_leaves_others(
 ):
     """delete_mailing_list_message only removes the given message."""
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<keep@example.com>",
         sent_at=sample_sent_at,
         list_name=default_list_name,
     )
     msg2, _ = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<remove@example.com>",
         sent_at=sample_sent_at,
         list_name=default_list_name,
@@ -214,7 +231,7 @@ def test_get_or_create_mailing_list_message_none_list_name_raises(
     """get_or_create_mailing_list_message raises ValueError for None list_name (invalid)."""
     with pytest.raises(ValueError, match="list_name must be one of"):
         services.get_or_create_mailing_list_message(
-            mailing_list_profile,
+            mailing_list_profile.pk,
             msg_id="<msg@example.com>",
             sent_at=sample_sent_at,
             list_name=None,  # type: ignore[arg-type]
@@ -233,7 +250,7 @@ def test_get_or_create_mailing_list_message_msg_id_at_max_length(
     """get_or_create_mailing_list_message accepts msg_id of 255 chars (max_length)."""
     long_msg_id = "a" * 255
     msg, created = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id=long_msg_id,
         sent_at=sample_sent_at,
         list_name=default_list_name,
@@ -252,7 +269,7 @@ def test_get_or_create_mailing_list_message_large_subject_and_content(
     subject_1024 = "s" * 1024
     content_large = "c" * 10000
     msg, created = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<large@example.com>",
         sent_at=sample_sent_at,
         subject=subject_1024,
@@ -275,7 +292,7 @@ def test_get_or_create_mailing_list_message_does_not_update_any_field(
 ):
     """get_or_create_mailing_list_message leaves all fields unchanged on existing msg."""
     services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="<no-update@example.com>",
         sent_at=sample_sent_at,
         parent_id="old_parent",
@@ -285,7 +302,7 @@ def test_get_or_create_mailing_list_message_does_not_update_any_field(
         list_name=default_list_name,
     )
     msg2, created = services.get_or_create_mailing_list_message(
-        mailing_list_profile,
+        mailing_list_profile.pk,
         msg_id="  <no-update@example.com>  ",  # stripped to same
         sent_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
         parent_id="new_parent",

--- a/boost_mailing_list_tracker/tests/test_subset_schema.py
+++ b/boost_mailing_list_tracker/tests/test_subset_schema.py
@@ -1,0 +1,48 @@
+"""Tests that run under subset INSTALLED_APPS (no cppa_user_tracker tables).
+
+Run:
+  DJANGO_SETTINGS_MODULE=config.test_settings_subset_boost_mailing_list \\
+    uv run pytest boost_mailing_list_tracker/tests/test_subset_schema.py -m subset_schema -v
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from boost_mailing_list_tracker import services
+from boost_mailing_list_tracker.models import MailingListMessage, MailingListName
+
+
+@pytest.mark.django_db
+@pytest.mark.subset_schema
+def test_mailing_list_message_create_with_soft_sender_id():
+    """MailingListMessage persists with sender_profile_id only (no identity hub ORM)."""
+    sender_id = 42_001
+    sent_at = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    msg, created = services.get_or_create_mailing_list_message(
+        sender_id,
+        msg_id="<subset@example.com>",
+        sent_at=sent_at,
+        list_name=MailingListName.BOOST_USERS.value,
+        subject="Subset test",
+        content="Body",
+    )
+    assert created is True
+    assert msg.sender_profile_id == sender_id
+    assert MailingListMessage.objects.filter(msg_id="<subset@example.com>").exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.subset_schema
+def test_mailing_list_message_rejects_invalid_sender_profile_id():
+    """Service validates sender_profile_id without requiring hub models."""
+    sent_at = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(
+        ValueError, match="sender_profile_id must be a positive integer"
+    ):
+        services.get_or_create_mailing_list_message(
+            0,
+            msg_id="<bad-sender@example.com>",
+            sent_at=sent_at,
+            list_name=MailingListName.BOOST.value,
+        )

--- a/config/test_settings_subset_boost_mailing_list.py
+++ b/config/test_settings_subset_boost_mailing_list.py
@@ -1,0 +1,16 @@
+"""
+Subset-schema test settings for boost_mailing_list_tracker.
+
+Uses PostgreSQL (via config.test_settings) but only installs django.contrib,
+core, and boost_mailing_list_tracker — no cppa_user_tracker or peer trackers.
+Requires DATABASE_URL (see README → Running tests).
+"""
+
+from .test_settings import *  # noqa: F401, F403
+
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "core",
+    "boost_mailing_list_tracker",
+]

--- a/conftest.py
+++ b/conftest.py
@@ -32,19 +32,28 @@ def pytest_configure(config):  # noqa: F841 (pytest hook; name must match spec)
 
 
 # Load app-level fixture modules so fixtures from each app are available everywhere.
-pytest_plugins = [
-    "cppa_user_tracker.tests.fixtures",
-    "core.tests.github_ops.fixtures",
-    "github_activity_tracker.tests.fixtures",
-    "boost_library_tracker.tests.fixtures",
-    "boost_library_docs_tracker.tests.fixtures",
-    "cppa_pinecone_sync.tests.fixtures",
-    "cppa_slack_tracker.tests.fixtures",
-    "boost_library_usage_dashboard.tests.fixtures",
-    "boost_usage_tracker.tests.fixtures",
-    "boost_mailing_list_tracker.tests.fixtures",
-    "boost_collector_runner.tests.fixtures",
-]
+# Subset-schema settings omit peer apps (and cppa_user_tracker); skip their fixture plugins.
+_settings_module = os.environ.get("DJANGO_SETTINGS_MODULE", "")
+_subset_schema_settings = _settings_module.endswith(
+    "test_settings_subset_boost_mailing_list"
+)
+
+if _subset_schema_settings:
+    pytest_plugins: list[str] = []
+else:
+    pytest_plugins = [
+        "cppa_user_tracker.tests.fixtures",
+        "core.tests.github_ops.fixtures",
+        "github_activity_tracker.tests.fixtures",
+        "boost_library_tracker.tests.fixtures",
+        "boost_library_docs_tracker.tests.fixtures",
+        "cppa_pinecone_sync.tests.fixtures",
+        "cppa_slack_tracker.tests.fixtures",
+        "boost_library_usage_dashboard.tests.fixtures",
+        "boost_usage_tracker.tests.fixtures",
+        "boost_mailing_list_tracker.tests.fixtures",
+        "boost_collector_runner.tests.fixtures",
+    ]
 
 
 @pytest.fixture(scope="session")

--- a/cppa_user_tracker/services.py
+++ b/cppa_user_tracker/services.py
@@ -164,6 +164,30 @@ def get_or_create_mailing_list_profile(
     return profile, True
 
 
+def get_mailing_list_profile_by_id(profile_id: int) -> MailingListProfile | None:
+    """Return MailingListProfile for profile_id, or None if not found (read-only lookup)."""
+    if profile_id < 1:
+        return None
+    return (
+        MailingListProfile.objects.select_related("identity")
+        .filter(pk=profile_id)
+        .first()
+    )
+
+
+def get_mailing_list_profiles_by_ids(
+    profile_ids: list[int],
+) -> dict[int, MailingListProfile]:
+    """Return mailing-list profiles keyed by pk for the given ids (read-only bulk lookup)."""
+    unique_ids = sorted({i for i in profile_ids if i > 0})
+    if not unique_ids:
+        return {}
+    profiles = MailingListProfile.objects.select_related("identity").filter(
+        pk__in=unique_ids
+    )
+    return {profile.pk: profile for profile in profiles}
+
+
 def get_or_create_github_account(
     github_account_id: int,
     username: str = "",

--- a/cppa_user_tracker/tests/test_services.py
+++ b/cppa_user_tracker/tests/test_services.py
@@ -600,6 +600,47 @@ def test_get_or_create_mailing_list_profile_strips_display_name_and_email():
     assert profile.emails.filter(email="trimmed@example.com").exists()
 
 
+# --- get_mailing_list_profile_by_id / get_mailing_list_profiles_by_ids ---
+
+
+@pytest.mark.django_db
+def test_get_mailing_list_profile_by_id_returns_profile():
+    """get_mailing_list_profile_by_id returns the profile when it exists."""
+    profile, _ = services.get_or_create_mailing_list_profile(
+        display_name="Lookup Me",
+        email="lookup@example.com",
+    )
+    found = services.get_mailing_list_profile_by_id(profile.pk)
+    assert found is not None
+    assert found.pk == profile.pk
+    assert found.display_name == "Lookup Me"
+
+
+@pytest.mark.django_db
+def test_get_mailing_list_profile_by_id_missing_or_invalid():
+    """get_mailing_list_profile_by_id returns None for missing or invalid ids."""
+    assert services.get_mailing_list_profile_by_id(999_999_999) is None
+    assert services.get_mailing_list_profile_by_id(0) is None
+    assert services.get_mailing_list_profile_by_id(-1) is None
+
+
+@pytest.mark.django_db
+def test_get_mailing_list_profiles_by_ids_bulk():
+    """get_mailing_list_profiles_by_ids returns a map of existing profiles."""
+    p1, _ = services.get_or_create_mailing_list_profile(
+        display_name="Bulk One", email="one@example.com"
+    )
+    p2, _ = services.get_or_create_mailing_list_profile(
+        display_name="Bulk Two", email="two@example.com"
+    )
+    result = services.get_mailing_list_profiles_by_ids(
+        [p1.pk, p2.pk, 0, 999_999_999, p1.pk]
+    )
+    assert set(result.keys()) == {p1.pk, p2.pk}
+    assert result[p1.pk].display_name == "Bulk One"
+    assert result[p2.pk].display_name == "Bulk Two"
+
+
 # --- get_or_create_wg21_paper_author_profile ---
 
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,10 @@
+# Architecture Decision Records (ADR)
+
+Short, durable records of significant architectural choices in Boost Data Collector.
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [identity-hub-decoupling.md](identity-hub-decoupling.md) | Identity hub data-layer decoupling (soft profile IDs) | Accepted (pilot: `boost_mailing_list_tracker`) |
+| [paradigm-unification.md](paradigm-unification.md) | Paradigm unification (collectors, service layer) | See document |
+
+When adding an ADR, link it here and reference [cross-app-dependencies.md](../cross-app-dependencies.md) for coupling detail.

--- a/docs/adr/identity-hub-decoupling.md
+++ b/docs/adr/identity-hub-decoupling.md
@@ -1,0 +1,25 @@
+# ADR: Identity hub data-layer decoupling
+
+**Status:** Accepted (pilot implemented for `boost_mailing_list_tracker`)
+**Context:** Week 22 import-linter contracts enforce Python import boundaries; ORM `ForeignKey` into `cppa_user_tracker` still forces every consumer app to depend on the full identity schema for migrations and pytest table creation.
+
+## Decision
+
+1. **Replace cross-app `ForeignKey` to profile models** with a **`BigIntegerField`** storing the profile primary key, keeping the existing **`db_column`** (e.g. `sender_id`) so production data needs no value rewrite.
+2. **Drop the PostgreSQL FK constraint** in migrations (`RunSQL` / dynamic constraint discovery); do not rely on `db_constraint=False` as the end state.
+3. **Resolve identity at boundaries:**
+   - **Writes:** consumer collectors call `cppa_user_tracker.services.get_or_create_*` and pass `profile.pk` into the consumer `services.py`.
+   - **Reads:** consumer code calls `cppa_user_tracker.services.get_*_profile_by_id` (and optional bulk helpers), not `cppa_user_tracker.models` from consumer packages (enforced by import-linter for decoupled apps).
+4. **Subset-schema tests:** per-app `config/test_settings_subset_<app>.py` with minimal `INSTALLED_APPS` so pytest can create only that app’s tables when the hub FK is removed.
+
+## Consequences
+
+- Deleting a profile row **no longer CASCADE-deletes** dependent messages in decoupled apps; ops should treat orphan `sender_id` values via periodic SQL checks.
+- Consumer `admin.py` loses `raw_id_fields` / `select_related` on profile FKs; use profile id columns and service lookups where needed.
+- Rollout order: mailing list (pilot) → YouTube / WG21 paper → Discord / Slack → GitHub cluster.
+
+## References
+
+- [cross-app-dependencies.md §1](../cross-app-dependencies.md) — FK inventory
+- [cppa_user_tracker/services.py](../../cppa_user_tracker/services.py) — identity write/read API
+- [config/test_settings_subset_boost_mailing_list.py](../../config/test_settings_subset_boost_mailing_list.py) — subset pytest settings (pilot)

--- a/docs/cross-app-dependencies.md
+++ b/docs/cross-app-dependencies.md
@@ -47,10 +47,11 @@ document.  `core` is excluded because it is shared infrastructure, not a peer tr
 
 These are hard database-level dependencies.  They cannot be removed without migrations.
 
-> **Note on `cppa_user_tracker`:** This app acts as an identity hub.  All other
-> tracker apps that deal with people (GitHub accounts, Discord/Slack users, WG21
-> authors, mailing-list senders, YouTube speakers) hold a FK into it.  This is the
-> dominant coupling pattern and is considered **intentional architecture**.
+> **Note on `cppa_user_tracker`:** This app acts as an identity hub.  Most tracker
+> apps that deal with people still hold an ORM FK into it; **`boost_mailing_list_tracker`**
+> is the first app migrated to a **soft profile ID** (`sender_profile_id` / DB column
+> `sender_id`) plus service-layer lookup — see [adr/identity-hub-decoupling.md](adr/identity-hub-decoupling.md).
+> Remaining FK couplings are documented below and are being phased out in risk order.
 
 | Source app | Target app | Mechanism | Fields / models | Intent |
 | --- | --- | --- | --- | --- |
@@ -68,7 +69,7 @@ These are hard database-level dependencies.  They cannot be removed without migr
 | `boost_usage_tracker` | `github_activity_tracker` | MTI | `BoostExternalRepository` extends `GitHubRepository` | Intentional — external repos ARE GitHub repos |
 | `boost_usage_tracker` | `github_activity_tracker` | FK | `BoostUsage.file_path` → `GitHubFile` | Intentional — usage anchored to a specific file |
 | `boost_usage_tracker` | `boost_library_tracker` | FK | `BoostUsage.boost_header` → `BoostFile` | Intentional — usage anchored to a Boost header |
-| `boost_mailing_list_tracker` | `cppa_user_tracker` | FK | `MailingListMessage.sender` → `MailingListProfile` | Intentional — sender identity |
+| `boost_mailing_list_tracker` | `cppa_user_tracker` | Soft ID (`BigIntegerField`, `db_column=sender_id`) | `MailingListMessage.sender_profile_id` → `MailingListProfile.pk` via `cppa_user_tracker.services` | Decoupled (pilot) — no ORM FK; PG FK constraint dropped |
 | `wg21_paper_tracker` | `cppa_user_tracker` | FK | `WG21PaperAuthor.profile` → `WG21PaperAuthorProfile` | Intentional — paper author identity |
 | `cppa_youtube_script_tracker` | `cppa_user_tracker` | FK | `YouTubeVideoSpeaker.speaker` → `YoutubeSpeaker` | Intentional — speaker identity |
 | `cppa_slack_tracker` | `cppa_user_tracker` | Direct import + FK | `SlackChannel.creator`, `SlackMessage.user`, `SlackChannelMembership.user`, `SlackChannelMembershipChangeLog.user` → `SlackUser` | Intentional — channel/message author identity |
@@ -151,7 +152,7 @@ The **Kind** column classifies the imported symbol:
 | `boost_usage_tracker` | `…/update_git_account.py` | `cppa_user_tracker` | `GitHubAccountType`, `get_or_create_github_account` | model + service | Intentional — correctly delegates account upsert |
 | `boost_usage_tracker` | `…/update_githubfile_from_csv.py` | `github_activity_tracker` | `GitHubRepository`, `create_or_update_github_file` | model + service | Intentional — correctly delegates |
 | `boost_usage_tracker` | `…/update_created_repos_by_language.py` | `github_activity_tracker` | `Language`, `create_or_update_created_repos_by_language` | model + service | Intentional — correctly delegates |
-| `boost_mailing_list_tracker` | `…/services.py` | `cppa_user_tracker` | `MailingListProfile` | model | Intentional — service references FK target |
+| `boost_mailing_list_tracker` | `…/preprocessor.py` | `cppa_user_tracker` | `get_mailing_list_profiles_by_ids` | service | Intentional — bulk sender display names for Pinecone docs |
 | `boost_mailing_list_tracker` | `…/run_boost_mailing_list_tracker.py` | `cppa_user_tracker` | `get_or_create_mailing_list_profile` | service | Intentional — correctly delegates |
 | `clang_github_tracker` | `…/sync_raw.py` | `github_activity_tracker` | `fetcher`, `save_*_raw_source`, `normalize_*_json`, path helpers (via `sync_api`) | utility | Intentional — cross-app orchestration via `github_activity_tracker.sync_api` |
 | `clang_github_tracker` | `…/preprocessors/pr_preprocessor.py` | `github_activity_tracker` | `build_pr_document`, `get_raw_source_pr_path` (via `sync_api`) | utility | Intentional — same |

--- a/docs/service_api/boost_mailing_list_tracker.md
+++ b/docs/service_api/boost_mailing_list_tracker.md
@@ -13,7 +13,7 @@
 | Function | Parameters | Return type | Summary |
 | --- | --- | --- | --- |
 | `delete_mailing_list_message` | message: MailingListMessage | None | Delete a MailingListMessage. |
-| `get_or_create_mailing_list_message` | sender: MailingListProfile, msg_id: str, sent_at: datetime, parent_id: str = '', thread_id: str = '', subject: str = '', content: str = '', list_name: str = '' | tuple[MailingListMessage, bool] | Get or create a MailingListMessage by msg_id (unique). |
+| `get_or_create_mailing_list_message` | sender_profile_id: int, msg_id: str, sent_at: datetime, parent_id: str = '', thread_id: str = '', subject: str = '', content: str = '', list_name: str = '' | tuple[MailingListMessage, bool] | Get or create a MailingListMessage by msg_id (unique). |
 
 <!-- SERVICE_API:GENERATED:END -->
 

--- a/docs/service_api/cppa_user_tracker.md
+++ b/docs/service_api/cppa_user_tracker.md
@@ -17,6 +17,8 @@
 | `create_identity` | display_name: str = '', description: str = '' | Identity | Create an Identity. Returns the new Identity. |
 | `create_tmp_identity` | display_name: str = '', description: str = '' | TmpIdentity | Create a TmpIdentity (staging). Returns the new TmpIdentity. |
 | `get_github_account_by_username` | username: str | GitHubAccount \| None | Return GitHubAccount for username, or None if not found (read-only lookup). |
+| `get_mailing_list_profile_by_id` | profile_id: int | MailingListProfile \| None | Return MailingListProfile for profile_id, or None if not found (read-only lookup). |
+| `get_mailing_list_profiles_by_ids` | profile_ids: list[int] | dict[int, MailingListProfile] | Return mailing-list profiles keyed by pk for the given ids (read-only bulk lookup). |
 | `get_or_create_discord_profile` | discord_user_id: int, username: str = '', display_name: str = '', avatar_url: str = '', is_bot: bool = False, identity: Optional[Identity] = None | tuple[DiscordProfile, bool] | Get or create a DiscordProfile by discord_user_id. Returns (profile, created). |
 | `get_or_create_github_account` | github_account_id: int, username: str = '', display_name: str = '', avatar_url: str = '', account_type: str = GitHubAccountType.USER, identity: Optional[Identity] = None | tuple[GitHubAccount, bool] | Get or create a GitHubAccount by github_account_id. Returns (account, created). |
 | `get_or_create_identity` | display_name: str = '', description: str = '', defaults: Optional[dict[str, Any]] = None | tuple[Identity, bool] | Get or create an Identity by display_name. If exists, updates description from defaults. |

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ filterwarnings =
 markers =
     django_db: mark test as using the database (django_db is built-in from pytest-django)
     benchmark: performance benchmarks; collection requires RUN_BENCHMARKS=1 (see CONTRIBUTING.md)
+    subset_schema: tests for config.test_settings_subset_* (minimal INSTALLED_APPS, no identity hub)


### PR DESCRIPTION
## Summary

Pilot **identity hub data-layer decoupling** for `boost_mailing_list_tracker`: replace `MailingListMessage.sender` ORM FK to `MailingListProfile` with `sender_profile_id` (`BigIntegerField`, column `sender_id`), drop the PostgreSQL FK constraint in migration `0003` (no data rewrite), and resolve profiles via `cppa_user_tracker.services` at read/write boundaries.
Adds hub read helpers (`get_mailing_list_profile_by_id`, `get_mailing_list_profiles_by_ids`), subset-schema pytest settings (`config.test_settings_subset_boost_mailing_list`), `subset_schema` marker/tests, import-linter contract forbidding `cppa_user_tracker.models` in mailing-list production code, ADR [`docs/adr/identity-hub-decoupling.md`](docs/adr/identity-hub-decoupling.md), and updates [`docs/cross-app-dependencies.md`](docs/cross-app-dependencies.md).
**Trade-off:** deleting a `MailingListProfile` no longer CASCADE-deletes messages; orphan `sender_id` values are an ops concern (see ADR).
Follow-on: same pattern for `wg21_paper_tracker`, `cppa_youtube_script_tracker`, Slack/Discord, then GitHub cluster.

## Apps touched

- `boost_mailing_list_tracker`
- `cppa_user_tracker`
- `core` (conftest only — subset settings skip hub fixture plugins)
- `config` (subset test settings)

## Test plan

- [ ] `python -m pytest boost_mailing_list_tracker/` (full `config.test_settings`)
- [ ] `DJANGO_SETTINGS_MODULE=config.test_settings_subset_boost_mailing_list python -m pytest boost_mailing_list_tracker/tests/test_subset_schema.py -m subset_schema`
- [ ] `python -m pytest cppa_user_tracker/tests/test_services.py -k "mailing_list_profile_by_id or mailing_list_profiles_by_ids"`
- [ ] `uv run pyright` (if typed code changed)
- [ ] `uv run lint-imports` (if imports or cross-app coupling changed)
- [ ] `uv run python scripts/check_service_layer_writes.py`
- [ ] `python manage.py migrate boost_mailing_list_tracker` on a DB with existing rows (FK dropped, `sender_id` unchanged)
- [ ] App command smoke-tested (if collector/command changed):

```bash
python manage.py run_boost_mailing_list_tracker
```

## Docs / coupling

- [ ] [cross-app-dependencies.md](docs/cross-app-dependencies.md) updated (if FKs or cross-app imports changed)
- [ ] `python scripts/generate_service_docs.py` run (if `services.py` or `core/protocols.py` changed)
- [x] App README or `docs/` updated - ADR + docs/adr/README.md
---
Closes #255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Admin Updates**
  * Simplified mailing-list message fields in the admin and streamlined search.

* **New Features**
  * Mailing-list messages now use a soft sender profile ID instead of a direct relationship.
  * Added profile lookup helpers for resolving one or many sender profiles by ID.
  * Added support for running mailing-list tests in a minimal subset schema setup.

* **Documentation**
  * Updated architecture and service docs to reflect the new decoupled profile handling.

* **Tests**
  * Expanded coverage for the new sender ID behavior, validation, and subset-schema scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->